### PR TITLE
Scope: simulation engine + Roth + tax/data/model closure (source)

### DIFF
--- a/src/components/Objects/Accounts/models.tsx
+++ b/src/components/Objects/Accounts/models.tsx
@@ -1,0 +1,1015 @@
+import { AssumptionsState } from "../Assumptions/AssumptionsContext";
+import { parseDate, hasClassName } from "../modelUtils";
+
+// 1. Interface
+
+export interface Account {
+  id: string;
+  name: string;
+  amount: number;
+}
+
+// 2. Base Abstract Class
+abstract class BaseAccount implements Account {
+  constructor(
+    public id: string,
+    public name: string,
+    public amount: number
+  ) {}
+}
+
+// 3. Concrete Classes
+
+export const TaxTypeEnum = ['Brokerage', 'Roth 401k', 'Traditional 401k', 'Roth IRA', 'Traditional IRA', 'HSA'] as const;
+export type TaxType = typeof TaxTypeEnum[number];
+
+// ESPP Lot interface for tracking individual share purchases
+export interface ESPPLot {
+  id: string;
+  grantDate: Date;        // Start of the offering period
+  purchaseDate: Date;     // End of the offering period when shares were purchased
+  fmvAtGrant: number;     // Fair market value per share at grant date
+  fmvAtPurchase: number;  // Fair market value per share at purchase date
+  purchasePrice: number;  // Price paid per share (after discount)
+  shares: number;         // Number of shares purchased
+  totalCost: number;      // Cost basis (purchasePrice * shares)
+  discountAmount: number; // Per-share discount (for tax calculation)
+}
+
+// Brokerage Lot interface for tracking individual contributions (simulation-internal, not persisted)
+export interface BrokerageLot {
+  purchaseYear: number;    // Year contribution was made
+  costBasis: number;       // Original amount (never grows)
+  currentValue: number;    // Market value (grows with returns)
+}
+
+export class SavedAccount extends BaseAccount {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    public apr: number = 0
+  ) {
+    super(id, name, amount);
+  }
+
+  increment (_assumptions: AssumptionsState, annualContribution: number = 0): SavedAccount {
+    // BOY timing: Apply contribution first, then growth
+    const amount = (this.amount + annualContribution) * (1 + this.apr/100);
+    return new SavedAccount(this.id, this.name, amount, this.apr);
+  }
+}
+
+export class InvestedAccount extends BaseAccount {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    // New: Track the specific portion of 'amount' that came from the employer
+    public employerBalance: number = 0,
+    // New: How many years have we been accumulating/vesting?
+    public tenureYears: number = 0,
+    public expenseRatio: number = 0.1,
+    public taxType: TaxType = 'Brokerage',
+    public isContributionEligible: boolean = true,
+    public vestedPerYear: number = 0.2, // 20% per year (5 year graded)
+    // Track total contributions for capital gains calculation
+    // costBasis = amount initially put in (contributions), gains = amount - costBasis
+    public costBasis: number = amount, // Default to current amount for backwards compatibility
+    // Optional custom return rate (overrides global assumptions)
+    public customROR?: number, // undefined means use global assumptions
+    // Track Roth conversion amounts with the year they occurred (for 5-year rule)
+    public conversionHistory: { year: number; amount: number }[] = [],
+    // Simulation-internal lot tracking for brokerage accounts (not persisted)
+    public lots: BrokerageLot[] = [],
+  ) {
+    super(id, name, amount);
+  }
+
+  // Total amount in costBasis that came from conversions
+  get totalConversionBasis(): number {
+    return this.conversionHistory.reduce((sum, c) => sum + c.amount, 0);
+  }
+
+  // Amount of costBasis that represents regular contributions (not conversions)
+  get regularContributions(): number {
+    return Math.max(0, this.costBasis - this.totalConversionBasis);
+  }
+
+  // Calculate unrealized gains (amount above cost basis)
+  get unrealizedGains(): number {
+    return Math.max(0, this.amount - this.costBasis);
+  }
+
+  // Calculate what portion of a withdrawal would be gains vs basis (proportional method)
+  calculateWithdrawalAllocation(withdrawAmount: number): { basis: number; gains: number } {
+    if (this.amount <= 0) return { basis: 0, gains: 0 };
+
+    const gainsPortion = this.unrealizedGains / this.amount;
+    const basisPortion = 1 - gainsPortion;
+
+    return {
+      basis: withdrawAmount * basisPortion,
+      gains: withdrawAmount * gainsPortion,
+    };
+  }
+
+  // Calculate lot-aware withdrawal breakdown for brokerage accounts
+  // Uses FIFO (First In, First Out) - sells oldest lots first
+  // Returns short-term vs long-term gains based on holding period of each lot
+  calculateLotAwareWithdrawal(withdrawAmount: number, currentYear: number): {
+    shortTermGains: number; longTermGains: number; basisReturn: number
+  } {
+    // Fall back to simple method if no lots present
+    if (this.lots.length === 0 || this.amount <= 0) {
+      const allocation = this.calculateWithdrawalAllocation(withdrawAmount);
+      return { shortTermGains: 0, longTermGains: allocation.gains, basisReturn: allocation.basis };
+    }
+
+    const totalLotValue = this.lots.reduce((sum, lot) => sum + lot.currentValue, 0);
+    if (totalLotValue <= 0) {
+      return { shortTermGains: 0, longTermGains: 0, basisReturn: withdrawAmount };
+    }
+
+    let shortTermGains = 0;
+    let longTermGains = 0;
+    let basisReturn = 0;
+    let remainingToWithdraw = Math.min(withdrawAmount, totalLotValue);
+
+    // FIFO: Sort lots by purchaseYear ascending (oldest first)
+    const sortedLots = [...this.lots].sort((a, b) => a.purchaseYear - b.purchaseYear);
+
+    for (const lot of sortedLots) {
+      if (remainingToWithdraw <= 0) break;
+
+      // How much to take from this lot
+      const lotWithdraw = Math.min(lot.currentValue, remainingToWithdraw);
+      remainingToWithdraw -= lotWithdraw;
+
+      // Calculate basis and gain for this portion
+      // Basis withdrawn is proportional to value withdrawn from this lot
+      const lotWithdrawPct = lot.currentValue > 0 ? lotWithdraw / lot.currentValue : 0;
+      const lotBasisWithdrawn = lot.costBasis * lotWithdrawPct;
+      const lotGain = Math.max(0, lotWithdraw - lotBasisWithdrawn);
+
+      basisReturn += lotBasisWithdrawn;
+
+      // Long-term if held >= 2 years (conservative with year-only precision)
+      // e.g., purchased 2022, sold 2024 → difference = 2 → definitely long-term
+      // Using >= 2 avoids misclassifying short-term as long-term (Dec 2023 → Jan 2024 = 1 year diff but only 1 month held)
+      if (currentYear - lot.purchaseYear >= 2) {
+        longTermGains += lotGain;
+      } else {
+        shortTermGains += lotGain;
+      }
+    }
+
+    return { shortTermGains, longTermGains, basisReturn };
+  }
+
+  // Helper to calculate the current "Risk" (Unvested Amount)
+  get nonVestedAmount(): number {
+    // Cap vesting at 100% (1.0)
+    const vestedPct = Math.min(1, this.tenureYears * this.vestedPerYear);
+    return this.employerBalance * (1 - vestedPct);
+  }
+
+  get vestedAmount(): number {
+    return this.amount - this.nonVestedAmount;
+  }
+
+  increment(
+    assumptions: AssumptionsState,
+    userContribution: number = 0,
+    employerContribution: number = 0,
+    overrideReturnRate?: number,
+    conversionAmount: number = 0,
+    currentYear: number = 0
+  ): InvestedAccount {
+
+    // 1. Calculate Growth Rate
+    // Priority: overrideReturnRate (Monte Carlo) > customROR (per-account) > global assumptions
+    let returnRate: number;
+    if (overrideReturnRate !== undefined) {
+      // overrideReturnRate is a percentage (e.g., 7 for 7%), already includes inflation if applicable
+      // Still subtract expense ratio
+      returnRate = 1 + (overrideReturnRate - this.expenseRatio) / 100;
+    } else if (this.customROR !== undefined) {
+      // Use per-account custom ROR (already a percentage, e.g., 7 for 7%)
+      returnRate = 1 + (this.customROR + (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) - this.expenseRatio) / 100;
+    } else {
+      returnRate = 1 + (assumptions.investments.returnRates.ror + (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) - this.expenseRatio) / 100;
+    }
+
+    // 2. BOY timing: Apply contributions/withdrawals BEFORE growth
+    // Calculate vesting using current year rate (tenureYears + 1)
+    const newTenure = this.tenureYears + 1;
+    const vestedPct = Math.min(1, newTenure * this.vestedPerYear);
+
+    // Start with current (pre-growth) balances
+    let preGrowthUserBalance = this.amount - this.employerBalance;
+    let preGrowthEmployerBalance = this.employerBalance;
+    let preGrowthCostBasis = this.costBasis;
+    // FIFO-drained conversion history, populated in the withdrawal branch below.
+    let newConversionHistoryFifo: { year: number; amount: number }[] | undefined;
+
+    // 3. Apply employer contribution (before growth)
+    preGrowthEmployerBalance += employerContribution;
+
+    // 4. Handle user contribution/withdrawal (before growth)
+    if (userContribution < 0) {
+      // User is withdrawing
+      const withdrawalAmount = Math.abs(userContribution);
+
+      // Check if withdrawal exceeds user's equity (using pre-growth balance)
+      if (withdrawalAmount > preGrowthUserBalance) {
+        // User is over-withdrawing - need to tap into employer funds
+        const shortfall = withdrawalAmount - preGrowthUserBalance;
+
+        // Calculate vested employer amount accessible to user
+        const vestedEmployerAmount = preGrowthEmployerBalance * vestedPct;
+
+        // Can only withdraw from vested employer funds
+        const allowedFromEmployer = Math.min(shortfall, vestedEmployerAmount);
+
+        // Apply the withdrawal
+        preGrowthEmployerBalance -= allowedFromEmployer;
+        preGrowthUserBalance = 0; // User equity depleted
+      } else {
+        // Normal withdrawal - doesn't exceed user equity
+        preGrowthUserBalance -= withdrawalAmount;
+      }
+
+      // Reduce cost basis (and, for Roth, conversion history) on withdrawal,
+      // before growth.
+      if (this.amount > 0) {
+        const isRoth = this.taxType === 'Roth IRA' || this.taxType === 'Roth 401k';
+        if (isRoth) {
+          // Roth: drain in IRS FIFO order, mirroring the WithdrawalPlanner
+          // (grossUpRoth): contribution basis first, then conversions oldest-first
+          // (preserving each layer's year for the 5-year rule), then earnings.
+          // increment() only receives a net withdrawal amount (no tranche
+          // breakdown), so we re-derive the ordering from the account's figures.
+          let remainingToWithdraw = withdrawalAmount;
+
+          // 1. Contribution basis first (penalty/tax-free, doesn't affect 5-year clock).
+          //    regularContributions = costBasis above the total conversion basis.
+          const fromContributions = Math.min(remainingToWithdraw, this.regularContributions);
+          remainingToWithdraw -= fromContributions;
+
+          // 2. Conversions next, oldest-first. Each dollar drawn reduces both the
+          //    conversion layer and costBasis (conversions are part of costBasis).
+          let fromConversions = 0;
+          if (remainingToWithdraw > 0) {
+            // Sort oldest-first so the 5-year clock is preserved per layer.
+            newConversionHistoryFifo = [...this.conversionHistory].sort((a, b) => a.year - b.year);
+            newConversionHistoryFifo = newConversionHistoryFifo
+              .map(c => {
+                if (remainingToWithdraw <= 0) return c;
+                const fromThis = Math.min(remainingToWithdraw, c.amount);
+                remainingToWithdraw -= fromThis;
+                fromConversions += fromThis;
+                return { year: c.year, amount: c.amount - fromThis };
+              })
+              .filter(c => c.amount > 0.01); // Remove negligible entries
+          } else {
+            newConversionHistoryFifo = this.conversionHistory.filter(c => c.amount > 0.01);
+          }
+
+          // 3. Any remainder comes from earnings, which carry no basis.
+          // costBasis is reduced only by the basis + conversion dollars actually drawn.
+          preGrowthCostBasis = this.costBasis - fromContributions - fromConversions;
+        } else {
+          // Non-Roth (e.g. taxable Brokerage without lot tracking): average-cost
+          // basis — costBasis reduces proportionally to the withdrawal. (Lot-based
+          // Brokerage re-derives costBasis from lots in the lifecycle block below.)
+          const withdrawalPct = withdrawalAmount / this.amount;
+          preGrowthCostBasis = this.costBasis * (1 - withdrawalPct);
+        }
+      }
+    } else {
+      // User is contributing (or no change)
+      preGrowthUserBalance += userContribution;
+
+      // Add contributions to cost basis (vested employer contributions count as basis)
+      const vestedEmployerContrib = employerContribution * vestedPct;
+      preGrowthCostBasis = this.costBasis + userContribution + vestedEmployerContrib;
+    }
+
+    // Build updated conversion history. On a withdrawal it was already drained in
+    // FIFO order above (newConversionHistoryFifo); otherwise carry it forward.
+    let newConversionHistory = newConversionHistoryFifo ?? [...this.conversionHistory];
+
+    // Add new conversion entry if applicable
+    if (conversionAmount > 0 && currentYear > 0) {
+      newConversionHistory.push({ year: currentYear, amount: conversionAmount });
+    }
+
+    // Lot lifecycle (Brokerage accounts only, simulation-internal)
+    let newLots: BrokerageLot[] = [];
+    if (this.taxType === 'Brokerage') {
+      // Seed lot: first time we see an empty lots array with existing balance
+      if (this.lots.length === 0 && this.amount > 0 && currentYear > 0) {
+        newLots = [{ purchaseYear: currentYear - 2, costBasis: this.costBasis, currentValue: this.amount }];
+      } else {
+        newLots = [...this.lots];
+      }
+
+      if (userContribution < 0 && this.amount > 0) {
+        // Withdrawal: FIFO - reduce oldest lots first
+        let remainingToWithdraw = Math.abs(userContribution);
+
+        // Sort by purchaseYear ascending (oldest first)
+        newLots.sort((a, b) => a.purchaseYear - b.purchaseYear);
+
+        // Reduce lots in FIFO order
+        newLots = newLots.map(lot => {
+          if (remainingToWithdraw <= 0) return lot;
+
+          const withdrawFromLot = Math.min(lot.currentValue, remainingToWithdraw);
+          remainingToWithdraw -= withdrawFromLot;
+
+          // Reduce basis proportionally to value withdrawn
+          const withdrawPct = lot.currentValue > 0 ? withdrawFromLot / lot.currentValue : 1;
+          return {
+            purchaseYear: lot.purchaseYear,
+            costBasis: lot.costBasis * (1 - withdrawPct),
+            currentValue: lot.currentValue - withdrawFromLot,
+          };
+        }).filter(lot => lot.currentValue >= 0.01); // Remove fully sold lots
+      } else if (userContribution > 0 && currentYear > 0) {
+        // Contribution: push a new lot
+        newLots.push({ purchaseYear: currentYear, costBasis: userContribution, currentValue: userContribution });
+      }
+
+      // Derive costBasis from lot-level truth after FIFO processing.
+      // The blended proportional reduction (line 244) diverges from FIFO lot accounting
+      // because FIFO sells high-gain lots first, removing less basis than the blended ratio.
+      if (newLots.length > 0) {
+        preGrowthCostBasis = newLots.reduce((sum, lot) => sum + lot.costBasis, 0);
+      }
+    }
+
+    // 5. Now apply growth to the adjusted (post-transaction) balances
+    const preGrowthTotal = preGrowthUserBalance + preGrowthEmployerBalance;
+    const grownTotal = preGrowthTotal * returnRate;
+    const grownEmployerBalance = preGrowthEmployerBalance * returnRate;
+    // Note: Cost basis does NOT grow with market returns - it only tracks contributions
+
+    // Grow lots proportionally (costBasis stays fixed, currentValue grows)
+    if (this.taxType === 'Brokerage' && newLots.length > 0) {
+      newLots = newLots.map(lot => ({
+        purchaseYear: lot.purchaseYear,
+        costBasis: lot.costBasis,
+        currentValue: lot.currentValue * returnRate,
+      }));
+    }
+
+    // 6. Final safety checks
+    let finalEmployerBalance = grownEmployerBalance;
+    if (finalEmployerBalance > grownTotal) {
+      finalEmployerBalance = Math.max(0, grownTotal);
+    }
+
+    // Cost basis can't exceed total amount or be negative
+    const finalCostBasis = Math.max(0, Math.min(preGrowthCostBasis, grownTotal));
+
+    return new InvestedAccount(
+      this.id,
+      this.name,
+      grownTotal,
+      finalEmployerBalance,
+      newTenure,
+      this.expenseRatio,
+      this.taxType,
+      this.isContributionEligible,
+      this.vestedPerYear,
+      finalCostBasis,
+      this.customROR,
+      newConversionHistory,
+      newLots
+    );
+  }
+}
+
+/**
+ * ESPP withdrawal preference - controls which lots are sold first
+ */
+export type ESPPWithdrawalPreference =
+  | 'fifo'                        // First-in, first-out (default)
+  | 'disqualifying_first'         // Sell disqualifying lots before qualifying
+  | 'qualifying_first'            // Sell qualifying lots first (lower ordinary income)
+  | 'dont_sell_until_qualifying'; // Skip ESPP in withdrawal order if no qualifying lots
+
+export const ESPP_WITHDRAWAL_PREFERENCE_OPTIONS = [
+  { value: 'fifo' as const, label: 'FIFO (First-In, First-Out)' },
+  { value: 'disqualifying_first' as const, label: 'Disqualifying First' },
+  { value: 'qualifying_first' as const, label: 'Qualifying First' },
+  { value: 'dont_sell_until_qualifying' as const, label: "Don't Sell Until Qualifying" },
+];
+
+/**
+ * ESPPAccount - Employee Stock Purchase Plan Account
+ *
+ * Tracks ESPP shares with lot-level detail for accurate tax treatment.
+ * ESPP has special tax rules based on holding periods:
+ * - Qualifying disposition: 2 years from grant + 1 year from purchase
+ * - Disqualifying disposition: Sold before meeting both holding periods
+ */
+export class ESPPAccount extends BaseAccount {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    public lots: ESPPLot[] = [],
+    public linkedIncomeId: string | null = null,  // Link to WorkIncome with ESPP
+    public customROR?: number, // Optional custom return rate (overrides global assumptions)
+    public stockTicker?: string,                  // Company ticker (e.g., "AAPL")
+    public currentSharePrice?: number,            // Current price per share
+    public withdrawalPreference: ESPPWithdrawalPreference = 'fifo',  // Lot selling order
+    public minimumHoldingDays: number = 0,        // Days before shares can be sold
+  ) {
+    super(id, name, amount);
+  }
+
+  /**
+   * Sort lots based on withdrawal preference
+   */
+  private sortLots(
+    lots: ESPPLot[],
+    saleDate: Date,
+    lotOrder: 'fifo' | 'disqualifying_first' | 'qualifying_first'
+  ): ESPPLot[] {
+    const byPurchaseDate = (a: ESPPLot, b: ESPPLot) =>
+      new Date(a.purchaseDate).getTime() - new Date(b.purchaseDate).getTime();
+
+    if (lotOrder === 'fifo') {
+      return [...lots].sort(byPurchaseDate);
+    }
+
+    const qualifyingFirst = lotOrder === 'qualifying_first';
+    return [...lots].sort((a, b) => {
+      const aQualifying = this.calculateDispositionType(a, saleDate) === 'qualifying';
+      const bQualifying = this.calculateDispositionType(b, saleDate) === 'qualifying';
+      if (aQualifying !== bQualifying) {
+        return qualifyingFirst
+          ? (aQualifying ? -1 : 1)
+          : (aQualifying ? 1 : -1);
+      }
+      return byPurchaseDate(a, b);
+    });
+  }
+
+  /**
+   * Determine if a lot qualifies for preferential tax treatment.
+   * Qualifying: 2 years from grant AND 1 year from purchase
+   */
+  calculateDispositionType(lot: ESPPLot, saleDate: Date): 'qualifying' | 'disqualifying' {
+    const grantDate = new Date(lot.grantDate);
+    const purchaseDate = new Date(lot.purchaseDate);
+
+    // Two years from grant date
+    const twoYearsFromGrant = new Date(grantDate);
+    twoYearsFromGrant.setFullYear(twoYearsFromGrant.getFullYear() + 2);
+
+    // One year from purchase date
+    const oneYearFromPurchase = new Date(purchaseDate);
+    oneYearFromPurchase.setFullYear(oneYearFromPurchase.getFullYear() + 1);
+
+    if (saleDate >= twoYearsFromGrant && saleDate >= oneYearFromPurchase) {
+      return 'qualifying';
+    }
+    return 'disqualifying';
+  }
+
+  /**
+   * Calculate tax implications of selling ESPP shares.
+   *
+   * For disqualifying dispositions:
+   * - Ordinary income = (FMV at purchase - purchase price) × shares = discount amount
+   * - Capital gains = sale price - FMV at purchase (per share) × shares
+   *
+   * For qualifying dispositions:
+   * - Ordinary income = lesser of: (1) discount at grant, or (2) actual gain
+   * - Capital gains = remainder is long-term capital gains
+   *
+   * @param sharesToSell - Number of shares to sell
+   * @param salePrice - Sale price per share
+   * @param saleDate - Date of sale (used to determine qualifying vs disqualifying)
+   * @param lotOrder - Order to sell lots: 'fifo', 'disqualifying_first', or 'qualifying_first'
+   * @param eligibleLots - Optional pre-filtered list of lots (e.g., after minimum holding period filter)
+   */
+  calculateSaleTax(
+    sharesToSell: number,
+    salePrice: number, // Per share
+    saleDate: Date,
+    lotOrder: 'fifo' | 'disqualifying_first' | 'qualifying_first' = 'fifo',
+    eligibleLots?: ESPPLot[]
+  ): { ordinaryIncome: number; shortTermGains: number; longTermGains: number; lotsUsed: ESPPLot[] } {
+    let ordinaryIncome = 0;
+    let shortTermGains = 0;
+    let longTermGains = 0;
+    let remainingShares = sharesToSell;
+    const lotsUsed: ESPPLot[] = [];
+
+    // Use provided eligible lots or all lots
+    const lotsToConsider = eligibleLots || this.lots;
+    const sortedLots = this.sortLots(lotsToConsider, saleDate, lotOrder);
+
+    for (const lot of sortedLots) {
+      if (remainingShares <= 0) break;
+
+      const sharesToUse = Math.min(remainingShares, lot.shares);
+      const dispositionType = this.calculateDispositionType(lot, saleDate);
+      const lotPurchaseDate = new Date(lot.purchaseDate);
+
+      // Check if held over 1 year for capital gains treatment
+      const oneYearFromPurchase = new Date(lotPurchaseDate);
+      oneYearFromPurchase.setFullYear(oneYearFromPurchase.getFullYear() + 1);
+      const isLongTerm = saleDate >= oneYearFromPurchase;
+
+      if (dispositionType === 'disqualifying') {
+        // Disqualifying: discount is ordinary income, rest is capital gain
+        const discountPerShare = lot.fmvAtPurchase - lot.purchasePrice;
+        ordinaryIncome += discountPerShare * sharesToUse;
+
+        const gainBeyondDiscount = (salePrice - lot.fmvAtPurchase) * sharesToUse;
+        if (isLongTerm) {
+          longTermGains += gainBeyondDiscount;
+        } else {
+          shortTermGains += gainBeyondDiscount;
+        }
+      } else {
+        // Qualifying: ordinary income is the lesser of (a) the actual gain, or (b) the
+        // discount measured at grant = FMV at grant × the plan's discount rate. Per IRS
+        // rules for §423 ESPP qualifying dispositions the rate is the plan's own discount
+        // (capped at the 15% statutory maximum) — not a flat 15%, since plans commonly
+        // offer less. Recover the plan rate from the lot's stored per-share discount.
+        const discountBase = lot.purchasePrice + lot.discountAmount;
+        const planDiscountRate = discountBase > 0
+          ? Math.min(lot.discountAmount / discountBase, 0.15)
+          : 0;
+        const grantDiscountPerShare = lot.fmvAtGrant * planDiscountRate;
+        const grantDiscount = grantDiscountPerShare * sharesToUse;
+        const actualGain = (salePrice - lot.purchasePrice) * sharesToUse;
+
+        if (actualGain <= 0) {
+          // Loss - no ordinary income, just capital loss
+          longTermGains += actualGain; // Will be negative
+        } else {
+          const ordinaryPortion = Math.min(grantDiscount, actualGain);
+          ordinaryIncome += ordinaryPortion;
+          longTermGains += actualGain - ordinaryPortion;
+        }
+      }
+
+      remainingShares -= sharesToUse;
+      lotsUsed.push({ ...lot, shares: sharesToUse });
+    }
+
+    return { ordinaryIncome, shortTermGains, longTermGains, lotsUsed };
+  }
+
+  /**
+   * Get total shares across all lots
+   */
+  get totalShares(): number {
+    return this.lots.reduce((sum, lot) => sum + lot.shares, 0);
+  }
+
+  /**
+   * Get total cost basis across all lots
+   */
+  get totalCostBasis(): number {
+    return this.lots.reduce((sum, lot) => sum + lot.totalCost, 0);
+  }
+
+  /**
+   * Get total unrealized gains
+   */
+  get unrealizedGains(): number {
+    return Math.max(0, this.amount - this.totalCostBasis);
+  }
+
+  /**
+   * Get count of qualifying vs disqualifying lots based on current date
+   */
+  getLotCounts(asOfDate: Date = new Date()): { qualifying: number; disqualifying: number } {
+    let qualifying = 0;
+    let disqualifying = 0;
+
+    for (const lot of this.lots) {
+      if (this.calculateDispositionType(lot, asOfDate) === 'qualifying') {
+        qualifying++;
+      } else {
+        disqualifying++;
+      }
+    }
+
+    return { qualifying, disqualifying };
+  }
+
+  /**
+   * Get lots that are eligible for sale (meet minimum holding period)
+   */
+  getEligibleLots(asOfDate: Date = new Date()): ESPPLot[] {
+    if (this.minimumHoldingDays <= 0) {
+      return this.lots;
+    }
+
+    return this.lots.filter(lot => {
+      const purchaseDate = new Date(lot.purchaseDate);
+      const daysSincePurchase = (asOfDate.getTime() - purchaseDate.getTime()) / (1000 * 60 * 60 * 24);
+      return daysSincePurchase >= this.minimumHoldingDays;
+    });
+  }
+
+  /**
+   * Get total shares that are eligible for sale (meet minimum holding period)
+   */
+  getEligibleShares(asOfDate: Date = new Date()): number {
+    return this.getEligibleLots(asOfDate).reduce((sum, lot) => sum + lot.shares, 0);
+  }
+
+  /**
+   * Check if there are any qualifying lots available for sale
+   */
+  hasQualifyingLots(asOfDate: Date = new Date()): boolean {
+    const eligibleLots = this.getEligibleLots(asOfDate);
+    return eligibleLots.some(lot => this.calculateDispositionType(lot, asOfDate) === 'qualifying');
+  }
+
+  /**
+   * Add a new lot from an ESPP purchase
+   */
+  addLot(lot: ESPPLot): ESPPAccount {
+    const newLots = [...this.lots, lot];
+    const newAmount = this.amount + (lot.fmvAtPurchase * lot.shares);
+
+    return new ESPPAccount(
+      this.id,
+      this.name,
+      newAmount,
+      newLots,
+      this.linkedIncomeId,
+      this.customROR,
+      this.stockTicker,
+      this.currentSharePrice,
+      this.withdrawalPreference,
+      this.minimumHoldingDays
+    );
+  }
+
+  /**
+   * Remove shares from lots (FIFO) after a sale
+   * @param lotOrder - Order to remove lots: 'fifo', 'disqualifying_first', or 'qualifying_first'
+   */
+  removeSoldShares(
+    sharesToRemove: number,
+    salePrice: number,
+    saleDate?: Date,
+    lotOrder: 'fifo' | 'disqualifying_first' | 'qualifying_first' = 'fifo'
+  ): ESPPAccount {
+    let remaining = sharesToRemove;
+    const newLots: ESPPLot[] = [];
+    const useSaleDate = saleDate || new Date();
+    const sortedLots = this.sortLots(this.lots, useSaleDate, lotOrder);
+
+    for (const lot of sortedLots) {
+      if (remaining >= lot.shares) {
+        // Use entire lot
+        remaining -= lot.shares;
+      } else if (remaining > 0) {
+        // Partial lot - keep the remainder
+        const remainingShares = lot.shares - remaining;
+        newLots.push({
+          ...lot,
+          shares: remainingShares,
+          totalCost: lot.purchasePrice * remainingShares,
+        });
+        remaining = 0;
+      } else {
+        // Keep the lot as-is
+        newLots.push(lot);
+      }
+    }
+
+    const saleProceeds = sharesToRemove * salePrice;
+    const newAmount = this.amount - saleProceeds;
+
+    return new ESPPAccount(
+      this.id,
+      this.name,
+      Math.max(0, newAmount),
+      newLots,
+      this.linkedIncomeId,
+      this.customROR,
+      this.stockTicker,
+      this.currentSharePrice,
+      this.withdrawalPreference,
+      this.minimumHoldingDays
+    );
+  }
+
+  /**
+   * Update a specific lot by ID
+   */
+  updateLot(lotId: string, updates: Partial<ESPPLot>): ESPPAccount {
+    const newLots = this.lots.map(lot =>
+      lot.id === lotId ? { ...lot, ...updates } : lot
+    );
+
+    // Recalculate amount based on lots if shares or FMV changed
+    const totalLotValue = newLots.reduce((sum, lot) => sum + (lot.fmvAtPurchase * lot.shares), 0);
+
+    return new ESPPAccount(
+      this.id,
+      this.name,
+      totalLotValue > 0 ? totalLotValue : this.amount,
+      newLots,
+      this.linkedIncomeId,
+      this.customROR,
+      this.stockTicker,
+      this.currentSharePrice,
+      this.withdrawalPreference,
+      this.minimumHoldingDays
+    );
+  }
+
+  /**
+   * Delete a lot by ID
+   */
+  deleteLot(lotId: string): ESPPAccount {
+    const lotToDelete = this.lots.find(lot => lot.id === lotId);
+    const newLots = this.lots.filter(lot => lot.id !== lotId);
+
+    // Reduce amount by the lot's current value
+    const lotValue = lotToDelete ? lotToDelete.fmvAtPurchase * lotToDelete.shares : 0;
+    const newAmount = Math.max(0, this.amount - lotValue);
+
+    return new ESPPAccount(
+      this.id,
+      this.name,
+      newAmount,
+      newLots,
+      this.linkedIncomeId,
+      this.customROR,
+      this.stockTicker,
+      this.currentSharePrice,
+      this.withdrawalPreference,
+      this.minimumHoldingDays
+    );
+  }
+
+  /**
+   * Increment the account value based on stock growth
+   */
+  increment(
+    assumptions: AssumptionsState,
+    overrideReturnRate?: number
+  ): ESPPAccount {
+    // Priority: overrideReturnRate (Monte Carlo) > customROR (per-account) > global assumptions
+    let returnRate: number;
+    if (overrideReturnRate !== undefined) {
+      returnRate = 1 + overrideReturnRate / 100;
+    } else if (this.customROR !== undefined) {
+      returnRate = 1 + (this.customROR + (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0)) / 100;
+    } else {
+      returnRate = 1 + (assumptions.investments.returnRates.ror + (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0)) / 100;
+    }
+
+    // Grow the overall amount
+    const newAmount = this.amount * returnRate;
+
+    // Note: Lots retain their original cost basis - only the current FMV (amount) grows
+    return new ESPPAccount(
+      this.id,
+      this.name,
+      newAmount,
+      this.lots,
+      this.linkedIncomeId,
+      this.customROR,
+      this.stockTicker,
+      this.currentSharePrice,
+      this.withdrawalPreference,
+      this.minimumHoldingDays
+    );
+  }
+}
+
+export class PropertyAccount extends BaseAccount {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    public ownershipType: 'Financed' | 'Owned',
+    public loanAmount: number,
+    public startingLoanBalance: number,
+    public linkedAccountId: string,
+    public apr: number = 0
+  ) {
+    super(id, name, amount);
+  }
+  increment(
+      assumptions: AssumptionsState, 
+      overrides?: { newLoanBalance?: number; newValue?: number }
+  ): PropertyAccount {
+    let nextValue: number;
+    if (overrides?.newValue !== undefined) {
+        nextValue = overrides.newValue;
+    } else {
+        // Home value grows nominally: real appreciation (housingAppreciation) plus
+        // general inflation when inflation-adjusted. Mirrors the linked-mortgage
+        // valuation path so owned and financed homes appreciate consistently.
+        const generalInflation = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+        nextValue = this.amount * (1 + assumptions.expenses.housingAppreciation / 100 + generalInflation);
+    }
+    let nextLoan: number;
+    if (overrides?.newLoanBalance !== undefined) {
+        nextLoan = overrides.newLoanBalance;
+    } else {
+        nextLoan = this.loanAmount; 
+    }
+
+    return new PropertyAccount(
+      this.id,
+      this.name,
+      nextValue,
+      this.ownershipType,
+      nextLoan, 
+      this.startingLoanBalance,
+      this.linkedAccountId
+    );
+  }
+}
+
+export class DebtAccount extends BaseAccount {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    public linkedAccountId: string,
+    public apr: number = 0
+  ) {
+    super(id, name, amount);
+  }
+  increment(
+      _assumptions: AssumptionsState,
+      overrideBalance?: number
+  ): DebtAccount {
+      const nextAmount = overrideBalance !== undefined
+          ? overrideBalance
+          : this.amount * (1 + this.apr / 100);
+
+      return new DebtAccount(
+          this.id,
+          this.name,
+          nextAmount,
+          this.linkedAccountId,
+          this.apr
+      );
+  }
+}
+
+/**
+ * System-generated debt account for tracking uncovered deficits.
+ * 0% APR, gets paid off before priority allocations.
+ */
+export class DeficitDebtAccount extends DebtAccount {
+  constructor(id: string, name: string, amount: number) {
+    super(id, name, amount, '', 0); // 0% APR, no linked account
+  }
+
+  increment(_assumptions: AssumptionsState, overrideBalance?: number): DeficitDebtAccount {
+    const nextAmount = overrideBalance !== undefined ? overrideBalance : this.amount;
+    return new DeficitDebtAccount(this.id, this.name, nextAmount);
+  }
+}
+
+// Union type for use in State Management
+export type AnyAccount = SavedAccount | InvestedAccount | ESPPAccount | PropertyAccount | DebtAccount | DeficitDebtAccount;
+
+export const ACCOUNT_CATEGORIES = [
+  'Cash',
+  'Invested',
+  'Property',
+  'Debt',
+] as const;
+
+export type AccountCategory = typeof ACCOUNT_CATEGORIES[number];
+
+export const ACCOUNT_COLORS_BACKGROUND: Record<AccountCategory, string> = {
+    Cash: "bg-chart-Fuchsia-50",
+    Invested: "bg-chart-Blue-50",
+    Property: "bg-chart-Yellow-50",
+    Debt: "bg-chart-Red-50",
+  };
+
+export const CLASS_TO_CATEGORY: Record<string, AccountCategory> = {
+    [SavedAccount.name]: 'Cash',
+    [InvestedAccount.name]: 'Invested',
+    [ESPPAccount.name]: 'Invested',
+    [PropertyAccount.name]: 'Property',
+    [DebtAccount.name]: 'Debt',
+    [DeficitDebtAccount.name]: 'Debt',
+};
+
+// Map Categories to their color palettes (using Tailwind classes for simplicity)
+// Uses 5-step gradients (1, 25, 50, 75, 100) defined in :root for SVG access
+const PALETTE_STEPS = [1, 25, 50, 75, 100];
+export const CATEGORY_PALETTES: Record<AccountCategory, string[]> = {
+	Cash: PALETTE_STEPS.map(i => `bg-chart-Fuchsia-${i}`),
+	Invested: PALETTE_STEPS.map(i => `bg-chart-Blue-${i}`),
+	Property: PALETTE_STEPS.map(i => `bg-chart-Yellow-${i}`),
+	Debt: PALETTE_STEPS.map(i => `bg-chart-Red-${i}`),
+};
+
+/**
+ * Robustly creates class instances from raw JSON.
+ * Maps fields explicitly and provides defaults for missing fields.
+ */
+export function reconstituteAccount(data: unknown): AnyAccount | null {
+    if (!hasClassName(data)) return null;
+
+    const id = String(data.id ?? '');
+    const name = String(data.name ?? 'Unnamed Account');
+    const amount = Number(data.amount) || 0;
+
+    switch (data.className) {
+        case 'SavedAccount':
+            return new SavedAccount(id, name, amount, Number(data.apr) || 0);
+
+        case 'InvestedAccount': {
+            const conversionHistory = Array.isArray(data.conversionHistory)
+                ? data.conversionHistory.map((c: any) => ({ year: Number(c.year), amount: Number(c.amount) }))
+                : [];
+            // Clamp persisted values to safe ranges. employerBalance > amount makes
+            // nonVestedAmount/vestedAmount go negative (RMDService then silently skips a
+            // required RMD). costBasis MAY exceed amount for an underwater position
+            // (contributions/conversions above current market value) — that is valid,
+            // so it is floored at 0 but NOT clamped to amount; clamping would erase the
+            // unrealized loss and tax later recovery as phantom gain.
+            const employerBalance = Math.max(0, Math.min(Number(data.employerBalance) || 0, amount));
+            const costBasis = Math.max(0, Number(data.costBasis ?? amount));
+            return new InvestedAccount(
+                id, name, amount,
+                employerBalance,
+                Number(data.tenureYears) || 0,
+                Number(data.expenseRatio ?? 0.1),
+                (data.taxType as TaxType) ?? 'Brokerage',
+                (data.isContributionEligible as boolean) ?? true,
+                Number(data.vestedPerYear ?? 0.2),
+                costBasis,
+                data.customROR !== undefined ? Number(data.customROR) : undefined,
+                conversionHistory
+            );
+        }
+
+        case 'ESPPAccount': {
+            const lotsData = Array.isArray(data.lots) ? data.lots : [];
+            const lots: ESPPLot[] = lotsData.map((lot: Record<string, unknown>) => ({
+                id: String(lot.id ?? ''),
+                grantDate: parseDate(lot.grantDate, new Date()) as Date,
+                purchaseDate: parseDate(lot.purchaseDate, new Date()) as Date,
+                fmvAtGrant: Number(lot.fmvAtGrant) || 0,
+                fmvAtPurchase: Number(lot.fmvAtPurchase) || 0,
+                purchasePrice: Number(lot.purchasePrice) || 0,
+                shares: Number(lot.shares) || 0,
+                totalCost: Number(lot.totalCost) || 0,
+                discountAmount: Number(lot.discountAmount) || 0,
+            }));
+            return new ESPPAccount(
+                id, name, amount, lots,
+                data.linkedIncomeId ? String(data.linkedIncomeId) : null,
+                data.customROR !== undefined ? Number(data.customROR) : undefined,
+                data.stockTicker ? String(data.stockTicker) : undefined,
+                data.currentSharePrice !== undefined ? Number(data.currentSharePrice) : undefined,
+                (data.withdrawalPreference as ESPPWithdrawalPreference) ?? 'fifo',
+                Number(data.minimumHoldingDays) || 0
+            );
+        }
+
+        case 'PropertyAccount':
+            return new PropertyAccount(
+                id, name, amount,
+                (data.ownershipType as 'Financed' | 'Owned') ?? 'Owned',
+                Number(data.loanAmount) || 0,
+                Number(data.startingLoanBalance) || 0,
+                String(data.linkedAccountId ?? '')
+            );
+
+        case 'DebtAccount':
+            return new DebtAccount(
+                id, name, amount,
+                String(data.linkedAccountId ?? ''),
+                Number(data.apr) || 0
+            );
+
+        case 'DeficitDebtAccount':
+            return new DeficitDebtAccount(id, name, amount);
+
+        default:
+            console.warn(`Unknown account type: ${data.className}`);
+            return null;
+    }
+}

--- a/src/components/Objects/Assumptions/AssumptionsContext.tsx
+++ b/src/components/Objects/Assumptions/AssumptionsContext.tsx
@@ -1,0 +1,532 @@
+// @refresh reset - This file exports both components and hooks, so full remount is needed for HMR
+import { createContext, useReducer, useContext, ReactNode, useMemo } from 'react';
+import { useDebouncedLocalStorage } from '../../../hooks/useDebouncedLocalStorage';
+import { EarningsRecord } from '../../../services/SocialSecurityCalculator';
+import { CustomMilestone } from '../../../services/simulation/types';
+
+// Built-in milestone IDs that cannot be removed
+export const BUILTIN_MILESTONE_IDS = {
+    BIRTH: 'BUILTIN_BIRTH',
+    RETIRE: 'BUILTIN_RETIRE',
+    END_OF_PLAN: 'BUILTIN_END_OF_PLAN',
+} as const;
+
+// Check if a milestone is a built-in milestone
+export const isBuiltinMilestone = (id: string): boolean =>
+    Object.values(BUILTIN_MILESTONE_IDS).includes(id as typeof BUILTIN_MILESTONE_IDS[keyof typeof BUILTIN_MILESTONE_IDS]);
+
+// Default values for built-in milestones
+const DEFAULT_BIRTH_YEAR = 1990;
+const DEFAULT_RETIREMENT_AGE = 65;
+const DEFAULT_LIFE_EXPECTANCY = 90;
+
+// Create default built-in milestones
+export const createBuiltinMilestones = (
+    birthYear: number = DEFAULT_BIRTH_YEAR,
+    retirementAge: number = DEFAULT_RETIREMENT_AGE,
+    lifeExpectancy: number = DEFAULT_LIFE_EXPECTANCY
+): CustomMilestone[] => [
+    {
+        id: BUILTIN_MILESTONE_IDS.BIRTH,
+        name: 'Birth',
+        conditions: [{ type: 'YEAR', operator: '=', value: birthYear }],
+        color: 'var(--c-accent-soft)', // blue-500
+    },
+    {
+        id: BUILTIN_MILESTONE_IDS.RETIRE,
+        name: 'Retire',
+        conditions: [{ type: 'AGE', operator: '>=', value: retirementAge }],
+        color: 'var(--c-positive-soft)', // green-500
+    },
+    {
+        id: BUILTIN_MILESTONE_IDS.END_OF_PLAN,
+        name: 'End of Plan',
+        // Trigger AFTER life expectancy year so expenses continue through it
+        conditions: [{ type: 'AGE', operator: '>=', value: lifeExpectancy}],
+        color: 'var(--c-content-subtle)', // gray-500
+    },
+];
+
+// Helper: Get the AGE value from a milestone's first AGE condition
+export const getAgeFromMilestone = (milestone: CustomMilestone | undefined, defaultValue: number): number => {
+    if (!milestone) return defaultValue;
+    const ageCondition = milestone.conditions.find(c => c.type === 'AGE');
+    return ageCondition?.value ?? defaultValue;
+};
+
+// Get birth year from the Birth milestone
+export const getBirthYear = (milestones: CustomMilestone[]): number => {
+    const birthMilestone = milestones.find(m => m.id === BUILTIN_MILESTONE_IDS.BIRTH);
+    if (!birthMilestone) return DEFAULT_BIRTH_YEAR;
+    const yearCondition = birthMilestone.conditions.find(c => c.type === 'YEAR');
+    return yearCondition?.value ?? DEFAULT_BIRTH_YEAR;
+};
+
+// Get retirement age from the Retire milestone
+export const getRetirementAge = (milestones: CustomMilestone[]): number => {
+    const retireMilestone = milestones.find(m => m.id === BUILTIN_MILESTONE_IDS.RETIRE);
+    return getAgeFromMilestone(retireMilestone, DEFAULT_RETIREMENT_AGE);
+};
+
+// Get life expectancy from the End of Plan milestone
+export const getLifeExpectancy = (milestones: CustomMilestone[]): number => {
+    const endOfPlanMilestone = milestones.find(m => m.id === BUILTIN_MILESTONE_IDS.END_OF_PLAN);
+    const rawValue = getAgeFromMilestone(endOfPlanMilestone, DEFAULT_LIFE_EXPECTANCY);
+    return rawValue;
+};
+
+export type CapType = 'MAX' | 'FIXED' | 'REMAINDER' | 'MULTIPLE_OF_EXPENSES';
+
+export interface PriorityBucket {
+  id: string;
+  name: string; // e.g., "Max out 401k"
+  type: 'DEBT' | 'INVESTMENT' | 'SAVINGS';
+  accountId?: string; // Link to your actual Account IDs
+  capType: CapType;
+  capValue?: number; // e.g., 23000 for 401k, or 500 for monthly savings
+}
+
+export interface WithdrawalBucket {
+  id: string;
+  name: string;      // e.g. "Emergency Fund", "Brokerage"
+  accountId: string; // The account to drain
+  maxAmount?: number; // Optional cap on annual withdrawal from this bucket (e.g., to stay in a tax bracket)
+}
+
+export interface AssumptionsState {
+  macro: {
+    inflationRate: number;       // e.g., 3.0
+    healthcareInflation: number; // e.g., 5.0
+    inflationAdjusted: boolean;   // usually true (pegged to inflation)
+  };
+  income: {
+    salaryGrowth: number;        // e.g., 3.0
+    qualifiesForSocialSecurity: boolean; // Whether user expects to receive SS benefits
+    socialSecurityFundingPercent: number; // Expected % of SS benefits (e.g., 75 if pessimistic about solvency)
+  };
+  expenses: {
+    lifestyleCreep: number;      // e.g., 50.0 (% of raise spent)
+    housingAppreciation: number; // e.g., 3.5
+    rentInflation: number;       // e.g., 4.0
+  };
+  investments: {
+    returnRates: {
+      ror: number;   // e.g., 10.0
+    };
+    withdrawalStrategy: 'None' | 'Needs Based' | 'Fixed Real' | 'Percentage' | 'Guyton Klinger';
+    withdrawalRate: number; // e.g., 4.0
+    // Guyton-Klinger guardrail settings
+    gkUpperGuardrail: number;     // Default 1.2 (20% above target triggers cut)
+    gkLowerGuardrail: number;     // Default 0.8 (20% below target triggers boost)
+    gkAdjustmentPercent: number;  // Default 10 (10% cut/increase per GK rules)
+    // Auto Roth conversions during retirement
+    autoRothConversions: boolean; // Automatically convert Traditional to Roth in low-tax years
+    // Which algorithm decides the per-year conversion amount when auto-conversions are on.
+    // 'rate-match' = bracket-walk that compares this year's marginal to projected RMD-age marginal.
+    // 'dp-precomputed' = experimental backward-induction DP solved once over the full horizon.
+    rothConversionStrategy?: 'rate-match' | 'dp-precomputed';
+    // Rate-match conversion: minimum percentage-point gap between current marginal
+    // rate and projected RMD-age marginal rate to justify converting that bracket.
+    // Higher = more conservative (skip conversions with smaller savings).
+    // 0.05 = "convert at 12% to dodge 22% only if savings ≥ 5pp."
+    rothConversionMinRateGap?: number;
+    // DP-precomputed conversion: per-year back-load preference (δ).
+    // V(t, b) = min over c of [tax(c) + (1 / (1 + δ)) × V(t+1, b')].
+    // δ > 0 makes future tax look slightly cheaper than present tax, biasing
+    // the optimal plan toward later conversions (SORR-friendly) at the cost of
+    // some lifetime-tax efficiency. 0 = lifetime-optimal (mildly front-loaded).
+    // 0.015 = 1.5%/yr (default). See RothConversionDP.ts for derivation.
+    rothConversionDPBackloadDelta?: number;
+    // Tax Optimization Mode
+    taxOptimizationEnabled: boolean; // When enabled, uses smart withdrawal order and auto-calculated Roth conversions
+    acaAware: boolean; // When true, limit Roth conversions to stay under ACA subsidy cliff (pre-65)
+    };
+  demographics: {
+    priorEarnings?: EarningsRecord[];  // SSA earnings history imported from XML
+    priorYearMode?: boolean;  // If true, simulation starts from last year using verified data
+    // NOTE: birthYear, retirementAge, and lifeExpectancy are derived from milestones
+    // Use getBirthYear(), getRetirementAge(), getLifeExpectancy() helpers
+  };
+  display: {
+    useCompactCurrency: boolean; // Show $1.2M instead of $1,200,000
+    showExperimentalFeatures: boolean; // Show Tax, Scenarios, Ratios tabs
+    hsaEligible: boolean; // Whether user has HDHP and is eligible for HSA
+  };
+  priorities: PriorityBucket[];
+  withdrawalStrategy: WithdrawalBucket[]; // The "Burn Order"
+  milestones: CustomMilestone[]; // User-defined milestone triggers
+}
+
+export const defaultAssumptions: AssumptionsState = {
+  macro: {
+    inflationRate: 2.6,
+    healthcareInflation: 3.9,
+    inflationAdjusted: true,
+  },
+  income: {
+    salaryGrowth: 1.0,
+    qualifiesForSocialSecurity: true,
+    socialSecurityFundingPercent: 100, // 100% = full benefits, reduce if pessimistic about SS solvency
+  },
+  expenses: {
+    lifestyleCreep: 75.0,
+    housingAppreciation: 1.4,
+    rentInflation: 1.2,
+  },
+  investments: {
+    returnRates: { ror: 5.9 },
+    withdrawalStrategy: 'Fixed Real',
+    withdrawalRate: 4.0,
+    gkUpperGuardrail: 1.2,      // Cut when rate > target * 1.2
+    gkLowerGuardrail: 0.8,      // Boost when rate < target * 0.8
+    gkAdjustmentPercent: 10,    // 10% adjustment (per actual GK rules)
+    autoRothConversions: false, // Auto-convert Traditional to Roth in retirement
+    rothConversionStrategy: 'rate-match', // 'rate-match' (default) | 'dp-precomputed' (experimental)
+    rothConversionMinRateGap: 0.05, // 5pp minimum savings to justify a non-free conversion (rate-match algorithm)
+    rothConversionDPBackloadDelta: 0.015, // 1.5%/yr default — DP-precomputed back-load preference
+    taxOptimizationEnabled: false, // Disabled by default - use manual withdrawal order
+    acaAware: true, // Limit Roth conversions to stay under ACA subsidy cliff (pre-65)
+  },
+  demographics: {
+    priorYearMode: false, // Default to current year mode
+    // birthYear, retirementAge, lifeExpectancy are now in milestones
+  },
+  display: {
+    useCompactCurrency: true,
+    showExperimentalFeatures: false,
+    hsaEligible: true,
+  },
+  priorities: [],
+  withdrawalStrategy: [],
+  milestones: createBuiltinMilestones(), // Built-in milestones with default values (birth 1990, retire 65, life 90)
+};
+
+/**
+ * Deep merge saved data with defaults, ensuring all fields exist.
+ * This handles cases where old localStorage data is missing newer fields.
+ */
+function migrateAssumptions(saved: unknown, defaults: AssumptionsState): AssumptionsState {
+  // If saved is not an object, return defaults
+  if (!saved || typeof saved !== 'object' || Array.isArray(saved)) {
+    return defaults;
+  }
+
+  const data = saved as Record<string, unknown>;
+
+  // Helper to safely merge nested objects
+  const mergeSection = <T extends Record<string, unknown>>(
+    savedSection: unknown,
+    defaultSection: T
+  ): T => {
+    if (!savedSection || typeof savedSection !== 'object' || Array.isArray(savedSection)) {
+      return defaultSection;
+    }
+    const section = savedSection as Record<string, unknown>;
+    const result = { ...defaultSection };
+
+    for (const key of Object.keys(defaultSection)) {
+      const defaultValue = defaultSection[key];
+      const savedValue = section[key];
+
+      // If savedValue exists and is the right type, use it
+      if (savedValue !== undefined && savedValue !== null) {
+        // Type check: ensure saved value matches expected type
+        if (typeof savedValue === typeof defaultValue) {
+          (result as Record<string, unknown>)[key] = savedValue;
+        } else if (typeof defaultValue === 'object' && !Array.isArray(defaultValue) && defaultValue !== null) {
+          // Recursively merge nested objects
+          (result as Record<string, unknown>)[key] = mergeSection(
+            savedValue,
+            defaultValue as Record<string, unknown>
+          );
+        }
+        // If types don't match, keep the default
+      }
+      // If savedValue is undefined/null, keep the default
+    }
+    return result;
+  };
+
+  // Build migrated state by merging each section
+  const migrated: AssumptionsState = {
+    macro: mergeSection(data.macro, defaults.macro),
+    income: mergeSection(data.income, defaults.income),
+    expenses: mergeSection(data.expenses, defaults.expenses),
+    investments: {
+      ...mergeSection(data.investments, defaults.investments),
+      // Ensure nested returnRates is also merged
+      returnRates: mergeSection(
+        (data.investments as Record<string, unknown>)?.returnRates,
+        defaults.investments.returnRates
+      ),
+    },
+    demographics: mergeSection(data.demographics, defaults.demographics),
+    display: mergeSection(data.display, defaults.display),
+    // Arrays: use saved if it's a valid array, otherwise use default
+    priorities: Array.isArray(data.priorities) ? data.priorities as PriorityBucket[] : defaults.priorities,
+    withdrawalStrategy: Array.isArray(data.withdrawalStrategy) ? data.withdrawalStrategy as WithdrawalBucket[] : defaults.withdrawalStrategy,
+    milestones: Array.isArray(data.milestones) ? data.milestones as CustomMilestone[] : defaults.milestones,
+  };
+
+  // Migration: Get legacy values from old demographics if present
+  const savedDemographics = data.demographics as Record<string, unknown> | undefined;
+
+  // priorEarnings is a saved-only demographics field (absent from the defaults
+  // object), so the mergeSection above silently drops it on every reload.
+  // Preserve the imported SSA earnings history explicitly — the SS benefit
+  // projection (IncomeProjection) depends on it.
+  if (savedDemographics?.priorEarnings !== undefined && savedDemographics?.priorEarnings !== null) {
+    migrated.demographics.priorEarnings = savedDemographics.priorEarnings as EarningsRecord[];
+  }
+
+  // Handle very old format with startAge/startYear
+  let legacyBirthYear = savedDemographics?.birthYear as number | undefined;
+  if (!legacyBirthYear && savedDemographics) {
+    const startAge = savedDemographics.startAge as number | undefined;
+    const startYear = savedDemographics.startYear as number | undefined;
+    if (startAge !== undefined && startYear !== undefined) {
+      legacyBirthYear = startYear - startAge;
+    } else if (startAge !== undefined) {
+      legacyBirthYear = new Date().getFullYear() - startAge;
+    }
+  }
+
+  const legacyRetirementAge = savedDemographics?.retirementAge as number | undefined;
+  const legacyLifeExpectancy = savedDemographics?.lifeExpectancy as number | undefined;
+
+  // Use legacy values or defaults for creating built-in milestones
+  const birthYearForMilestones = legacyBirthYear ?? DEFAULT_BIRTH_YEAR;
+  const retirementAgeForMilestones = legacyRetirementAge ?? DEFAULT_RETIREMENT_AGE;
+  const lifeExpectancyForMilestones = legacyLifeExpectancy ?? DEFAULT_LIFE_EXPECTANCY;
+
+  // Migration: Ensure built-in milestones always exist
+  const existingIds = new Set(migrated.milestones.map(m => m.id));
+
+  // If Birth milestone doesn't exist, create it with legacy or default value
+  if (!existingIds.has(BUILTIN_MILESTONE_IDS.BIRTH)) {
+    migrated.milestones.unshift({
+      id: BUILTIN_MILESTONE_IDS.BIRTH,
+      name: 'Birth',
+      conditions: [{ type: 'YEAR', operator: '=', value: birthYearForMilestones }],
+      color: 'var(--c-accent-soft)',
+    });
+  }
+
+  // If Retire milestone doesn't exist, create it with legacy or default value
+  if (!existingIds.has(BUILTIN_MILESTONE_IDS.RETIRE)) {
+    const birthIndex = migrated.milestones.findIndex(m => m.id === BUILTIN_MILESTONE_IDS.BIRTH);
+    const insertIndex = birthIndex >= 0 ? birthIndex + 1 : 0;
+    migrated.milestones.splice(insertIndex, 0, {
+      id: BUILTIN_MILESTONE_IDS.RETIRE,
+      name: 'Retire',
+      conditions: [{ type: 'AGE', operator: '>=', value: retirementAgeForMilestones }],
+      color: 'var(--c-positive-soft)',
+    });
+  }
+
+  // If End of Plan milestone doesn't exist, create it with legacy or default value
+  if (!existingIds.has(BUILTIN_MILESTONE_IDS.END_OF_PLAN)) {
+    const retireIndex = migrated.milestones.findIndex(m => m.id === BUILTIN_MILESTONE_IDS.RETIRE);
+    const insertIndex = retireIndex >= 0 ? retireIndex + 1 : 0;
+    migrated.milestones.splice(insertIndex, 0, {
+      id: BUILTIN_MILESTONE_IDS.END_OF_PLAN,
+      name: 'End of Plan',
+      // Trigger AFTER life expectancy year so expenses continue through it
+      conditions: [{ type: 'AGE', operator: '>=', value: lifeExpectancyForMilestones }],
+      color: 'var(--c-content-subtle)',
+    });
+  }
+
+  // Ensure built-in milestones have correct names and formats
+  migrated.milestones = migrated.milestones.map(m => {
+    if (m.id === BUILTIN_MILESTONE_IDS.BIRTH) {
+      return { ...m, name: 'Birth' };
+    }
+    if (m.id === BUILTIN_MILESTONE_IDS.RETIRE) {
+      return { ...m, name: 'Retire' };
+    }
+    if (m.id === BUILTIN_MILESTONE_IDS.END_OF_PLAN) {
+      // Migrate old format (operator '>') to new format (operator '>=') preserving
+      // the age value: getLifeExpectancy returns this value verbatim, so it must equal
+      // the intended life expectancy for both fresh and migrated users (no +1).
+      const ageCondition = m.conditions.find(c => c.type === 'AGE');
+      if (ageCondition && ageCondition.operator === '>') {
+        return {
+          ...m,
+          name: 'End of Plan',
+          conditions: [{ type: 'AGE' as const, operator: '>=' as const, value: ageCondition.value }],
+        };
+      }
+      return { ...m, name: 'End of Plan' };
+    }
+    return m;
+  });
+
+  // Clear deprecated fields (they're now derived from milestones)
+  delete (migrated.demographics as Record<string, unknown>).birthYear;
+  delete (migrated.demographics as Record<string, unknown>).retirementAge;
+  delete (migrated.demographics as Record<string, unknown>).lifeExpectancy;
+
+  return migrated;
+}
+
+type Action =
+  | { type: 'UPDATE_MACRO'; payload: Partial<AssumptionsState['macro']> }
+  | { type: 'UPDATE_INCOME'; payload: Partial<AssumptionsState['income']> }
+  | { type: 'UPDATE_EXPENSES'; payload: Partial<AssumptionsState['expenses']> }
+  | { type: 'UPDATE_INVESTMENTS'; payload: Partial<AssumptionsState['investments']> }
+  | { type: 'UPDATE_INVESTMENT_RATES'; payload: Partial<AssumptionsState['investments']['returnRates']> }
+  | { type: 'UPDATE_DEMOGRAPHICS'; payload: Partial<AssumptionsState['demographics']> }
+  | { type: 'UPDATE_DISPLAY'; payload: Partial<AssumptionsState['display']> }
+  | { type: 'RESET_DEFAULTS' }
+  | { type: 'SET_BULK_DATA'; payload: AssumptionsState }
+  | { type: 'SET_PRIORITIES'; payload: PriorityBucket[] }
+  | { type: 'ADD_PRIORITY'; payload: PriorityBucket }
+  | { type: 'REMOVE_PRIORITY'; payload: string }
+  | { type: 'UPDATE_PRIORITY'; payload: PriorityBucket }
+  | { type: 'SET_WITHDRAWAL_STRATEGY'; payload: WithdrawalBucket[] }
+  | { type: 'ADD_WITHDRAWAL_STRATEGY'; payload: WithdrawalBucket }
+  | { type: 'REMOVE_WITHDRAWAL_STRATEGY'; payload: string }
+  | { type: 'UPDATE_WITHDRAWAL_STRATEGY'; payload: WithdrawalBucket }
+  | { type: 'SET_PRIOR_EARNINGS'; payload: EarningsRecord[] }
+  | { type: 'CLEAR_PRIOR_EARNINGS' }
+  | { type: 'SET_MILESTONES'; payload: CustomMilestone[] }
+  | { type: 'ADD_MILESTONE'; payload: CustomMilestone }
+  | { type: 'REMOVE_MILESTONE'; payload: string }
+  | { type: 'UPDATE_MILESTONE'; payload: CustomMilestone };
+
+const assumptionsReducer = (state: AssumptionsState, action: Action): AssumptionsState => {
+  switch (action.type) {
+    case 'UPDATE_MACRO':
+      return { ...state, macro: { ...state.macro, ...action.payload } };
+    case 'UPDATE_INCOME':
+      return { ...state, income: { ...state.income, ...action.payload } };
+    case 'UPDATE_EXPENSES':
+      return { ...state, expenses: { ...state.expenses, ...action.payload } };
+    case 'UPDATE_INVESTMENTS':
+      return { ...state, investments: { ...state.investments, ...action.payload } };
+    case 'UPDATE_INVESTMENT_RATES':
+      return {
+        ...state,
+        investments: {
+          ...state.investments,
+          returnRates: { ...state.investments.returnRates, ...action.payload },
+        },
+      };
+    case 'UPDATE_DEMOGRAPHICS':
+      return { ...state, demographics: { ...state.demographics, ...action.payload } };
+    case 'UPDATE_DISPLAY':
+      return { ...state, display: { ...state.display, ...action.payload } };
+    case 'RESET_DEFAULTS':
+      // Preserve user's allocations, withdrawal order, and milestones
+      return {
+        ...defaultAssumptions,
+        priorities: state.priorities,
+        withdrawalStrategy: state.withdrawalStrategy,
+        milestones: state.milestones,
+      };
+    case 'SET_BULK_DATA':
+      return action.payload;
+    case 'SET_PRIORITIES':
+        return { ...state, priorities: action.payload };
+    case 'ADD_PRIORITY':
+        return { ...state, priorities: [...state.priorities, action.payload] };
+    case 'REMOVE_PRIORITY':
+        return { ...state, priorities: state.priorities.filter(p => p.id !== action.payload) };
+    case 'UPDATE_PRIORITY':
+        return { 
+            ...state, 
+            priorities: state.priorities.map(p => p.id === action.payload.id ? action.payload : p) 
+        };
+    case 'SET_WITHDRAWAL_STRATEGY':
+        return { ...state, withdrawalStrategy: action.payload };
+    case 'ADD_WITHDRAWAL_STRATEGY':
+        return { ...state, withdrawalStrategy: [...state.withdrawalStrategy, action.payload] };
+    case 'REMOVE_WITHDRAWAL_STRATEGY':
+        return { ...state, withdrawalStrategy: state.withdrawalStrategy.filter(p => p.id !== action.payload) };
+    case 'UPDATE_WITHDRAWAL_STRATEGY':
+        return {
+            ...state,
+            withdrawalStrategy: state.withdrawalStrategy.map(p => p.id === action.payload.id ? action.payload : p)
+        };
+    case 'SET_PRIOR_EARNINGS':
+        return {
+            ...state,
+            demographics: { ...state.demographics, priorEarnings: action.payload }
+        };
+    case 'CLEAR_PRIOR_EARNINGS':
+        return {
+            ...state,
+            demographics: { ...state.demographics, priorEarnings: undefined }
+        };
+    case 'SET_MILESTONES':
+        return { ...state, milestones: action.payload };
+    case 'ADD_MILESTONE':
+        return { ...state, milestones: [...state.milestones, action.payload] };
+    case 'REMOVE_MILESTONE':
+        // Prevent removing built-in milestones
+        if (isBuiltinMilestone(action.payload)) {
+            return state;
+        }
+        return { ...state, milestones: state.milestones.filter(m => m.id !== action.payload) };
+    case 'UPDATE_MILESTONE': {
+        // For built-in milestones, preserve the name
+        const updatedMilestone = isBuiltinMilestone(action.payload.id)
+            ? { ...action.payload, name: state.milestones.find(m => m.id === action.payload.id)?.name || action.payload.name }
+            : action.payload;
+        return {
+            ...state,
+            milestones: state.milestones.map(m => m.id === updatedMilestone.id ? updatedMilestone : m)
+        };
+    }
+    default:
+      return state;
+  }
+};
+
+interface AssumptionsContextProps {
+    state: AssumptionsState;
+    dispatch: React.Dispatch<Action>;
+}
+
+export const AssumptionsContext = createContext<AssumptionsContextProps>({
+  state: defaultAssumptions,
+  dispatch: () => null,
+})
+
+export const AssumptionsProvider = ({ children }: { children: ReactNode }) => {
+  const [state, dispatch] = useReducer(assumptionsReducer, defaultAssumptions, (initial) => {
+    const saved = localStorage.getItem('assumptions_settings');
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        // Deep merge with defaults to handle missing fields from older versions
+        return migrateAssumptions(parsed, initial);
+      } catch (e) {
+        // JSON parse failed - return defaults
+        return initial;
+      }
+    }
+    return initial;
+  });
+
+  // Debounced localStorage persistence (500ms delay to prevent main thread blocking)
+  useDebouncedLocalStorage('assumptions_settings', state);
+
+  // Memoize context value to prevent unnecessary re-renders
+  const contextValue = useMemo(() => ({
+    state,
+    dispatch
+  }), [state, dispatch]);
+
+  return <AssumptionsContext.Provider value={contextValue}>{children}</AssumptionsContext.Provider>;
+};
+
+/**
+ * Custom hook to access assumptions state
+ * @returns Object containing assumptions state and dispatch function
+ */
+export const useAssumptions = () => {
+  const { state, dispatch } = useContext(AssumptionsContext);
+  return { assumptions: state, dispatch };
+};

--- a/src/components/Objects/Assumptions/SimulationEngine.tsx
+++ b/src/components/Objects/Assumptions/SimulationEngine.tsx
@@ -1,0 +1,743 @@
+// src/components/Simulation/SimulationEngine.ts
+// Thin orchestrator - delegates to focused service modules.
+
+import { AnyAccount } from "../../Objects/Accounts/models";
+import { AnyExpense, MortgageExpense, LoanExpense, isLongTermGoal, isGoalDueInYear } from "../Expense/models";
+import { AnyIncome, WorkIncome, PassiveIncome } from "../../Objects/Income/models";
+import { AssumptionsState, getBirthYear, BUILTIN_MILESTONE_IDS } from "./AssumptionsContext";
+import { TaxState } from "../../Objects/Taxes/TaxContext";
+import * as TaxService from "../../Objects/Taxes/TaxService";
+
+// Re-export types from the new module structure
+export type { SimulationYear } from "../../../services/simulation/types";
+import { SimulationYear, WithdrawalState, BaselineProjections } from "../../../services/simulation/types";
+
+// Re-export helper for external consumers (e.g., RothConversionService tests)
+export { calculateEffectiveConversionTax } from "../../../services/simulation/helpers";
+
+// Import service modules
+import { projectIncomes } from "../../../services/simulation/IncomeProjection";
+import { processRMDs } from "../../../services/simulation/RMDService";
+import { applyLifestyleCreep, calculateStrategyTarget, calculateTotalDiscretionary } from "../../../services/simulation/SpendingStrategy";
+import { processDeficitDebt } from "../../../services/simulation/WithdrawalService";
+import { processInflows, growAccounts } from "../../../services/simulation/AccountGrowth";
+import { evaluateAllMilestones, isActiveByMilestone, MilestoneContext } from "../../../services/simulation/MilestoneEvaluator";
+import { InvestedAccount, SavedAccount, ESPPAccount } from "../Accounts/models";
+import { solveYear, YearSolverInput } from "../../../services/simulation/YearSolver";
+import { YearPlan } from "../../../services/simulation/types";
+import { buildCashflowDetail } from "../../../services/simulation/CashflowDetailBuilder";
+
+// =============================================================================
+// YearSolver-based simulation engine
+// =============================================================================
+
+/**
+ * Execute a YearPlan by applying withdrawals and conversions to accounts.
+ * This is Phase 3 of the new engine - mutations happen here.
+ */
+function executeYearPlan(
+    plan: YearPlan,
+    accounts: AnyAccount[],
+    withdrawalState: WithdrawalState,
+    logs: string[]
+): { conversionDeposits: Record<string, number> } {
+    const conversionDeposits: Record<string, number> = {};
+
+    // Execute withdrawals
+    for (const withdrawal of plan.withdrawals) {
+        const account = accounts.find(a => a.id === withdrawal.accountId);
+        if (!account || !(account instanceof InvestedAccount || account instanceof SavedAccount || account instanceof ESPPAccount)) {
+            continue;
+        }
+
+        // Skip RMDs — RMDService.processRMDs() already deducted from the account and
+        // recorded the totals. The RMD entry is in plan.withdrawals only as a tracking
+        // record for the solver's iteration logic and consumers that filter by reason.
+        if (withdrawal.reason === 'Required Minimum Distribution') {
+            continue;
+        }
+
+        // Deduct from account (will be applied in growAccounts)
+        withdrawalState.userInflows[account.id] =
+            (withdrawalState.userInflows[account.id] || 0) - withdrawal.gross;
+
+        withdrawalState.totalWithdrawals += withdrawal.gross;
+        withdrawalState.withdrawalDetail[account.name] =
+            (withdrawalState.withdrawalDetail[account.name] || 0) + withdrawal.gross;
+
+        // Track capital gains from brokerage withdrawals
+        if (withdrawal.capitalGains) {
+            withdrawalState.longTermCapitalGains += withdrawal.capitalGains.longTerm;
+            withdrawalState.shortTermCapitalGains += withdrawal.capitalGains.shortTerm;
+        }
+
+        // Track penalties
+        withdrawalState.withdrawalPenalties += withdrawal.penalty;
+
+        // Track Traditional withdrawals for tax calculations
+        if (withdrawal.source === 'traditional_401k' || withdrawal.source === 'traditional_ira') {
+            withdrawalState.traditionalWithdrawals += withdrawal.gross;
+        }
+
+        if (withdrawal.gross > 0) {
+            logs.push(`[V2 exec] Withdrew $${withdrawal.gross.toLocaleString()} from ${withdrawal.accountName} (${withdrawal.reason})`);
+        }
+    }
+
+    // Execute Roth conversion
+    if (plan.conversion) {
+        const sourceAccount = accounts.find(a => a.id === plan.conversion!.fromAccountId);
+        const targetAccount = accounts.find(a => a.id === plan.conversion!.toAccountId);
+
+        if (sourceAccount && targetAccount &&
+            sourceAccount instanceof InvestedAccount && targetAccount instanceof InvestedAccount) {
+
+            // Deduct from source (Traditional)
+            withdrawalState.userInflows[sourceAccount.id] =
+                (withdrawalState.userInflows[sourceAccount.id] || 0) - plan.conversion.amount;
+
+            // Add to target (Roth) - userInflows drives the balance change,
+            // conversionDeposits tracks conversion history in increment()
+            withdrawalState.userInflows[targetAccount.id] =
+                (withdrawalState.userInflows[targetAccount.id] || 0) + plan.conversion.netToRoth;
+            conversionDeposits[targetAccount.id] = plan.conversion.netToRoth;
+
+            logs.push(`[V2] Roth conversion: $${plan.conversion.amount.toLocaleString()} from ${sourceAccount.name} → ${targetAccount.name}`);;
+        }
+    }
+
+    return { conversionDeposits };
+}
+
+/**
+ * Convert YearPlan tax to withdrawal state format for compatibility.
+ * Uses the split tax values from YearPlan:
+ * - capitalGainsLT: tax from brokerage/ESPP withdrawals (have w.capitalGains)
+ * - withdrawalOrdinaryTax: tax from Roth earnings (5-year rule), Traditional, HSA non-medical
+ */
+function updateWithdrawalStateFromPlan(
+    plan: YearPlan,
+    withdrawalState: WithdrawalState
+): void {
+    // Use the pre-split values from YearPlan.tax (computed by YearSolver)
+    withdrawalState.capitalGainsTaxTotal = plan.tax.capitalGainsLT;
+    withdrawalState.withdrawalOrdinaryTaxTotal = plan.tax.withdrawalOrdinaryTax;
+    withdrawalState.withdrawalTaxes = plan.tax.total - plan.tax.fica;
+}
+
+/**
+ * Simulate one year using the new YearSolver-based engine.
+ *
+ * This is the V2 engine that uses:
+ * - Conversion-before-withdrawal ordering
+ * - Algebraic gross-up formulas
+ * - Convergence loop for bracket crossings
+ */
+function simulateOneYearWithNewEngine(
+    year: number,
+    incomes: AnyIncome[],
+    expenses: AnyExpense[],
+    accounts: AnyAccount[],
+    assumptions: AssumptionsState,
+    taxState: TaxState,
+    previousSimulation: SimulationYear[] = [],
+    returnOverride?: number,
+    previousActiveMilestones: string[] = [],
+    previousMilestoneReachYears: Map<string, number> = new Map(),
+    baselineProjections?: BaselineProjections,
+    conversionMode: 'rate-match' | 'std-ded-only' = 'rate-match',
+    dpConversionPlan?: Map<number, number>,
+    dpDebugByYear?: Map<number, string[]>,
+): SimulationYear {
+    const logs: string[] = [];
+    logs.push('[V2 Engine] Using new YearSolver-based simulation');
+
+    // Calculate current age
+    const currentAge = year - getBirthYear(assumptions.milestones);
+
+    // ------------------------------------------------------------------
+    // MILESTONE EVALUATION (same as old engine)
+    // ------------------------------------------------------------------
+    const milestoneContext: MilestoneContext = {
+        accounts,
+        expenses,
+        year,
+        age: currentAge,
+        milestoneReachYears: previousMilestoneReachYears,
+        filingStatus: taxState.filingStatus,
+    };
+
+    const milestoneResult = evaluateAllMilestones(
+        assumptions.milestones || [],
+        new Set(previousActiveMilestones),
+        milestoneContext
+    );
+
+    const activeMilestoneSet = new Set(milestoneResult.activeMilestones);
+    const isRetired = activeMilestoneSet.has(BUILTIN_MILESTONE_IDS.RETIRE);
+
+    milestoneResult.newlyReached.forEach(event => {
+        const milestone = assumptions.milestones?.find(m => m.id === event.milestoneId);
+        if (milestone) {
+            logs.push(`🎯 Milestone reached: "${milestone.name}" at age ${event.ageReached}`);
+        }
+    });
+
+    const previousMilestoneSet = new Set(previousActiveMilestones);
+
+    // ------------------------------------------------------------------
+    // ROTH 401K → ROTH IRA ROLLOVER AT RETIREMENT
+    // ------------------------------------------------------------------
+    // Per IRS Notice 2014-54 and §402A(d)(4), a Roth 401k rolled into a Roth
+    // IRA carries its contribution basis as Roth IRA regular contributions
+    // (immediately tappable, no penalty) and earnings as Roth IRA earnings.
+    // This eliminates the Roth 401k pro-rata distribution rule for retirees
+    // and aligns with how the WithdrawalPlanner already orders Roth dollars
+    // (contributions → conversions → earnings).
+    const justRetired = isRetired && !previousMilestoneSet.has(BUILTIN_MILESTONE_IDS.RETIRE);
+    if (justRetired) {
+        accounts = accounts.map(acc => {
+            if (acc instanceof InvestedAccount && acc.taxType === 'Roth 401k') {
+                logs.push(`💸 Rolled over Roth 401k "${acc.name}" → Roth IRA at retirement (balance $${Math.round(acc.amount).toLocaleString()}, contributions $${Math.round(acc.regularContributions).toLocaleString()})`);
+                return new InvestedAccount(
+                    acc.id,
+                    acc.name,
+                    acc.amount,
+                    acc.employerBalance,
+                    acc.tenureYears,
+                    acc.expenseRatio,
+                    'Roth IRA',
+                    acc.isContributionEligible,
+                    acc.vestedPerYear,
+                    acc.costBasis,
+                    acc.customROR,
+                    acc.conversionHistory,
+                    acc.lots,
+                );
+            }
+            return acc;
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // FILTER INCOMES AND EXPENSES BY MILESTONE
+    // ------------------------------------------------------------------
+    const milestoneFilteredIncomes = incomes.filter(inc => {
+        if (!isActiveByMilestone(inc.startMilestoneId, inc.endMilestoneId, activeMilestoneSet, previousMilestoneSet)) {
+            return false;
+        }
+        if (isRetired && inc instanceof WorkIncome && !inc.endMilestoneId) {
+            return false;
+        }
+        return true;
+    });
+
+    const milestoneFilteredExpenses = expenses.filter(exp =>
+        isActiveByMilestone(exp.startMilestoneId, exp.endMilestoneId, activeMilestoneSet, previousMilestoneSet)
+    );
+
+    // ------------------------------------------------------------------
+    // PROJECT INCOMES (same as old engine)
+    // ------------------------------------------------------------------
+    const incomeResult = projectIncomes(
+        year, milestoneFilteredIncomes, accounts, assumptions, previousSimulation,
+        currentAge, isRetired, logs
+    );
+    const { nextIncomes: incomesWithEarningsTest, allIncomes } = incomeResult;
+
+    // ------------------------------------------------------------------
+    // LIFESTYLE CREEP (same as old engine)
+    // ------------------------------------------------------------------
+    let nextExpenses = milestoneFilteredExpenses.map(exp => {
+        const next = exp.increment(assumptions);
+        // A goal's `amount` is its total cost, funded by a nominal fixed monthly
+        // set-aside (and the budget computes that set-aside from the un-inflated
+        // amount). Inflating the cost here would make the lump outgrow the fund
+        // and silently underfund the purchase, so keep it static.
+        if (isLongTermGoal(exp)) next.amount = exp.amount;
+        return next;
+    });
+    nextExpenses = applyLifestyleCreep(nextExpenses, milestoneFilteredIncomes, assumptions, year, isRetired, logs);
+
+    // ------------------------------------------------------------------
+    // CALCULATE EXPENSES
+    // ------------------------------------------------------------------
+    const totalLivingExpenses = nextExpenses.reduce((sum, exp) => {
+        if (exp instanceof MortgageExpense) {
+            return sum + exp.calculateAnnualAmortization(year).totalPayment;
+        }
+        if (exp instanceof LoanExpense) {
+            return sum + exp.calculateAnnualAmortization(year).totalPayment;
+        }
+        return sum + exp.getAnnualAmount(year);
+    }, 0);
+
+    // ------------------------------------------------------------------
+    // WITHDRAWAL STRATEGY TARGET (for GK, Fixed Real, etc.)
+    // ------------------------------------------------------------------
+    const strategyWithdrawalResult = isRetired
+        ? calculateStrategyTarget(accounts, assumptions, previousSimulation, year, currentAge, logs)
+        : undefined;
+
+    // ------------------------------------------------------------------
+    // PROCESS RMDs
+    // ------------------------------------------------------------------
+    const totalGrossIncome = TaxService.getGrossIncome(allIncomes, year);
+    const preTaxDeductions = TaxService.getPreTaxExemptions(incomesWithEarningsTest, year);
+
+    const withdrawalState: WithdrawalState = {
+        userInflows: {},
+        employerInflows: {},
+        withdrawalTaxes: 0,
+        capitalGainsTaxTotal: 0,
+        withdrawalOrdinaryTaxTotal: 0,
+        strategyWithdrawalExecuted: 0,
+        totalWithdrawals: 0,
+        withdrawalDetail: {},
+        withdrawalPenalties: 0,
+        totalGrossIncome,
+        traditionalWithdrawals: 0,
+        longTermCapitalGains: 0,
+        shortTermCapitalGains: 0,
+        stateCapitalGainsTax: 0,
+    };
+
+    const rmdResult = processRMDs(
+        year, accounts, assumptions,
+        previousSimulation, currentAge, totalGrossIncome,
+        withdrawalState, logs
+    );
+
+    const rmdDetails = rmdResult.rmdDetails;
+    const rmdIncomes = rmdResult.rmdIncomes;
+    const rmdAmount = rmdDetails?.totalWithdrawn || 0;
+
+    // Add RMD incomes to allIncomes
+    allIncomes.push(...rmdIncomes);
+
+    // ------------------------------------------------------------------
+    // CALL YEAR SOLVER (Phase 2)
+    // ------------------------------------------------------------------
+    // Calculate fixed vs discretionary expenses for GK budget handling
+    const discretionaryExpenses = calculateTotalDiscretionary(nextExpenses, year);
+    const fixedExpenses = totalLivingExpenses - discretionaryExpenses;
+
+    // A goal's sinking-fund priority should only run while the goal is actively
+    // saving: from its start year onward, and — for one-time (targetDate) goals —
+    // only up to the purchase year. Outside that window funding would pile into an
+    // account the goal doesn't need yet (before start) or into a drained, reserved
+    // account forever (after a one-time purchase). We neutralize those priorities
+    // (cap them to $0) rather than removing them: dropping the bucket entirely can
+    // leave the list empty and trip the surplus allocator's smart-default, which
+    // would refill the reserved SavedAccount anyway. Capping at 0 lets the surplus
+    // flow to the remaining priorities/remainder instead, and mirrors the budget's
+    // fundingStartMonth so the "expected balance" benchmark matches the sim.
+    // Recurring goals keep funding past each purchase — they refill toward the
+    // next cycle.
+    const inactiveGoalFundIds = new Set(
+        expenses
+            .filter(e => isLongTermGoal(e) && e.goalAccountId)
+            .filter(e => {
+                const goalStartYear = (e.startDate ? new Date(e.startDate) : new Date()).getFullYear();
+                if (year < goalStartYear) return true; // not saving yet
+                if (e.goalType === 'targetDate' && e.goalTargetDate
+                    && new Date(e.goalTargetDate).getFullYear() < year) return true; // already purchased
+                return false;
+            })
+            .map(e => e.goalAccountId!)
+    );
+    const effectiveAssumptions = inactiveGoalFundIds.size > 0
+        ? {
+            ...assumptions,
+            priorities: (assumptions.priorities || []).map(p =>
+                p.accountId && inactiveGoalFundIds.has(p.accountId)
+                    ? { ...p, capType: 'FIXED' as const, capValue: 0 }
+                    : p
+            ),
+        }
+        : assumptions;
+
+    const solverInput: YearSolverInput = {
+        year,
+        currentAge,
+        isRetired,
+        incomes: allIncomes,
+        expenses: nextExpenses,
+        totalLivingExpenses,
+        rmdAmount,
+        accounts,
+        withdrawalOrder: assumptions.withdrawalStrategy.map(w => ({ accountId: w.accountId })),
+        taxState,
+        assumptions: effectiveAssumptions,
+        strategyResult: strategyWithdrawalResult,
+        taxOptimizationEnabled: assumptions.investments.taxOptimizationEnabled,
+        acaAware: currentAge < 65 && (assumptions.investments.acaAware !== false),
+        previousSimulation: previousSimulation.map(s => ({ year: s.year, accounts: s.accounts })),
+        // GK Guardrails: Pass budget and expense breakdown when strategy is active
+        gkBudget: strategyWithdrawalResult?.amount,
+        fixedExpenses,
+        discretionaryExpenses,
+        // Per-year sub-sim baseline projections. Used by the conversion ceiling
+        // calculator so SS / pension / passive / Trad-balance at RMD come from a
+        // forward sub-simulation that does only std-ded-headroom conversions —
+        // rather than rough estimates or naive forward-compounding.
+        baselineProjections,
+        conversionMode,
+        dpConversionPlan,
+        dpDebugByYear,
+    };
+
+    const yearPlan = solveYear(solverInput);
+
+    // Log decisions from solver (planning phase)
+    yearPlan.decisions.forEach(d => {
+        if (d.category === 'warning') {
+            logs.push(`⚠️ ${d.description}`);
+        } else if (d.category === 'conversion' || d.category === 'withdrawal') {
+            // Always log conversion/withdrawal decisions (skip, reduce, execute)
+            if (d.amount) {
+                logs.push(`[V2 plan] ${d.category}: $${d.amount.toLocaleString()} - ${d.description}`);
+            } else {
+                logs.push(`[V2 plan] ${d.category}: ${d.description}`);
+            }
+        } else if (d.amount) {
+            logs.push(`[V2 plan] ${d.category}: $${d.amount.toLocaleString()} - ${d.description}`);
+        }
+    });
+
+    // ------------------------------------------------------------------
+    // ADJUST EXPENSES FOR GK TRIMMING + BUILD STRATEGY ADJUSTMENT RESULT
+    // ------------------------------------------------------------------
+    // When GK guardrails trim discretionary spending, the solver uses a reduced
+    // effectiveLivingExpenses but the expense objects still report full amounts.
+    // Adjust discretionary expense objects so their getAnnualAmount() values
+    // match the actual trimmed spending. This ensures downstream consumers
+    // (like the Sankey chart) get consistent data without needing corrections.
+    let strategyAdjustmentResult: SimulationYear['strategyAdjustment'] = undefined;
+
+    if (yearPlan.totalExpenses < totalLivingExpenses) {
+        const trimAmount = totalLivingExpenses - yearPlan.totalExpenses;
+        const totalDiscretionary = calculateTotalDiscretionary(nextExpenses, year);
+        if (totalDiscretionary > 0) {
+            const cutRatio = 1 - Math.min(trimAmount, totalDiscretionary) / totalDiscretionary;
+            nextExpenses = nextExpenses.map(exp =>
+                exp.isDiscretionary ? exp.adjustAmount(cutRatio) : exp
+            );
+        }
+
+        // Populate strategyAdjustment so the UI can show warning banners.
+        // This fires for any withdrawal strategy budget cap — including the first
+        // retirement year where guardrailTriggered is 'none' (just the base 4% withdrawal).
+        if (strategyWithdrawalResult) {
+            strategyAdjustmentResult = {
+                guardrailTriggered: strategyWithdrawalResult.guardrailTriggered,
+                requiredAdjustment: trimAmount,
+                actualAdjustment: Math.min(trimAmount, totalDiscretionary),
+                discretionaryAvailable: totalDiscretionary,
+                warning: totalDiscretionary < trimAmount
+                    ? `Fixed expenses exceed budget. Only $${totalDiscretionary.toLocaleString()} of $${trimAmount.toLocaleString()} could be cut.`
+                    : undefined,
+            };
+        }
+    } else if (strategyWithdrawalResult && strategyWithdrawalResult.guardrailTriggered === 'prosperity'
+        && yearPlan.totalExpenses > totalLivingExpenses) {
+        // Prosperity: solver increased spending above original expenses
+        strategyAdjustmentResult = {
+            guardrailTriggered: 'prosperity',
+            requiredAdjustment: 0,
+            actualAdjustment: yearPlan.totalExpenses - totalLivingExpenses,
+            discretionaryAvailable: discretionaryExpenses,
+        };
+    }
+
+    // ------------------------------------------------------------------
+    // EXECUTE YEAR PLAN (Phase 3)
+    // ------------------------------------------------------------------
+    const { conversionDeposits } = executeYearPlan(yearPlan, accounts, withdrawalState, logs);
+    updateWithdrawalStateFromPlan(yearPlan, withdrawalState);
+
+    // ------------------------------------------------------------------
+    // SURPLUS ALLOCATION (from YearPlan - computed by YearSolver)
+    // ------------------------------------------------------------------
+    // Track surplus allocations for Sankey display and account growth
+    // Note: YearSolver already computed the allocations - we just apply them here
+    const surplusBucketDetail: Record<string, number> = {};
+
+    if (yearPlan.surplusAllocations.length > 0) {
+        // Apply surplus allocations to withdrawal state (for account growth) and bucket detail (for Sankey)
+        yearPlan.surplusAllocations.forEach(alloc => {
+            logs.push(`[V2] Surplus allocated: $${alloc.amount.toLocaleString()} to ${alloc.reason}`);
+
+            // Add to userInflows so growAccounts() will deposit the surplus
+            withdrawalState.userInflows[alloc.accountId] =
+                (withdrawalState.userInflows[alloc.accountId] || 0) + alloc.amount;
+
+            // Track in bucket detail for Sankey display
+            surplusBucketDetail[alloc.accountId] =
+                (surplusBucketDetail[alloc.accountId] || 0) + alloc.amount;
+        });
+    }
+
+    // Compute totalSurplusAllocations early so we can subtract it from trueUserSaved
+    // (bucket allocations are counted separately, so they shouldn't also be in "invested")
+    const totalSurplusAllocations = Object.values(surplusBucketDetail).reduce((sum, amt) => sum + amt, 0);
+
+    // ------------------------------------------------------------------
+    // DEFICIT DEBT TRACKING
+    // ------------------------------------------------------------------
+    // V2 path: Use unfundedDeficit from YearSolver to track when expenses
+    // couldn't be covered by income + withdrawals (portfolio failure).
+    // Pass as negative because processDeficitDebt expects negative = deficit.
+    let discretionaryCash = -yearPlan.unfundedDeficit;
+    const deficitDebtResult = processDeficitDebt(discretionaryCash, accounts, logs);
+    const existingDeficitDebt = deficitDebtResult.existingDeficitDebt;
+    discretionaryCash = deficitDebtResult.discretionaryCash;
+
+    // ------------------------------------------------------------------
+    // PROCESS INFLOWS (contributions, matching, etc.)
+    // ------------------------------------------------------------------
+    const inflowResult = processInflows(
+        incomesWithEarningsTest, accounts, assumptions, year, withdrawalState,
+        discretionaryCash, existingDeficitDebt, totalLivingExpenses, currentAge, logs
+    );
+    discretionaryCash = inflowResult.discretionaryCash;
+
+    // ------------------------------------------------------------------
+    // GROW ACCOUNTS (Phase 4)
+    // ------------------------------------------------------------------
+    const nextAccounts = growAccounts(
+        accounts, nextExpenses, withdrawalState, conversionDeposits,
+        inflowResult.esppLots, yearPlan.deficitDebtPayment, existingDeficitDebt,
+        assumptions, year, returnOverride, logs
+    );
+
+    // ------------------------------------------------------------------
+    // LONG-TERM GOAL PURCHASES
+    // In a goal's due year, spend the lump from its reserved sinking-fund
+    // account. Net worth dips by what's available in the fund; recurring goals
+    // keep accruing toward the next cycle afterward.
+    // ------------------------------------------------------------------
+    for (const exp of expenses) {
+        if (!isLongTermGoal(exp) || !exp.goalAccountId || !isGoalDueInYear(exp, year)) continue;
+        // A recurring goal can carry an end date (when to stop replacing it);
+        // don't fire the lump after it.
+        if (exp.endDate && new Date(exp.endDate).getUTCFullYear() < year) continue;
+        const fund = nextAccounts.find(a => a.id === exp.goalAccountId);
+        if (!fund) continue;
+        const spent = Math.min(fund.amount, exp.amount);
+        fund.amount -= spent;
+        logs.push(`🎯 Goal "${exp.name}" came due: spent $${Math.round(spent).toLocaleString()} from its fund (balance now $${Math.round(fund.amount).toLocaleString()})`);
+    }
+
+    // ------------------------------------------------------------------
+    // BUILD ROTH CONVERSION RESULT (for output compatibility)
+    // ------------------------------------------------------------------
+    let rothConversionResult: SimulationYear['rothConversion'] = undefined;
+    if (yearPlan.conversion) {
+        const sourceAccount = accounts.find(a => a.id === yearPlan.conversion!.fromAccountId);
+        const targetAccount = accounts.find(a => a.id === yearPlan.conversion!.toAccountId);
+
+        if (sourceAccount && targetAccount) {
+            rothConversionResult = {
+                amount: yearPlan.conversion.amount,
+                taxCost: yearPlan.conversion.taxAmount,
+                federalTaxCost: yearPlan.conversion.federalTaxCost,
+                stateTaxCost: yearPlan.conversion.stateTaxCost,
+                taxAfter: yearPlan.tax.federal + yearPlan.conversion.taxAmount,
+                fromAccounts: { [sourceAccount.name]: yearPlan.conversion.amount },
+                toAccounts: { [targetAccount.name]: yearPlan.conversion.netToRoth },
+                fromAccountIds: { [sourceAccount.id]: yearPlan.conversion.amount },
+                toAccountIds: { [targetAccount.id]: yearPlan.conversion.netToRoth },
+            };
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // CALCULATE FINAL STATS
+    // ------------------------------------------------------------------
+    const totalInsuranceCost = incomesWithEarningsTest.reduce((sum, inc) => {
+        if (inc instanceof WorkIncome) {
+            return sum + inc.getProratedAnnual(inc.insurance, year);
+        }
+        return sum;
+    }, 0);
+
+    const postTaxDeductions = TaxService.getPostTaxExemptions(incomesWithEarningsTest, year);
+    const totalTax = yearPlan.tax.total;
+
+    // ------------------------------------------------------------------
+    // SANKEY CASH ACCOUNTING (Fix A + Fix B + Fix C)
+    // ------------------------------------------------------------------
+    // Fix A: Use solver's spendable income (excludes reinvested dividends which aren't cash)
+    // Fix B: Subtract bucket allocations (counted separately in Sankey outflows)
+    // Fix C: Subtract the planner's LTCG tax baked into the brokerage gross-up.
+    //
+    // Sankey equation: inflows = outflows
+    //   inflows = spendableIncome + withdrawals - brokerageLTCGFromGross
+    //   outflows = expenses + taxes + invested + bucketAllocations + discretionary
+    //
+    // The solver's spendable income correctly excludes reinvested dividends (taxable but not cash).
+    const spendableIncome = yearPlan.income.spendable;
+    //
+    // LTCG NOTE: planner's LTCG (sum of w.tax for brokerage/ESPP) is paid directly to the
+    // government from the brokerage gross-up — it never reaches user cash. Subtracting it
+    // here mirrors YearSolver Step F's `actualLTCGTax` subtraction in `cashIn`. Without this,
+    // a phantom surplus equal to the LTCG tax appears in `trueUserSaved` (showing up as
+    // "investedUser" during retirement years even when there's $0 income).
+    //
+    // When planner rate is 0% (low ordinary income) there's no gross-up, sum is 0, no
+    // change. Auth LTCG in that case is captured by `unfundedDeficit` instead.
+    const brokerageLTCGFromGross = yearPlan.withdrawals
+        .filter(w => w.capitalGains !== undefined)
+        .reduce((sum, w) => sum + w.tax, 0);
+    const totalCashAvailable =
+        spendableIncome
+        + withdrawalState.totalWithdrawals
+        - brokerageLTCGFromGross;
+    const totalBucketAllocationsForSankey = totalSurplusAllocations + inflowResult.totalBucketAllocations;
+    // Use solver's actual expenses (yearPlan.totalExpenses) which reflects GK budget trimming,
+    // not the pre-trim totalLivingExpenses. Otherwise the Sankey equation is unbalanced when
+    // GK cuts discretionary spending — withdrawals cover the trimmed amount but this formula
+    // subtracts the full (untrimmed) expenses, creating a phantom negative "invested" amount.
+    const actualLivingExpenses = yearPlan.totalExpenses;
+    const trueUserSaved = totalCashAvailable - totalTax - totalInsuranceCost - actualLivingExpenses - discretionaryCash - totalBucketAllocationsForSankey;
+
+    // Filter out RMD incomes from returned array
+    const returnedIncomes = allIncomes.filter(inc =>
+        !(inc instanceof PassiveIncome && inc.sourceType === 'RMD')
+    );
+
+    // ------------------------------------------------------------------
+    // MERGE BUCKET DETAILS (surplus allocations + inflow allocations)
+    // ------------------------------------------------------------------
+    const mergedBucketDetail: Record<string, number> = { ...inflowResult.bucketDetail };
+    for (const [accountId, amount] of Object.entries(surplusBucketDetail)) {
+        mergedBucketDetail[accountId] = (mergedBucketDetail[accountId] || 0) + amount;
+    }
+    // Note: totalSurplusAllocations was already computed earlier for trueUserSaved calculation
+    const totalBucketAllocations = inflowResult.totalBucketAllocations + totalSurplusAllocations;
+
+    // ------------------------------------------------------------------
+    // BUILD CASHFLOW DETAIL (for Sankey chart - avoids re-deriving
+    // per-source income, contribution splits, mortgage breakdown, and
+    // expense categories from scratch in the chart layer)
+    // ------------------------------------------------------------------
+    // Use allIncomes so reinvested interest (created in projectIncomes) is
+    // included, and so RMD-sourced PassiveIncomes are surfaced as income (they
+    // drain the Traditional account via userInflows but are not in
+    // withdrawalDetail, so income is their single Sankey representation).
+    const cashflowDetail = buildCashflowDetail({
+        incomes: allIncomes,
+        expenses: nextExpenses,
+        accounts: nextAccounts,
+        insurance: totalInsuranceCost,
+        year,
+        brokerageLTCGFromGross,
+        employerInflows: withdrawalState.employerInflows,
+    });
+
+    // ------------------------------------------------------------------
+    // RETURN SIMULATION YEAR
+    // ------------------------------------------------------------------
+    return {
+        year,
+        incomes: returnedIncomes,
+        expenses: nextExpenses,
+        accounts: nextAccounts,
+        cashflow: {
+            // Use spendableIncome for Sankey (excludes reinvested dividends which aren't cash)
+            totalIncome: spendableIncome,
+            totalExpense: actualLivingExpenses + totalTax + preTaxDeductions + postTaxDeductions,
+            livingExpenses: actualLivingExpenses,
+            discretionary: discretionaryCash,
+            investedUser: trueUserSaved,
+            investedMatch: inflowResult.totalEmployerMatch,
+            totalInvested: trueUserSaved + inflowResult.totalEmployerMatch,
+            bucketAllocations: totalBucketAllocations,
+            bucketDetail: mergedBucketDetail,
+            withdrawals: withdrawalState.totalWithdrawals,
+            withdrawalDetail: withdrawalState.withdrawalDetail,
+        },
+        cashflowDetail,
+        taxDetails: {
+            fed: yearPlan.tax.federal + withdrawalState.withdrawalPenalties,
+            state: yearPlan.tax.state,
+            fica: yearPlan.tax.fica,
+            preTax: preTaxDeductions - totalInsuranceCost,
+            insurance: totalInsuranceCost,
+            postTax: postTaxDeductions,
+            capitalGains: withdrawalState.capitalGainsTaxTotal,
+            withdrawalOrdinaryTax: withdrawalState.withdrawalOrdinaryTaxTotal,
+            niit: yearPlan.tax.niit,
+            earlyWithdrawalPenalty: withdrawalState.withdrawalPenalties,
+            longTermCapitalGains: withdrawalState.longTermCapitalGains,
+        },
+        logs,
+        strategyWithdrawal: strategyWithdrawalResult,
+        strategyAdjustment: strategyAdjustmentResult,
+        rothConversion: rothConversionResult,
+        rmdDetails,
+        milestoneEvents: milestoneResult.newlyReached,
+        activeMilestones: milestoneResult.activeMilestones,
+        taxOptimizationTarget: yearPlan.taxOptimizationTarget,
+    };
+}
+
+/**
+ * Runs the simulation for a single timestep (1 year).
+ * Takes "Year N" data and returns "Year N+1" data.
+ *
+ * ARCHITECTURE NOTE: Tax/Withdrawal Circular Dependency
+ * =====================================================
+ *
+ * There is a circular dependency in tax calculation:
+ *   Deficit → Withdrawals → LTCG → Tax → Deficit
+ *
+ * Current approach (Option B - Post-hoc correction):
+ * - Calculate preliminary tax with LTCG=0 to estimate deficit
+ * - Execute withdrawals, which determines actual LTCG/STCG from brokerage sales
+ * - Recalculate final tax with actual LTCG/STCG
+ * - Do NOT iterate — accept any shortfall/surplus in discretionary cash
+ *
+ * Tradeoffs:
+ * - Shortfall: If LTCG triggers more tax than estimated (e.g., NIIT), the
+ *   shortfall reduces discretionary cash or rolls to next year
+ * - Magnitude: Typically <$1k/year; could be $5-10k in years with large
+ *   brokerage liquidation
+ * - Over full simulation: Total taxes are correct, just slightly misallocated
+ *   between years
+ *
+ * TODO: Future SimulationEngine rewrite should consider:
+ * 1. Iteration with convergence cap (max 3 passes, accept <$500 difference)
+ * 2. Predictive LTCG estimation based on withdrawal plan before execution
+ * 3. Full constraint-based solver that handles all circular dependencies
+ *
+ * Related issues this affects:
+ * - NIIT calculation (3.8% on investment income when MAGI > $200k/$250k)
+ * - LTCG stacking (LTCG rate depends on ordinary taxable income)
+ * - SS torpedo (withdrawal amount affects SS taxability, but we handle this
+ *   correctly since Traditional withdrawals are known before tax calc)
+ */
+export function simulateOneYear(
+    year: number,
+    incomes: AnyIncome[],
+    expenses: AnyExpense[],
+    accounts: AnyAccount[],
+    assumptions: AssumptionsState,
+    taxState: TaxState,
+    previousSimulation: SimulationYear[] = [],
+    returnOverride?: number,
+    previousActiveMilestones: string[] = [],
+    previousMilestoneReachYears: Map<string, number> = new Map(),
+    baselineProjections?: BaselineProjections,
+    conversionMode: 'rate-match' | 'std-ded-only' = 'rate-match',
+    dpConversionPlan?: Map<number, number>,
+    dpDebugByYear?: Map<number, string[]>,
+): SimulationYear {
+    return simulateOneYearWithNewEngine(
+        year, incomes, expenses, accounts, assumptions, taxState,
+        previousSimulation, returnOverride, previousActiveMilestones,
+        previousMilestoneReachYears, baselineProjections, conversionMode,
+        dpConversionPlan, dpDebugByYear,
+    );
+}

--- a/src/components/Objects/Expense/models.tsx
+++ b/src/components/Objects/Expense/models.tsx
@@ -1,0 +1,1123 @@
+import { AssumptionsState } from "../Assumptions/AssumptionsContext";
+import { parseDate, parseDateRequired, hasClassName } from "../modelUtils";
+
+export type ExpenseFrequency = 'Weekly' | 'Monthly' | 'Annually';
+
+/**
+ * How an `Annually` expense is spread across the budget's monthly view:
+ * - 'lump'        – the full amount is budgeted only in its `dueMonth`.
+ * - 'sinkingFund' – amount/12 is budgeted every month (save up for it).
+ * Only meaningful when `frequency === 'Annually'`. Ignored by the simulation
+ * engine, which is year-granular.
+ */
+export type AnnualBudgetMode = 'lump' | 'sinkingFund';
+
+/**
+ * A long-term savings goal — the "Longer term" cadence. Either:
+ * - 'recurring'  – a big-ticket item replaced on a long cycle (roof every N
+ *   years); `intervalYears` set; recurs forever.
+ * - 'targetDate' – a one-time goal funded by `goalTargetDate`; done afterward.
+ * In both cases `amount` is the total cost, funded by a steady monthly
+ * set-aside (a sinking fund) over the horizon.
+ */
+export type GoalType = 'recurring' | 'targetDate';
+
+export interface Expense {
+  id: string;
+  name: string;
+  amount: number;
+  frequency: ExpenseFrequency;
+  startDate?: Date;
+  endDate?: Date;
+  isDiscretionary?: boolean; // If true, can be cut during Guyton-Klinger guardrail triggers
+  dueMonth?: number;          // 1-12; month an `Annually` expense is actually due
+  annualMode?: AnnualBudgetMode; // how an `Annually` expense spreads across the budget
+  goalType?: GoalType;        // marks a long-term goal ("Longer term" cadence)
+  intervalYears?: number;     // recurrence (years) for a 'recurring' goal
+  goalTargetDate?: Date;      // funding deadline for a 'targetDate' goal
+  goalAccountId?: string;     // linked sinking-fund SavedAccount
+}
+
+// 2. Base Abstract Class
+export abstract class BaseExpense implements Expense {
+  constructor(
+    public id: string,
+    public name: string,
+    public amount: number,
+    public frequency: ExpenseFrequency,
+    public startDate?: Date,
+    public endDate?: Date,
+    public isDiscretionary: boolean = false, // Can be cut during Guyton-Klinger guardrail triggers
+    public startMilestoneId?: string,  // Start expense when this milestone is reached
+    public endMilestoneId?: string,    // End expense when this milestone is reached
+  ) { }
+
+  // Cross-cutting cadence metadata for `Annually` expenses. Declared as plain
+  // fields (not constructor params) so they don't have to thread through every
+  // subclass constructor; set after construction and copied on clone via
+  // `copyMetaTo`, exactly like `isDiscretionary`.
+  public dueMonth?: number;
+  public annualMode: AnnualBudgetMode = 'lump';
+
+  // Long-term goal metadata ("Longer term" cadence). Presence of `goalType`
+  // marks an expense as a goal. `amount` holds the total cost.
+  public goalType?: GoalType;
+  public intervalYears?: number;   // for 'recurring' goals
+  public goalTargetDate?: Date;    // for 'targetDate' goals
+  public goalAccountId?: string;   // linked sinking-fund SavedAccount
+
+  /**
+   * Copy cross-cutting metadata not passed through constructors onto a freshly
+   * cloned expense (used by increment/adjustAmount). Returns the target for
+   * convenient `return this.copyMetaTo(clone)`.
+   */
+  protected copyMetaTo<T extends BaseExpense>(target: T): T {
+    target.isDiscretionary = this.isDiscretionary;
+    target.dueMonth = this.dueMonth;
+    target.annualMode = this.annualMode;
+    target.goalType = this.goalType;
+    target.intervalYears = this.intervalYears;
+    target.goalTargetDate = this.goalTargetDate;
+    target.goalAccountId = this.goalAccountId;
+    return target;
+  }
+
+  getProratedAnnual(value: number, year?: number): number {
+    let annual = 0;
+    switch (this.frequency) {
+      case 'Weekly': annual = value * 52; break;
+      case 'Monthly': annual = value * 12; break;
+      case 'Annually': annual = value; break;
+      default: annual = 0;
+    }
+
+    if (year !== undefined) {
+      return annual * getExpenseActiveMultiplier(this, year);
+    }
+
+    return annual;
+  }
+
+  getProratedMonthly(value: number, year?: number): number {
+    return this.getProratedAnnual(value, year) / 12;
+  }
+
+  // --- REFACTORED MAIN METHODS ---
+
+  getAnnualAmount(year?: number): number {
+    // Long-term goals are funded as a savings set-aside, not spent as a
+    // recurring expense — so `amount` (the total cost) must not be read as an
+    // annual outflow. The budget shows the set-aside via getExpenseMonthlyBudget,
+    // and the simulation handles accrue-and-lump separately; here a goal
+    // contributes 0 to ordinary expense totals.
+    if (this.goalType) return 0;
+    return this.getProratedAnnual(this.amount, year);
+  }
+
+  getMonthlyAmount(year?: number): number {
+    if (this.goalType) return 0;
+    return this.getProratedMonthly(this.amount, year);
+  }
+
+  /**
+   * Returns a new expense with the amount adjusted by the given ratio.
+   * Used for Guyton-Klinger guardrail adjustments.
+   * @param ratio - Multiplier for the amount (e.g., 0.9 for 10% cut, 1.1 for 10% increase)
+   */
+  abstract adjustAmount(ratio: number): AnyExpense;
+
+  /**
+   * Helper to get the general inflation rate from assumptions.
+   * Returns 0 if inflationAdjusted is false.
+   */
+  protected getGeneralInflation(assumptions: AssumptionsState): number {
+    return (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+  }
+}
+
+/**
+ * SimpleExpense - Base class for expenses that only need general inflation adjustment.
+ *
+ * This consolidates the common pattern shared by: VacationExpense, SubscriptionExpense,
+ * EmergencyExpense, TransportExpense, FoodExpense, and OtherExpense.
+ */
+abstract class SimpleExpense extends BaseExpense {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: ExpenseFrequency,
+    startDate?: Date,
+    endDate?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, amount, frequency, startDate, endDate, false, startMilestoneId, endMilestoneId);
+  }
+
+  /**
+   * Clone this instance as the same concrete subclass, with `amount` scaled
+   * by the given factor. Uses `this.constructor` so each subclass inherits the
+   * behavior without having to implement its own factory.
+   */
+  private cloneWithAmount(newAmount: number): AnyExpense {
+    type SimpleExpenseCtor = new (
+      id: string,
+      name: string,
+      amount: number,
+      frequency: ExpenseFrequency,
+      startDate?: Date,
+      endDate?: Date,
+      startMilestoneId?: string,
+      endMilestoneId?: string,
+    ) => AnyExpense;
+    const Ctor = this.constructor as SimpleExpenseCtor;
+    const result = new Ctor(
+      this.id,
+      this.name,
+      newAmount,
+      this.frequency,
+      this.startDate,
+      this.endDate,
+      this.startMilestoneId,
+      this.endMilestoneId,
+    );
+    return this.copyMetaTo(result);
+  }
+
+  increment(assumptions: AssumptionsState): AnyExpense {
+    const generalInflation = this.getGeneralInflation(assumptions);
+    return this.cloneWithAmount(this.amount * (1 + generalInflation));
+  }
+
+  adjustAmount(ratio: number): AnyExpense {
+    return this.cloneWithAmount(this.amount * ratio);
+  }
+}
+
+// 3. Concrete Classes
+
+export class RentExpense extends BaseExpense {
+  constructor(
+    id: string,
+    name: string,
+    public payment: number,
+    public utilities: number,
+    frequency: ExpenseFrequency,
+    startDate?: Date,
+    endDate?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, payment + utilities, frequency, startDate, endDate, false, startMilestoneId, endMilestoneId);
+  }
+
+  increment(assumptions: AssumptionsState): RentExpense {
+    const rentInflation = assumptions.expenses.rentInflation / 100;
+    const generalInflation = this.getGeneralInflation(assumptions);
+
+    const newPayment = this.payment * (1 + rentInflation + generalInflation);
+    const newUtilities = this.utilities * (1 + rentInflation + generalInflation);
+
+    const result = new RentExpense(
+      this.id, this.name, newPayment, newUtilities, this.frequency, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+
+  adjustAmount(ratio: number): RentExpense {
+    const result = new RentExpense(
+      this.id, this.name, this.payment * ratio, this.utilities * ratio, this.frequency, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+}
+
+export class MortgageExpense extends BaseExpense {
+  constructor(
+    id: string,
+    name: string,
+    frequency: ExpenseFrequency,
+    public valuation: number,
+    public loan_balance: number,
+    public starting_loan_balance: number,
+    public apr: number,
+    public term_length: number,
+    public property_taxes: number,
+    public valuation_deduction: number,
+    public maintenance: number,
+    public utilities: number,
+    public home_owners_insurance: number,
+    public pmi: number,
+    public hoa_fee: number,
+    public is_tax_deductible: 'Yes' | 'No' | 'Itemized',
+    public tax_deductible: number,
+    public linkedAccountId: string,
+    startDate?: Date,
+    public payment: number = 0,
+    public extra_payment: number = 0,
+    endDate?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    const r = apr / 100 / 12;
+    const n = term_length * 12;
+    // Guard against 0% APR: the standard amortization formula is 0/0 = NaN when r === 0,
+    // which would poison the entire payment. Fall back to straight-line principal / n.
+    const fixed_amortization = r === 0
+      ? (n > 0 ? starting_loan_balance / n : 0)
+      : starting_loan_balance * ((r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1));
+
+    const interest_payment = loan_balance * r;
+    const principal_payment = (loan_balance > 0 ? fixed_amortization : 0) - interest_payment;
+
+    const property_tax_payment = (valuation - valuation_deduction) * property_taxes / 100 / 12;
+    // PMI applies while loan-to-value is ABOVE 80% (low equity) and drops off once LTV <= 80%.
+    const pmi_payment = (loan_balance/valuation) > .8 ? valuation * pmi / 100 / 12 : 0;
+    const repair_payment = maintenance / 100 / 12 * valuation;
+    const home_owners_insurance_payment = home_owners_insurance / 100 / 12 * valuation;
+
+    payment = principal_payment + property_tax_payment + pmi_payment + hoa_fee + repair_payment + utilities + home_owners_insurance_payment + interest_payment + extra_payment;
+    tax_deductible = interest_payment;
+
+    super(id, name, payment, frequency, startDate, endDate, false, startMilestoneId, endMilestoneId);
+    this.payment = payment;
+    this.tax_deductible = tax_deductible;
+  }
+
+  increment(assumptions: AssumptionsState): MortgageExpense {
+    const monthlyRate = this.apr / 100 / 12;
+    let balance = this.loan_balance;
+    let totalInterestPaid = 0;
+
+    // Simulate 12 monthly payments
+    const standardPI = this.calculatePrincipalAndInterest();
+
+    for (let i = 0; i < 12; i++) {
+      if (balance <= 0) break;
+
+      const interest = balance * monthlyRate;
+      const totalMonthlyPay = standardPI + this.extra_payment;
+      const principal = Math.min(balance, totalMonthlyPay - interest);
+
+      balance -= principal;
+      totalInterestPaid += interest;
+    }
+
+    const generalInflation = this.getGeneralInflation(assumptions);
+    const housingAppreciation = assumptions.expenses.housingAppreciation / 100;
+
+    const newValuation = this.valuation * (1 + housingAppreciation + generalInflation);
+    const newUtilities = this.utilities * (1 + generalInflation);
+    const newHoa = this.hoa_fee * (1 + generalInflation);
+    const newDeduction = this.valuation_deduction * (1 + housingAppreciation + generalInflation);
+
+    if (balance < 0.005) {
+      balance = 0;
+    }
+
+    // Auto-remove PMI when equity reaches 20%
+    let nextPmi = this.pmi;
+    if (newValuation > 0 && balance > 0) {
+      const equity = (newValuation - balance) / newValuation;
+      if (equity >= 0.2) {
+        nextPmi = 0;
+      }
+    } else if (balance <= 0) {
+      nextPmi = 0;
+    }
+
+    const nextYearMortgage = new MortgageExpense(
+      this.id, this.name, this.frequency,
+      newValuation, balance, this.starting_loan_balance,
+      this.apr, this.term_length, this.property_taxes, newDeduction,
+      this.maintenance, newUtilities, this.home_owners_insurance, nextPmi, newHoa,
+      this.is_tax_deductible, this.tax_deductible, this.linkedAccountId,
+      this.startDate, this.payment, this.extra_payment, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+
+    nextYearMortgage.tax_deductible = totalInterestPaid;
+    this.copyMetaTo(nextYearMortgage);
+
+    return nextYearMortgage;
+  }
+
+  // Helper method required for the grow calculation
+  private calculatePrincipalAndInterest(): number {
+    if (this.apr === 0) return this.starting_loan_balance / (this.term_length * 12);
+
+    const r = this.apr / 100 / 12;
+    const n = this.term_length * 12;
+    return this.starting_loan_balance * ((r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1));
+  }
+
+
+  calculateAnnualAmortization(year: number): { totalInterest: number, totalPrincipal: number, totalPayment: number } {
+    const purchaseYear = this.startDate != null ? this.startDate.getFullYear() : new Date().getFullYear();
+    const purchaseMonth = this.startDate != null ? this.startDate.getMonth() : new Date().getMonth();
+
+    if (year < purchaseYear) {
+      return { totalInterest: 0, totalPrincipal: 0, totalPayment: 0 };
+    }
+
+    // FIX 1: Trust that 'this.loan_balance' is already the correct starting balance for this year.
+    // We DO NOT skip months based on (year - purchaseYear) because the simulation 
+    // has already incremented/reduced the balance for previous years.
+    let balance = this.loan_balance;
+
+    const monthlyRate = this.apr / 100 / 12;
+    const numPayments = this.term_length * 12;
+
+    // Calculate the Standard P&I + Extra Payment Target (Same as before)
+    // Guard against 0% APR: the amortization formula is 0/0 = NaN when monthlyRate === 0.
+    // Fall back to straight-line principal / numPayments (matches constructor & calculatePrincipalAndInterest).
+    const standardMonthlyPI = monthlyRate === 0
+      ? (numPayments > 0 ? this.starting_loan_balance / numPayments : 0)
+      : this.starting_loan_balance * (monthlyRate * Math.pow(1 + monthlyRate, numPayments)) / (Math.pow(1 + monthlyRate, numPayments) - 1);
+    const targetMonthlyPayment = standardMonthlyPI + this.extra_payment;
+
+    // Isolate the Escrow Amount (Taxes, HOA, Insurance)
+    // We assume 'this.amount' is the Total Monthly Payment (P&I + Escrow)
+    let monthlyEscrow = 0;
+    if (this.loan_balance <= 0) {
+      monthlyEscrow = this.amount; // If loan is paid off, entire payment is escrow
+    }
+    else {
+      monthlyEscrow = this.amount - targetMonthlyPayment;
+    }
+
+    // Handle partial first year
+    const startMonth = (year === purchaseYear) ? purchaseMonth : 0;
+
+    let totalInterest = 0;
+    let totalPrincipal = 0;
+    let totalPayment = 0;
+
+    for (let month = startMonth; month < 12; month++) {
+      if (balance <= 0) {
+        totalPayment += monthlyEscrow * (12 - month); // Pay only escrow for remaining months
+        break;
+      }
+      const interest = balance * monthlyRate;
+      
+      // Calculate Principal (Cap at remaining balance)
+      const expectedPrincipal = targetMonthlyPayment - interest;
+      const principal = Math.min(balance, expectedPrincipal);
+      
+      // FIX 2: Calculate the ACTUAL payment for this specific month.
+      // If it's the final month, we only pay Principal + Interest + Escrow, 
+      // NOT the full 'this.amount'.
+      const actualPayment = principal + interest + monthlyEscrow;
+
+      balance -= principal;
+      
+      totalPayment += actualPayment;
+      totalInterest += interest;
+      totalPrincipal += principal;
+    }
+
+    return { totalInterest, totalPrincipal, totalPayment };
+  }
+
+  calculatePayment(): number {
+    const r = this.apr / 100 / 12;
+    const n = this.term_length * 12;
+
+    // Fixed P&I Calculation (Always use starting_loan_balance)
+    // Guard 0% APR: formula is 0/0 = NaN when r === 0; fall back to straight-line.
+    const fixed_amortization = r === 0
+      ? (n > 0 ? this.starting_loan_balance / n : 0)
+      : this.starting_loan_balance * ((r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1));
+
+    // Interest (Based on current balance)
+    const interest_payment = this.loan_balance * r;
+
+    // Principal (The remainder)
+    const principal_payment = fixed_amortization - interest_payment;
+
+    const property_tax_payment = (this.valuation - this.valuation_deduction) * this.property_taxes / 100 / 12;
+    const pmi_payment = this.valuation * this.pmi / 100 / 12;
+    const repair_payment = this.maintenance / 100 / 12 * this.valuation;
+    const home_owners_insurance_payment = this.home_owners_insurance / 100 / 12 * this.valuation;
+
+    return principal_payment + property_tax_payment + pmi_payment + this.hoa_fee + repair_payment + this.utilities + home_owners_insurance_payment + interest_payment + this.extra_payment;
+  }
+
+  calculateDeductible(): number {
+    const interest_payment = this.loan_balance * (this.apr / 100 / 12);
+    return interest_payment;
+  }
+
+  /**
+   * Mortgages are contractual obligations and cannot be adjusted.
+   * Returns the same mortgage unchanged.
+   */
+  adjustAmount(_ratio: number): MortgageExpense {
+    // Mortgages are fixed contractual obligations - cannot scale them
+    // If someone marks a mortgage as discretionary, we just ignore the adjustment
+    return this;
+  }
+
+  getPrincipalPayment(): number {
+    const r = this.apr / 100 / 12;
+    const n = this.term_length * 12;
+
+    // Fixed P&I Calculation (Always use starting_loan_balance)
+    // FIX: Switched from this.loan_balance to this.starting_loan_balance
+    // Guard 0% APR: formula is 0/0 = NaN when r === 0; fall back to straight-line.
+    const fixed_amortization = r === 0
+      ? (n > 0 ? this.starting_loan_balance / n : 0)
+      : this.starting_loan_balance * ((r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1));
+
+    const interest_payment = this.loan_balance * r;
+
+    // Result is the Principal portion of the *Standard* payment
+    return fixed_amortization - interest_payment;
+  }
+
+  getBalanceAtDate(dateStr: string): number {
+    const targetDate = new Date(dateStr);
+    const start = new Date(this.startDate != null ? this.startDate : new Date());
+
+    // If target is before purchase, the loan didn't exist yet (return 0)
+    if (targetDate < start) return 0;
+
+    // Calculate months elapsed
+    const monthsElapsed =
+      (targetDate.getUTCFullYear() - start.getUTCFullYear()) * 12 +
+      (targetDate.getUTCMonth() - start.getUTCMonth());
+
+    if (monthsElapsed <= 0) return this.starting_loan_balance;
+
+    // Calculate Monthly P&I Payment (Principal + Interest only)
+    const r = this.apr / 100 / 12;
+    const n = this.term_length * 12;
+
+    // Standard Formula for Fixed Monthly Payment using Starting Balance
+    // Guard 0% APR: formula is 0/0 = NaN when r === 0; fall back to straight-line.
+    const piPayment = r === 0
+      ? (n > 0 ? this.starting_loan_balance / n : 0)
+      : this.starting_loan_balance * ((r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1));
+
+    let balance = this.starting_loan_balance;
+
+    // Iterate to find balance at specific month
+    for (let i = 0; i < monthsElapsed; i++) {
+      if (balance <= 0) return 0;
+      const interest = balance * r;
+      // We assume the payment made was the calculated PI payment + any defined extra payment
+      const principal = (piPayment + this.extra_payment) - interest;
+      balance -= principal;
+    }
+
+    return balance > 0 ? balance : 0;
+  }
+}
+
+export class LoanExpense extends BaseExpense {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: ExpenseFrequency,
+    public apr: number,
+    public interest_type: 'Compounding' | 'Simple',
+    public payment: number,
+    public is_tax_deductible: 'Yes' | 'No' | 'Itemized',
+    public tax_deductible: number,
+    public linkedAccountId: string,
+    startDate?: Date,
+    endDate?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    const effectiveStartDate = startDate || new Date();
+    const effectiveEndDate = endDate || (() => {
+      const end = new Date(effectiveStartDate);
+      end.setFullYear(end.getFullYear() + 10);
+      return end;
+    })();
+
+    super(id, name, amount, frequency, effectiveStartDate, effectiveEndDate, false, startMilestoneId, endMilestoneId);
+
+    if (!this.payment) {
+      this.payment = this.calculatePaymentFromEndDate();
+    }
+  }
+  increment(_assumptions: AssumptionsState): LoanExpense {
+    let balance = this.amount; // In LoanExpense, 'amount' tracks the current balance
+    const monthlyRate = this.apr / 100 / 12;
+
+    // 1. Internal Loop: 12 Months
+    for (let i = 0; i < 12; i++) {
+      if (balance <= 0) break;
+
+      // Accrue interest on the outstanding balance for both Simple and Compounding loans.
+      // (Previously 'Simple' loans skipped this branch and accrued zero interest, so the
+      // entire payment went to principal and the loan effectively cost nothing.)
+      let interest = 0;
+      if (this.apr > 0) {
+        interest = balance * monthlyRate;
+      }
+
+      // Logic: Payment covers interest first, then principal
+      // this.payment is the total monthly payment
+      const principal = Math.min(balance, this.payment - interest);
+
+      // If payment is too low to cover interest, balance grows (negative amortization)
+      // Otherwise balance shrinks
+      balance = balance - principal;
+    }
+
+    // 2. Return new state
+    const result = new LoanExpense(
+      this.id,
+      this.name,
+      balance, // New Balance
+      this.frequency,
+      this.apr,
+      this.interest_type,
+      this.payment, // Payment stays fixed
+      this.is_tax_deductible,
+      this.tax_deductible,
+      this.linkedAccountId,
+      this.startDate,
+      this.endDate,
+      this.startMilestoneId,
+      this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+
+  calculateAnnualAmortization(year: number): { totalInterest: number, totalPrincipal: number, totalPayment: number } {
+    const loanStartYear = this.startDate ? this.startDate.getFullYear() : new Date().getFullYear();
+    if (year < loanStartYear) {
+        return { totalInterest: 0, totalPrincipal: 0, totalPayment: 0 };
+    }
+
+    const loanEndYear = this.endDate ? this.endDate.getFullYear() : null;
+    if (loanEndYear !== null && year > loanEndYear) {
+        return { totalInterest: 0, totalPrincipal: 0, totalPayment: 0 };
+    }
+
+    let balance = this.amount; // Balance at start of the year
+    let totalInterest = 0;
+    let totalPrincipal = 0;
+
+    const monthlyRate = this.apr / 100 / 12;
+
+    const startMonth = (year === loanStartYear) ? (this.startDate ? this.startDate.getMonth() : 0) : 0;
+    const endMonth = (loanEndYear === year) ? (this.endDate ? this.endDate.getMonth() : 11) : 11;
+
+    for (let month = startMonth; month <= endMonth; month++) {
+        if (balance <= 0) {
+            break;
+        }
+
+        const interest = this.apr > 0 ? balance * monthlyRate : 0;
+        
+        // Determine the payment for this month
+        // It's either the full payment, or just enough to clear the balance
+        const paymentThisMonth = Math.min(this.payment, balance + interest);
+        
+        let principalPaid = paymentThisMonth - interest;
+        
+        // Ensure we don't overpay principal
+        if (principalPaid > balance) {
+            principalPaid = balance;
+        }
+        
+        totalInterest += interest;
+        totalPrincipal += principalPaid;
+        balance -= principalPaid;
+    }
+    
+    const totalPayment = totalPrincipal + totalInterest;
+
+    return { totalInterest, totalPrincipal, totalPayment };
+  }
+  
+  calculatePaymentFromEndDate(): number {
+    const months = this.getMonthsUntilPaidOff();
+    if (months <= 0) return this.amount;
+
+    if (this.apr === 0) {
+      return this.amount / months;
+    }
+    const monthlyRate = this.apr / 100 / 12;
+    const payment = this.amount * (monthlyRate * Math.pow(1 + monthlyRate, months)) / (Math.pow(1 + monthlyRate, months) - 1);
+    return parseFloat(payment.toFixed(2));
+  }
+
+  calculateEndDateFromPayment(payment: number): Date {
+    const months = this.calculateMonthsFromPayment(payment);
+    const newEndDate = new Date(this.startDate!);
+    newEndDate.setMonth(newEndDate.getMonth() + months);
+    return newEndDate;
+  }
+
+  calculateMonthsFromPayment(payment: number): number {
+    if (this.apr === 0) {
+      return payment > 0 ? this.amount / payment : Infinity;
+    }
+    const monthlyRate = this.apr / 100 / 12;
+    if (payment <= this.amount * monthlyRate) {
+      return Infinity;
+    }
+    const months = -Math.log(1 - (this.amount * monthlyRate) / payment) / Math.log(1 + monthlyRate);
+    return Math.round(months);
+  }
+
+  getMonthsUntilPaidOff(): number {
+    if (!this.endDate || !this.startDate) return 0;
+    const start = new Date(this.startDate);
+    const end = new Date(this.endDate);
+    return (end.getFullYear() - start.getFullYear()) * 12 + (end.getMonth() - start.getMonth());
+  }
+
+  getAnnualAmount(year?: number): number {
+    return this.getProratedAnnual(this.payment, year);
+  }
+
+  getMonthlyAmount(year?: number): number {
+    return this.getProratedAnnual(this.payment, year) / 12;
+  }
+
+  /**
+   * Loans are contractual obligations and cannot be adjusted.
+   * Returns the same loan unchanged.
+   */
+  adjustAmount(_ratio: number): LoanExpense {
+    // Loans are fixed contractual obligations - cannot scale them
+    return this;
+  }
+}
+
+export class DependentExpense extends BaseExpense {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: ExpenseFrequency,
+    public is_tax_deductible: 'Yes' | 'No' | 'Itemized',
+    public tax_deductible: number,
+    startDate?: Date,
+    endDate?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, amount, frequency, startDate, endDate, false, startMilestoneId, endMilestoneId);
+  }
+
+  increment(assumptions: AssumptionsState): DependentExpense {
+    const generalInflation = this.getGeneralInflation(assumptions);
+    const result = new DependentExpense(
+      this.id, this.name, this.amount * (1 + generalInflation), this.frequency,
+      this.is_tax_deductible, this.tax_deductible, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+
+  adjustAmount(ratio: number): DependentExpense {
+    const result = new DependentExpense(
+      this.id, this.name, this.amount * ratio, this.frequency,
+      this.is_tax_deductible, this.tax_deductible, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+}
+
+export class HealthcareExpense extends BaseExpense {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: ExpenseFrequency,
+    public is_tax_deductible: 'Yes' | 'No' | 'Itemized',
+    public tax_deductible: number,
+    startDate?: Date,
+    endDate?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, amount, frequency, startDate, endDate, false, startMilestoneId, endMilestoneId);
+  }
+
+  increment(assumptions: AssumptionsState): HealthcareExpense {
+    const inflation = assumptions.macro.healthcareInflation / 100;
+    const result = new HealthcareExpense(
+      this.id, this.name, this.amount * (1 + inflation), this.frequency,
+      this.is_tax_deductible, this.tax_deductible, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+
+  adjustAmount(ratio: number): HealthcareExpense {
+    const result = new HealthcareExpense(
+      this.id, this.name, this.amount * ratio, this.frequency,
+      this.is_tax_deductible, this.tax_deductible, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+}
+
+// Each of these is a SimpleExpense — they exist as named classes so production
+// code can pattern-match via `instanceof` and so saved data round-trips through
+// className. Inflation + adjustAmount behavior lives on the parent.
+export class VacationExpense extends SimpleExpense {}
+export class SubscriptionExpense extends SimpleExpense {}
+export class EmergencyExpense extends SimpleExpense {}
+export class TransportExpense extends SimpleExpense {}
+export class FoodExpense extends SimpleExpense {}
+export class OtherExpense extends SimpleExpense {}
+
+export class CharityExpense extends BaseExpense {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: ExpenseFrequency,
+    public is_tax_deductible: 'Yes' | 'No' | 'Itemized',
+    public tax_deductible: number,
+    startDate?: Date,
+    endDate?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, amount, frequency, startDate, endDate, true, startMilestoneId, endMilestoneId);
+    // Charity is typically discretionary - already set via super call
+  }
+
+  increment(assumptions: AssumptionsState): CharityExpense {
+    const generalInflation = this.getGeneralInflation(assumptions);
+    const result = new CharityExpense(
+      this.id, this.name, this.amount * (1 + generalInflation), this.frequency,
+      this.is_tax_deductible, this.tax_deductible, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+
+  adjustAmount(ratio: number): CharityExpense {
+    const result = new CharityExpense(
+      this.id, this.name, this.amount * ratio, this.frequency,
+      this.is_tax_deductible, this.tax_deductible, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+}
+
+export type AnyExpense = RentExpense | MortgageExpense | LoanExpense | DependentExpense | HealthcareExpense | VacationExpense | EmergencyExpense | TransportExpense | FoodExpense | OtherExpense | CharityExpense | SubscriptionExpense;
+
+export function getExpenseActiveMultiplier(expense: BaseExpense, year: number): number {
+  const expenseStartDate = expense.startDate ? new Date(expense.startDate) : new Date();
+  // Date-only values come from parseDate, which returns UTC dates (see modelUtils
+  // contract). Read with getUTC* so the active window doesn't shift by a month/year
+  // in negative timezones.
+  const startYear = expenseStartDate.getUTCFullYear();
+
+  const safeEndDate = expense.endDate ? new Date(expense.endDate) : null;
+  const endYear = safeEndDate ? safeEndDate.getUTCFullYear() : null;
+
+  if (startYear > year) return 0;
+  if (endYear !== null && endYear < year) return 0;
+
+  const startMonthIndex = (startYear < year) ? 0 : expenseStartDate.getUTCMonth();
+
+  const endMonthIndex = (safeEndDate && endYear === year)
+    ? safeEndDate.getUTCMonth()
+    : 11;
+
+  const monthsActive = endMonthIndex - startMonthIndex + 1;
+
+  return Math.max(0, monthsActive) / 12;
+}
+
+export function isExpenseActiveInCurrentMonth(expense: AnyExpense): boolean {
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  const currentMonth = today.getMonth();
+
+  const expenseStartDate = expense.startDate != null ? expense.startDate : new Date();
+  const expenseStartYear = expenseStartDate.getFullYear();
+  const expenseStartMonth = expenseStartDate.getMonth();
+
+  const currentMonthStart = new Date(currentYear, currentMonth, 1);
+  const expenseEffectiveStart = new Date(expenseStartYear, expenseStartMonth, 1);
+
+  if (expenseEffectiveStart > currentMonthStart) {
+    return false;
+  }
+
+  if (expense.endDate) {
+    const expenseEndDate = new Date(expense.endDate);
+    const expenseEndYear = expenseEndDate.getFullYear();
+    const expenseEndMonth = expenseEndDate.getMonth();
+
+    const expenseEffectiveEnd = new Date(expenseEndYear, expenseEndMonth + 1, 0);
+
+    if (expenseEffectiveEnd < currentMonthStart) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * An expense is "done" when it no longer applies going forward:
+ * - its end date is in the past, or
+ * - it's a loan whose balance has been paid off.
+ * Done expenses are hidden from the active list by default (but kept for the
+ * record). Mortgages are intentionally excluded — even with the loan paid off
+ * they carry ongoing escrow costs (taxes, insurance, HOA).
+ */
+export function isExpenseDone(expense: AnyExpense): boolean {
+  const now = new Date();
+  if (expense.endDate && new Date(expense.endDate) < now) return true;
+  if (expense instanceof LoanExpense && expense.amount <= 0) return true;
+  // A one-time goal is done once its target date has passed. Recurring goals
+  // never finish.
+  if (expense.goalType === 'targetDate' && expense.goalTargetDate
+      && new Date(expense.goalTargetDate) < now) return true;
+  return false;
+}
+
+/** True if the expense is a long-term savings goal ("Longer term" cadence). */
+export function isLongTermGoal(expense: AnyExpense): boolean {
+  return expense.goalType != null;
+}
+
+/** Whole months between two dates (>= 0). */
+function monthsBetween(from: Date, to: Date): number {
+  const months = (to.getUTCFullYear() - from.getUTCFullYear()) * 12 + (to.getUTCMonth() - from.getUTCMonth());
+  return Math.max(0, months);
+}
+
+/**
+ * Steady monthly set-aside that funds a goal over its horizon (a sinking fund).
+ * - recurring: total / (intervalYears * 12)
+ * - targetDate: total / months from start to target
+ * Returns 0 for non-goals or ill-defined horizons.
+ */
+export function getGoalMonthlySetAside(expense: AnyExpense): number {
+  if (expense.goalType === 'recurring' && expense.intervalYears && expense.intervalYears > 0) {
+    return expense.amount / (expense.intervalYears * 12);
+  }
+  if (expense.goalType === 'targetDate' && expense.goalTargetDate) {
+    const start = expense.startDate ? new Date(expense.startDate) : new Date();
+    const months = monthsBetween(start, new Date(expense.goalTargetDate));
+    return months > 0 ? expense.amount / months : 0;
+  }
+  return 0;
+}
+
+/**
+ * Whether a goal's lump comes due in the given calendar year.
+ * - targetDate: the year of the target date.
+ * - recurring: anchor year (start date) + k*intervalYears for k >= 1, so the
+ *   first purchase is one full interval after you start saving.
+ */
+export function isGoalDueInYear(expense: AnyExpense, year: number): boolean {
+  if (expense.goalType === 'targetDate' && expense.goalTargetDate) {
+    return new Date(expense.goalTargetDate).getUTCFullYear() === year;
+  }
+  if (expense.goalType === 'recurring' && expense.intervalYears && expense.intervalYears > 0) {
+    const anchorYear = (expense.startDate ? new Date(expense.startDate) : new Date()).getUTCFullYear();
+    const diff = year - anchorYear;
+    return diff > 0 && diff % expense.intervalYears === 0;
+  }
+  return false;
+}
+
+export const EXPENSE_CATEGORIES = [
+  'Rent',
+  'Mortgage',
+  'Loan',
+  'Dependent',
+  'Healthcare',
+  'Vacation',
+  'Subscription',
+  'Emergency',
+  'Transport',
+  'Food',
+  'Charity',
+  'Other'
+] as const;
+
+export type ExpenseCategory = typeof EXPENSE_CATEGORIES[number];
+
+export const EXPENSE_COLORS_BACKGROUND: Record<ExpenseCategory, string> = {
+  Rent: "bg-chart-Fuchsia-50",
+  Mortgage: "bg-chart-Blue-50",
+  Loan: "bg-chart-Blue-50",
+  Dependent: "bg-chart-Yellow-50",
+  Healthcare: "bg-chart-Red-50",
+  Vacation: "bg-chart-Green-50",
+  Subscription: "bg-chart-Cyan-50",
+  Emergency: "bg-chart-Fuchsia-50",
+  Transport: "bg-chart-Blue-50",
+  Food: "bg-chart-Yellow-50",
+  Charity: "bg-chart-Orange-50",
+  Other: "bg-chart-Red-50",
+};
+
+export const CLASS_TO_CATEGORY: Record<string, ExpenseCategory> = {
+  [RentExpense.name]: 'Rent',
+  [MortgageExpense.name]: 'Mortgage',
+  [LoanExpense.name]: 'Loan',
+  [DependentExpense.name]: 'Dependent',
+  [HealthcareExpense.name]: 'Healthcare',
+  [VacationExpense.name]: 'Vacation',
+  [SubscriptionExpense.name]: 'Subscription',
+  [EmergencyExpense.name]: 'Emergency',
+  [TransportExpense.name]: 'Transport',
+  [FoodExpense.name]: 'Food',
+  [CharityExpense.name]: 'Charity',
+  [OtherExpense.name]: 'Other',
+};
+
+// Map Categories to their color palettes (using Tailwind classes)
+// Uses 5-step gradients (1, 25, 50, 75, 100) defined in :root for SVG access
+const PALETTE_STEPS = [1, 25, 50, 75, 100];
+export const CATEGORY_PALETTES: Record<ExpenseCategory, string[]> = {
+  Rent: PALETTE_STEPS.map(i => `bg-chart-Fuchsia-${i}`),
+  Mortgage: PALETTE_STEPS.map(i => `bg-chart-Fuchsia-${i}`),
+  Loan: PALETTE_STEPS.map(i => `bg-chart-Blue-${i}`),
+  Dependent: PALETTE_STEPS.map(i => `bg-chart-Yellow-${i}`),
+  Healthcare: PALETTE_STEPS.map(i => `bg-chart-Red-${i}`),
+  Vacation: PALETTE_STEPS.map(i => `bg-chart-Green-${i}`),
+  Subscription: PALETTE_STEPS.map(i => `bg-chart-Cyan-${i}`),
+  Emergency: PALETTE_STEPS.map(i => `bg-chart-Fuchsia-${i}`),
+  Transport: PALETTE_STEPS.map(i => `bg-chart-Blue-${i}`),
+  Food: PALETTE_STEPS.map(i => `bg-chart-Yellow-${i}`),
+  Charity: PALETTE_STEPS.map(i => `bg-chart-Orange-${i}`),
+  Other: PALETTE_STEPS.map(i => `bg-chart-Red-${i}`),
+};
+
+export function reconstituteExpense(data: unknown): AnyExpense | null {
+    if (!hasClassName(data)) return null;
+
+    const startDate = parseDateRequired(data.startDate);
+    const endDate = parseDate(data.endDate);
+    const frequency = (data.frequency as ExpenseFrequency) || 'Monthly';
+    const id = String(data.id ?? '');
+    const name = String(data.name ?? 'Unnamed Expense');
+    const amount = Number(data.amount) || 0;
+    const isDiscretionary = (data.isDiscretionary as boolean) ?? false;
+    const startMilestoneId = data.startMilestoneId ? String(data.startMilestoneId) : undefined;
+    const endMilestoneId = data.endMilestoneId ? String(data.endMilestoneId) : undefined;
+    const dueMonth = data.dueMonth != null ? Number(data.dueMonth) : undefined;
+    const annualMode: AnnualBudgetMode = data.annualMode === 'sinkingFund' ? 'sinkingFund' : 'lump';
+    const goalType: GoalType | undefined =
+        data.goalType === 'recurring' || data.goalType === 'targetDate' ? data.goalType : undefined;
+    const intervalYears = data.intervalYears != null ? Number(data.intervalYears) : undefined;
+    const goalTargetDate = parseDate(data.goalTargetDate);
+    const goalAccountId = data.goalAccountId ? String(data.goalAccountId) : undefined;
+
+    let expense: AnyExpense | null = null;
+
+    switch (data.className) {
+        case 'HousingExpense':
+        case 'RentExpense':
+            expense = new RentExpense(
+                id, name, Number(data.payment) || 0, Number(data.utilities) || 0,
+                frequency, startDate, endDate, startMilestoneId, endMilestoneId
+            );
+            break;
+        case 'MortgageExpense':
+            expense = new MortgageExpense(
+                id, name, frequency,
+                Number(data.valuation) || 0, Number(data.loan_balance) || 0,
+                Number(data.starting_loan_balance) || 0, Number(data.apr) || 0,
+                Number(data.term_length) || 0, Number(data.property_taxes) || 0,
+                Number(data.valuation_deduction) || 0, Number(data.maintenance) || 0,
+                Number(data.utilities) || 0, Number(data.home_owners_insurance) || 0,
+                Number(data.pmi) || 0, Number(data.hoa_fee) || 0,
+                (data.is_tax_deductible as 'Yes' | 'No' | 'Itemized') || 'No',
+                Number(data.tax_deductible) || 0, String(data.linkedAccountId ?? ''),
+                startDate, Number(data.payment) || 0, Number(data.extra_payment) || 0, endDate,
+                startMilestoneId, endMilestoneId
+            );
+            break;
+        case 'LoanExpense':
+            expense = new LoanExpense(
+                id, name, amount, frequency, Number(data.apr) || 0,
+                (data.interest_type as 'Compounding' | 'Simple') || 'Simple',
+                Number(data.payment) || 0,
+                (data.is_tax_deductible as 'Yes' | 'No' | 'Itemized') || 'No',
+                Number(data.tax_deductible) || 0, String(data.linkedAccountId ?? ''),
+                startDate, endDate, startMilestoneId, endMilestoneId
+            );
+            break;
+        case 'DependentExpense':
+            expense = new DependentExpense(
+                id, name, amount, frequency,
+                (data.is_tax_deductible as 'Yes' | 'No' | 'Itemized') || 'No',
+                Number(data.tax_deductible) || 0, startDate, endDate,
+                startMilestoneId, endMilestoneId
+            );
+            break;
+        case 'HealthcareExpense':
+            expense = new HealthcareExpense(
+                id, name, amount, frequency,
+                (data.is_tax_deductible as 'Yes' | 'No' | 'Itemized') || 'No',
+                Number(data.tax_deductible) || 0, startDate, endDate,
+                startMilestoneId, endMilestoneId
+            );
+            break;
+        case 'VacationExpense':
+            expense = new VacationExpense(id, name, amount, frequency, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+            break;
+        case 'SubscriptionExpense':
+            expense = new SubscriptionExpense(id, name, amount, frequency, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+            break;
+        case 'EmergencyExpense':
+            expense = new EmergencyExpense(id, name, amount, frequency, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+            break;
+        case 'TransportExpense':
+            expense = new TransportExpense(id, name, amount, frequency, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+            break;
+        case 'FoodExpense':
+            expense = new FoodExpense(id, name, amount, frequency, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+            break;
+        case 'OtherExpense':
+            expense = new OtherExpense(id, name, amount, frequency, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+            break;
+        case 'CharityExpense':
+            expense = new CharityExpense(
+                id, name, amount, frequency,
+                (data.is_tax_deductible as 'Yes' | 'No' | 'Itemized') || 'Itemized',
+                Number(data.tax_deductible) || 0, startDate, endDate,
+                startMilestoneId, endMilestoneId
+            );
+            break;
+        default:
+            return null;
+    }
+
+    if (expense) {
+        expense.isDiscretionary = isDiscretionary;
+        expense.dueMonth = dueMonth;
+        expense.annualMode = annualMode;
+        expense.goalType = goalType;
+        expense.intervalYears = intervalYears;
+        expense.goalTargetDate = goalTargetDate;
+        expense.goalAccountId = goalAccountId;
+    }
+
+    return expense;
+}

--- a/src/components/Objects/Income/models.tsx
+++ b/src/components/Objects/Income/models.tsx
@@ -1,0 +1,989 @@
+import { TaxType } from "../../Objects/Accounts/models";
+import { AssumptionsState } from '../Assumptions/AssumptionsContext';
+import { get401kLimit, getHSALimit } from '../../../data/ContributionLimits';
+import {
+  calculateFERSBasicBenefit,
+  calculateCSRSBasicBenefit,
+  getFERSCOLA,
+  getCSRSCOLA,
+  checkFERSEligibility,
+  checkCSRSEligibility,
+  calculateFERSSupplement,
+} from '../../../data/PensionData';
+import { parseDate, parseDateRequired, hasClassName } from "../modelUtils";
+
+export type ContributionGrowthStrategy = 'FIXED' | 'GROW_WITH_SALARY' | 'TRACK_ANNUAL_MAX';
+export type AutoMax401kOption = 'disabled' | 'custom' | 'traditional' | 'roth';
+export type ESPPContributionType = 'NONE' | 'PERCENTAGE' | 'FIXED';
+export type PensionSystem = 'NONE' | 'FERS' | 'CSRS';
+export type EmployerMatchType = 'fixed' | 'percent';
+
+export type IncomeFrequency = 'Weekly' | 'Bi-Weekly' | 'Semi-Monthly' | 'Monthly' | 'Annually';
+
+export interface Income {
+  id: string;
+  name: string;
+  amount: number;
+  frequency: IncomeFrequency;
+  earned_income: "Yes" | "No";
+  startDate?: Date;
+  end_date?: Date;
+}
+
+// 2. Base Abstract Class
+export abstract class BaseIncome implements Income {
+  /** Discriminator for type checking that survives minification and serialization */
+  public className: string = '';
+  constructor(
+    public id: string,
+    public name: string,
+    public amount: number,
+    public frequency: IncomeFrequency,
+    public earned_income: "Yes" | "No",
+    public startDate?: Date,
+    public end_date?: Date,
+    public annualGrowthRate: number = 0.03,
+    public startMilestoneId?: string,  // Start income when this milestone is reached
+    public endMilestoneId?: string,    // End income when this milestone is reached
+  ) {}
+  // Number of pay periods per year implied by this income's frequency.
+  getPeriodsPerYear(): number {
+    switch (this.frequency) {
+      case 'Weekly': return 52;
+      case 'Bi-Weekly': return 26;
+      case 'Semi-Monthly': return 24;
+      case 'Monthly': return 12;
+      case 'Annually': return 1;
+      default: return 0;
+    }
+  }
+
+  // Convert an annual figure (e.g. an IRS contribution limit) into the per-period
+  // unit that per-period fields like preTax401k are stored in.
+  annualToPerPeriod(annualValue: number): number {
+    const periods = this.getPeriodsPerYear();
+    return periods > 0 ? annualValue / periods : annualValue;
+  }
+
+  getProratedAnnual(value: number, year?: number): number {
+    const annual = value * this.getPeriodsPerYear();
+
+    // Apply the time-based multiplier if a year is requested
+    if (year !== undefined) {
+        return annual * getIncomeActiveMultiplier(this as unknown as AnyIncome, year);
+    }
+
+    return annual;
+  }
+
+  getProratedMonthly(value: number, year?: number): number {
+    return this.getProratedAnnual(value, year) / 12;
+  }
+
+  // --- REFACTORED MAIN METHODS ---
+
+  getAnnualAmount(year?: number): number {
+    // Just reuse the generic helper with the main amount
+    return this.getProratedAnnual(this.amount, year);
+  }
+
+  getMonthlyAmount(year?: number): number {
+    return this.getProratedMonthly(this.amount, year);
+  }
+}
+
+// 3. Concrete Classes
+
+export class WorkIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: IncomeFrequency,
+    earned_income: "Yes" | "No",
+    public preTax401k: number = 0,
+    public insurance: number = 0,
+    public roth401k: number = 0,
+    public employerMatch: number = 0,
+    public matchAccountId: string,
+    public taxType: TaxType | null = null,
+    public contributionGrowthStrategy: ContributionGrowthStrategy = 'FIXED',
+    startDate?: Date,
+    end_date?: Date,
+    public hsaContribution: number = 0,  // HSA contribution (pre-tax + FICA-exempt)
+    public autoMax401k: AutoMax401kOption = 'custom',  // Auto-max 401k: disabled, custom, traditional, or roth
+    // ESPP configuration
+    public esppContributionType: ESPPContributionType = 'NONE',
+    public esppContributionAmount: number = 0,      // % of salary (1-15) or fixed $/period
+    public esppDiscountPercent: number = 15,        // Typical ESPP discount (5-15%)
+    public esppHasLookback: boolean = true,         // Lookback provision (purchase at lower of grant/purchase price)
+    public esppOfferingPeriodMonths: number = 6,    // Typical is 6 months
+    public esppAccountId: string | null = null,     // Linked ESPP account
+    public esppExpectedStockGrowth: number = 7,     // Expected annual stock growth for lookback modeling
+    public pensionSystem: PensionSystem = 'NONE',   // Which pension system this job is covered by
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+    public employerMatchType: EmployerMatchType = 'fixed',
+    public employerMatchPercent: number = 0,
+    public employerMatchMax: number = 0,  // Annual cap in dollars (0 = no cap)
+  ) {
+    super(id, name, amount, frequency, earned_income, startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'WorkIncome';
+  }
+
+  getEffectiveAnnualEmployerMatch(year?: number): number {
+    if (this.employerMatchType === 'percent') {
+      const annualSalary = this.getProratedAnnual(this.amount, year);
+      const matchAmount = annualSalary * (this.employerMatchPercent / 100);
+      if (this.employerMatchMax > 0) {
+        const activeMult = year !== undefined ? getIncomeActiveMultiplier(this as unknown as AnyIncome, year) : 1;
+        return Math.min(matchAmount, this.employerMatchMax * activeMult);
+      }
+      return matchAmount;
+    }
+    return this.getProratedAnnual(this.employerMatch, year);
+  }
+  increment (assumptions: AssumptionsState, year?: number, age?: number): WorkIncome {
+    const salaryGrowth = assumptions.income.salaryGrowth / 100;
+    const generalInflation = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+
+    // 1. Grow Salary
+    const newAmount = this.amount * (1 + salaryGrowth + generalInflation);
+
+    // 2. Grow Employer Match
+    // (Assuming match is a % of salary, so it grows at the same rate as salary)
+    const newMatch = this.employerMatch * (1 + salaryGrowth + generalInflation);
+
+    // 3. Grow Contributions (401k, Roth, HSA)
+    let newPreTax = this.preTax401k;
+    let newRoth = this.roth401k;
+    let newHSA = this.hsaContribution;
+
+    switch (this.contributionGrowthStrategy) {
+      case 'GROW_WITH_SALARY':
+        newPreTax = this.preTax401k * (1 + salaryGrowth + generalInflation);
+        newRoth = this.roth401k * (1 + salaryGrowth + generalInflation);
+        newHSA = this.hsaContribution * (1 + salaryGrowth + generalInflation);
+        break;
+      case 'TRACK_ANNUAL_MAX':
+        // Cap contributions at IRS annual limits
+        if (year !== undefined && age !== undefined) {
+          // Get annual limits (includes catch-up for age 50+/55+)
+          const inflationAdjusted = assumptions.macro.inflationAdjusted;
+          // Contributions are stored per pay period, so cap against per-period limits.
+          const limit401k = this.annualToPerPeriod(get401kLimit(year, age, inflationAdjusted));
+          const limitHSA = this.annualToPerPeriod(getHSALimit(year, age, 'individual', inflationAdjusted));
+
+          // Combined 401k limit (pre-tax + Roth share same limit)
+          // Grow current values first, then cap at limit
+          const grownPreTax = this.preTax401k * (1 + salaryGrowth + generalInflation);
+          const grownRoth = this.roth401k * (1 + salaryGrowth + generalInflation);
+          const grownTotal401k = grownPreTax + grownRoth;
+
+          if (grownTotal401k > limit401k) {
+            // Cap at limit, maintaining ratio between pre-tax and Roth
+            const ratio = grownTotal401k > 0 ? grownPreTax / grownTotal401k : 0.5;
+            newPreTax = limit401k * ratio;
+            newRoth = limit401k * (1 - ratio);
+          } else {
+            newPreTax = grownPreTax;
+            newRoth = grownRoth;
+          }
+
+          // Cap HSA at limit
+          const grownHSA = this.hsaContribution * (1 + salaryGrowth + generalInflation);
+          newHSA = Math.min(grownHSA, limitHSA);
+        } else {
+          // Fallback to grow with salary if year/age not provided
+          newPreTax = this.preTax401k * (1 + salaryGrowth + generalInflation);
+          newRoth = this.roth401k * (1 + salaryGrowth + generalInflation);
+          newHSA = this.hsaContribution * (1 + salaryGrowth + generalInflation);
+        }
+        break;
+      case 'FIXED':
+      default:
+        // Values remain the same
+        break;
+    }
+
+    // 3b. Apply auto-max 401k if enabled (overrides the above logic)
+    if (this.autoMax401k === 'disabled') {
+      // No 401k contributions
+      newPreTax = 0;
+      newRoth = 0;
+    } else if ((this.autoMax401k === 'traditional' || this.autoMax401k === 'roth') && year !== undefined && age !== undefined) {
+      // The IRS limit is annual; store it per pay period to match the field's unit.
+      const perPeriodLimit = this.annualToPerPeriod(get401kLimit(year, age, assumptions.macro.inflationAdjusted));
+      if (this.autoMax401k === 'traditional') {
+        newPreTax = perPeriodLimit;
+        newRoth = 0;
+      } else {
+        newPreTax = 0;
+        newRoth = perPeriodLimit;
+      }
+    }
+
+    // 4. Grow Insurance Cost
+    // Insurance grows with salary (it's a payroll deduction)
+    const newInsurance = this.insurance * (1 + salaryGrowth + generalInflation);
+
+    // ESPP contribution grows with salary if percentage-based
+    let newESPPAmount = this.esppContributionAmount;
+    if (this.esppContributionType === 'PERCENTAGE') {
+      // Percentage stays the same, effective amount grows with salary
+      newESPPAmount = this.esppContributionAmount;
+    } else if (this.esppContributionType === 'FIXED' && this.contributionGrowthStrategy === 'GROW_WITH_SALARY') {
+      // Fixed amount can optionally grow with salary
+      newESPPAmount = this.esppContributionAmount * (1 + salaryGrowth + generalInflation);
+    }
+
+    return new WorkIncome(
+      this.id,
+      this.name,
+      newAmount,
+      this.frequency,
+      this.earned_income,
+      newPreTax,
+      newInsurance,
+      newRoth,
+      newMatch,
+      this.matchAccountId,
+      this.taxType,
+      this.contributionGrowthStrategy,
+      this.startDate,
+      this.end_date,
+      newHSA,
+      this.autoMax401k,
+      this.esppContributionType,
+      newESPPAmount,
+      this.esppDiscountPercent,
+      this.esppHasLookback,
+      this.esppOfferingPeriodMonths,
+      this.esppAccountId,
+      this.esppExpectedStockGrowth,
+      this.pensionSystem,
+      this.startMilestoneId,
+      this.endMilestoneId,
+      this.employerMatchType,
+      this.employerMatchPercent,
+      this.employerMatchMax,
+    );
+  }
+
+  /**
+   * Get the effective 401k contributions for a given year/age, applying autoMax401k if enabled
+   * @param inflationAdjusted - If true, projects limits for future years with inflation. Defaults to true.
+   */
+  getEffective401k(year: number, age: number, inflationAdjusted: boolean = true): { preTax: number; roth: number } {
+    if (this.autoMax401k === 'disabled') {
+      return { preTax: 0, roth: 0 };
+    }
+    if (this.autoMax401k === 'custom') {
+      return { preTax: this.preTax401k, roth: this.roth401k };
+    }
+    // The IRS limit is annual; preTax401k/roth401k are stored per pay period, so spread
+    // the limit across the income's pay periods. Consumers re-annualize via getProratedAnnual.
+    const perPeriodLimit = this.annualToPerPeriod(get401kLimit(year, age, inflationAdjusted));
+    if (this.autoMax401k === 'traditional') {
+      return { preTax: perPeriodLimit, roth: 0 };
+    } else {
+      return { preTax: 0, roth: perPeriodLimit };
+    }
+  }
+
+  /**
+   * Get the annual ESPP contribution based on contribution type and salary
+   */
+  getAnnualESPPContribution(year?: number): number {
+    if (this.esppContributionType === 'NONE') {
+      return 0;
+    }
+
+    const annualSalary = this.getAnnualAmount(year);
+
+    if (this.esppContributionType === 'PERCENTAGE') {
+      // esppContributionAmount is a percentage (e.g., 10 for 10%)
+      return annualSalary * (this.esppContributionAmount / 100);
+    } else {
+      // FIXED: esppContributionAmount is per-period, convert to annual
+      return this.getProratedAnnual(this.esppContributionAmount, year);
+    }
+  }
+}
+
+export class SocialSecurityIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: IncomeFrequency,
+    public claimingAge: number,
+    public fullRetirementAgeBenefit?: number, // Optional: store FRA benefit for reference
+    startDate?: Date,
+    end_date?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, amount, frequency, "No", startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'SocialSecurityIncome';
+  }
+
+  /**
+   * Calculate the benefit adjustment factor based on claiming age
+   * Full Retirement Age (FRA) is 67 for people born in 1960 or later
+   * @param claimingAge Age when benefits are claimed (62-70)
+   * @returns Adjustment factor (e.g., 0.70 for age 62, 1.24 for age 70)
+   */
+  static calculateBenefitAdjustment(claimingAge: number): number {
+    // Claiming before FRA (67) reduces benefits by ~6.67% per year
+    // Claiming after FRA increases benefits by 8% per year (up to age 70)
+    const FRA = 67;
+
+    if (claimingAge < 62) return 0.70; // Minimum is age 62
+    if (claimingAge >= 70) return 1.24; // Maximum is age 70
+
+    if (claimingAge < FRA) {
+      // Early claiming: ~6.67% reduction per year before FRA
+      // Age 62: 70%, Age 63: 75%, Age 64: 80%, Age 65: 86.7%, Age 66: 93.3%, Age 67: 100%
+      const yearsEarly = FRA - claimingAge;
+      const reductionFactor = 0.0667; // ~6.67% per year (simplified)
+      return Math.max(0.70, 1.0 - (yearsEarly * reductionFactor));
+    } else {
+      // Delayed claiming: 8% increase per year after FRA
+      // Age 68: 108%, Age 69: 116%, Age 70: 124%
+      const yearsDelayed = claimingAge - FRA;
+      return 1.0 + (yearsDelayed * 0.08);
+    }
+  }
+
+  /**
+   * Calculate benefit amount based on FRA benefit and claiming age
+   * @param fraBenefit Benefit amount at Full Retirement Age (67)
+   * @param claimingAge Age when claiming (62-70)
+   * @returns Adjusted benefit amount
+   */
+  static calculateBenefitFromFRA(fraBenefit: number, claimingAge: number): number {
+    const adjustmentFactor = SocialSecurityIncome.calculateBenefitAdjustment(claimingAge);
+    return fraBenefit * adjustmentFactor;
+  }
+
+  increment (assumptions: AssumptionsState): SocialSecurityIncome {
+    const generalInflation = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+
+    return new SocialSecurityIncome(
+      this.id,
+      this.name,
+      this.amount * (1 + generalInflation),
+      this.frequency,
+      this.claimingAge,
+      this.fullRetirementAgeBenefit ? this.fullRetirementAgeBenefit * (1 + generalInflation) : undefined,
+      this.startDate,
+      this.end_date,
+      this.startMilestoneId,
+      this.endMilestoneId
+    );
+  }
+}
+
+export class PassiveIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: IncomeFrequency,
+    earned_income: "Yes" | "No",
+    public sourceType: 'Dividend' | 'Rental' | 'Royalty' | 'Interest' | 'RMD' | 'Other',
+    startDate?: Date,
+    end_date?: Date,
+    public isReinvested: boolean = false,  // If true, income is taxable but not available as spendable cash (e.g., savings interest that stays in the account)
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, amount, frequency, earned_income, startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'PassiveIncome';
+  }
+  increment (assumptions: AssumptionsState): PassiveIncome {
+    let growthRate = 0;
+
+    // Smart defaults based on source
+    switch (this.sourceType) {
+      case 'Rental':
+        // Rents tend to grow faster than general inflation
+        growthRate = (assumptions.expenses.rentInflation + (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0)) / 100;
+        break;
+      case 'Interest':
+        // Interest income is generated fresh each year based on account balance
+        // It doesn't grow independently - the growth comes from the account balance increasing
+        growthRate = 0;
+        break;
+      case 'RMD':
+        // RMD income is regenerated each year based on account balance and age
+        // It doesn't grow independently - the amount is recalculated each year
+        growthRate = 0;
+        break;
+      case 'Dividend':
+      case 'Royalty':
+      case 'Other':
+      default:
+        // Default to general inflation to maintain purchasing power
+        growthRate = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+        break;
+    }
+
+    return new PassiveIncome(
+      this.id,
+      this.name,
+      this.amount * (1 + growthRate),
+      this.frequency,
+      this.earned_income,
+      this.sourceType,
+      this.startDate,
+      this.end_date,
+      this.isReinvested,
+      this.startMilestoneId,
+      this.endMilestoneId
+    );
+  }
+}
+
+export class WindfallIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: IncomeFrequency,
+    earned_income: "Yes" | "No",
+    startDate?: Date,
+    end_date?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, amount, frequency, earned_income, startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'WindfallIncome';
+  }
+  increment (assumptions: AssumptionsState): WindfallIncome {
+    const inflation = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+
+    // Only grow if the user marked it as inflation adjusted
+
+    return new WindfallIncome(
+      this.id,
+      this.name,
+      this.amount * (1 + inflation),
+      this.frequency,
+      this.earned_income,
+      this.startDate,
+      this.end_date,
+      this.startMilestoneId,
+      this.endMilestoneId
+    );
+  }
+}
+
+/**
+ * CurrentSocialSecurityIncome
+ *
+ * For users who are already receiving Social Security benefits:
+ * - Disability (SSDI)
+ * - Survivor benefits
+ * - Retirement benefits (already claimed)
+ *
+ * Amount is manually entered and grows with COLA (Cost of Living Adjustment).
+ * COLA typically tracks inflation rate.
+ */
+export class CurrentSocialSecurityIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: IncomeFrequency,
+    startDate?: Date,
+    end_date?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    // Social Security is never considered "earned income" for tax purposes
+    super(id, name, amount, frequency, "No", startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'CurrentSocialSecurityIncome';
+  }
+
+  increment(assumptions: AssumptionsState): CurrentSocialSecurityIncome {
+    // COLA (Cost of Living Adjustment) tracks inflation
+    const cola = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+
+    return new CurrentSocialSecurityIncome(
+      this.id,
+      this.name,
+      this.amount * (1 + cola),
+      this.frequency,
+      this.startDate,
+      this.end_date,
+      this.startMilestoneId,
+      this.endMilestoneId
+    );
+  }
+}
+
+/**
+ * FutureSocialSecurityIncome
+ *
+ * For future retirement benefits that will be automatically calculated
+ * based on earnings history using SSA's AIME/PIA formula.
+ *
+ * Key features:
+ * - Amount is calculated by SimulationEngine (not user-entered)
+ * - Calculation triggered when user reaches claiming age
+ * - Uses 35 highest earning years with wage indexing
+ * - Start date = claiming age (auto-computed)
+ * - End date = life expectancy (auto-set)
+ *
+ * calculatedPIA stores the monthly benefit amount.
+ * When calculatedPIA = 0, the benefit hasn't been calculated yet.
+ */
+export class FutureSocialSecurityIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    public claimingAge: number,
+    public calculatedPIA: number = 0,  // Monthly benefit at claiming (feeds amount)
+    public calculationYear: number = 0,  // Year when PIA was calculated
+    startDate?: Date,
+    end_date?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+    public projectedPIA: number = 0,  // Monthly benefit for planning (does NOT feed amount)
+  ) {
+    // Amount is annual (calculatedPIA × 12)
+    // Social Security is never considered "earned income" for tax purposes
+    super(id, name, calculatedPIA * 12, 'Annually', "No", startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'FutureSocialSecurityIncome';
+  }
+
+  increment(assumptions: AssumptionsState): FutureSocialSecurityIncome {
+    // After benefits start, grow with COLA (inflation)
+    const cola = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+
+    return new FutureSocialSecurityIncome(
+      this.id,
+      this.name,
+      this.claimingAge,
+      this.calculatedPIA * (1 + cola),
+      this.calculationYear,
+      this.startDate,
+      this.end_date,
+      this.startMilestoneId,
+      this.endMilestoneId,
+      this.projectedPIA * (1 + cola)  // Keep projectedPIA in sync with COLA
+    );
+  }
+}
+
+/**
+ * FERSPensionIncome
+ *
+ * Federal Employees Retirement System pension for federal employees hired after 1983.
+ * FERS is a three-part retirement plan: Basic Benefit + Social Security + TSP.
+ *
+ * This class models the Basic Benefit component:
+ * - Formula: Years of Service × High-3 × Multiplier (1% or 1.1%)
+ * - COLA: Reduced (CPI-1% if inflation > 3%)
+ * - FERS Supplement: Bridge payment from MRA to age 62
+ *
+ * The pension is auto-calculated when the user reaches retirement age.
+ */
+export class FERSPensionIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    public yearsOfService: number,
+    public high3Salary: number,
+    public retirementAge: number,
+    public birthYear: number,
+    public calculatedBenefit: number = 0,  // Annual benefit, calculated by simulation
+    public fersSupplement: number = 0,      // Annual FERS Supplement (ends at 62)
+    public estimatedSSAt62: number = 0,     // For calculating FERS Supplement
+    startDate?: Date,
+    end_date?: Date,
+    public autoCalculateHigh3: boolean = false,  // If true, calculate High-3 from linked income
+    public linkedIncomeId: string | null = null,  // Work income to track for High-3 calculation
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    // Amount is the calculated annual benefit
+    super(id, name, calculatedBenefit, 'Annually', "No", startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'FERSPensionIncome';
+  }
+
+  /**
+   * Calculate the FERS pension benefit
+   * Called by SimulationEngine when retirement is reached
+   */
+  calculateBenefit(): number {
+    const baseBenefit = calculateFERSBasicBenefit(
+      this.yearsOfService,
+      this.high3Salary,
+      this.retirementAge
+    );
+
+    // Check for early retirement reduction (MRA+10)
+    const eligibility = checkFERSEligibility(
+      this.retirementAge,
+      this.yearsOfService,
+      this.birthYear
+    );
+
+    const reductionFactor = 1 - (eligibility.reductionPercent / 100);
+    return baseBenefit * reductionFactor;
+  }
+
+  /**
+   * Calculate FERS Supplement amount
+   * Only available if retiring before age 62 with immediate unreduced retirement
+   */
+  calculateSupplement(): number {
+    if (this.retirementAge >= 62) return 0;
+    if (this.estimatedSSAt62 <= 0) return 0;
+
+    // Check eligibility (MRA+10 retirees generally don't get supplement)
+    const eligibility = checkFERSEligibility(
+      this.retirementAge,
+      this.yearsOfService,
+      this.birthYear
+    );
+
+    // Only full retirees (no reduction) get the supplement
+    if (eligibility.reductionPercent > 0) return 0;
+
+    return calculateFERSSupplement(this.yearsOfService, this.estimatedSSAt62 / 12);
+  }
+
+  increment(assumptions: AssumptionsState, _year?: number, age?: number): FERSPensionIncome {
+    const inflation = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+    const currentAge = age || this.retirementAge;
+
+    // FERS COLA is reduced compared to full CPI
+    const cola = getFERSCOLA(inflation, currentAge);
+
+    // FERS Supplement ends at age 62
+    const newSupplement = currentAge >= 62 ? 0 : this.fersSupplement * (1 + cola);
+
+    return new FERSPensionIncome(
+      this.id,
+      this.name,
+      this.yearsOfService,
+      this.high3Salary * (1 + inflation), // High-3 doesn't grow after retirement, but keep for reference
+      this.retirementAge,
+      this.birthYear,
+      this.calculatedBenefit * (1 + cola),
+      newSupplement,
+      this.estimatedSSAt62 * (1 + inflation),
+      this.startDate,
+      this.end_date,
+      this.autoCalculateHigh3,
+      this.linkedIncomeId,
+      this.startMilestoneId,
+      this.endMilestoneId
+    );
+  }
+
+  /**
+   * Get total annual income including FERS Supplement
+   */
+  getTotalAnnualAmount(year?: number): number {
+    const base = this.getAnnualAmount(year);
+    if (base <= 0) return 0;
+    // Prorate the FERS supplement with the same active-year multiplier as the base
+    // benefit, so a mid-year start prorates both identically (matches getProratedAnnual).
+    const activeMult = year !== undefined ? getIncomeActiveMultiplier(this as unknown as AnyIncome, year) : 1;
+    return base + (this.fersSupplement || 0) * activeMult;
+  }
+}
+
+/**
+ * CSRSPensionIncome
+ *
+ * Civil Service Retirement System pension for federal employees hired before 1984.
+ * CSRS is a standalone pension system with no Social Security coverage.
+ *
+ * Formula:
+ * - 1.5% × High-3 × first 5 years
+ * - 1.75% × High-3 × years 6-10
+ * - 2.0% × High-3 × years 11+
+ * - Maximum: 80% of High-3
+ *
+ * COLA: Full CPI adjustment
+ */
+export class CSRSPensionIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    public yearsOfService: number,
+    public high3Salary: number,
+    public retirementAge: number,
+    public calculatedBenefit: number = 0,  // Annual benefit, calculated by simulation
+    startDate?: Date,
+    end_date?: Date,
+    public autoCalculateHigh3: boolean = false,  // If true, calculate High-3 from linked income
+    public linkedIncomeId: string | null = null,  // Work income to track for High-3 calculation
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    // Amount is the calculated annual benefit
+    super(id, name, calculatedBenefit, 'Annually', "No", startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'CSRSPensionIncome';
+  }
+
+  /**
+   * Calculate the CSRS pension benefit
+   * Called by SimulationEngine when retirement is reached
+   */
+  calculateBenefit(): number {
+    const baseBenefit = calculateCSRSBasicBenefit(
+      this.yearsOfService,
+      this.high3Salary
+    );
+
+    // Check for early retirement reduction
+    const eligibility = checkCSRSEligibility(
+      this.retirementAge,
+      this.yearsOfService
+    );
+
+    const reductionFactor = 1 - (eligibility.reductionPercent / 100);
+    return baseBenefit * reductionFactor;
+  }
+
+  increment(assumptions: AssumptionsState): CSRSPensionIncome {
+    const inflation = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+
+    // CSRS gets full COLA
+    const cola = getCSRSCOLA(inflation);
+
+    return new CSRSPensionIncome(
+      this.id,
+      this.name,
+      this.yearsOfService,
+      this.high3Salary, // Doesn't grow after retirement
+      this.retirementAge,
+      this.calculatedBenefit * (1 + cola),
+      this.startDate,
+      this.end_date,
+      this.autoCalculateHigh3,
+      this.linkedIncomeId,
+      this.startMilestoneId,
+      this.endMilestoneId
+    );
+  }
+}
+
+export type AnyIncome = WorkIncome | SocialSecurityIncome | CurrentSocialSecurityIncome | FutureSocialSecurityIncome | FERSPensionIncome | CSRSPensionIncome | PassiveIncome | WindfallIncome;
+
+/**
+ * Calculate the year when Social Security benefits should start
+ * @param birthYear User's birth year
+ * @param claimingAge Age when claiming SS (62-70)
+ * @returns Year when SS benefits begin
+ */
+export function calculateSocialSecurityStartYear(
+    birthYear: number,
+    claimingAge: number
+): number {
+    return birthYear + claimingAge;
+}
+
+/**
+ * Calculate the start date for Social Security income
+ * @param birthYear User's birth year
+ * @param claimingAge Age when claiming SS (62-70)
+ * @param claimingMonth Month when claiming (0-11, defaults to 0 for January)
+ * @returns Date object for when SS benefits begin
+ */
+export function calculateSocialSecurityStartDate(
+    birthYear: number,
+    claimingAge: number,
+    claimingMonth: number = 0
+): Date {
+    const year = calculateSocialSecurityStartYear(birthYear, claimingAge);
+    return new Date(Date.UTC(year, claimingMonth, 1));
+}
+
+export function getIncomeActiveMultiplier(income: AnyIncome, year: number): number {
+    const incomeStartDate = income.startDate ? new Date(income.startDate) : new Date();
+    // Date-only values come from parseDate, which returns UTC dates (see modelUtils
+    // contract). Read with getUTC* so the active window doesn't shift by a month/year
+    // in negative timezones.
+    const startYear = incomeStartDate.getUTCFullYear();
+
+    const safeEndDate = income.end_date ? new Date(income.end_date) : null;
+    const endYear = safeEndDate ? safeEndDate.getUTCFullYear() : null;
+
+    if (startYear > year) return 0;
+    if (endYear !== null && endYear < year) return 0;
+
+    const startMonthIndex = (startYear < year) ? 0 : incomeStartDate.getUTCMonth();
+
+    const endMonthIndex = (safeEndDate && endYear === year)
+        ? safeEndDate.getUTCMonth()
+        : 11;
+
+    const monthsActive = endMonthIndex - startMonthIndex + 1;
+
+    return Math.max(0, monthsActive) / 12;
+}
+
+export function isIncomeActiveInCurrentMonth(income: AnyIncome): boolean {
+    const today = new Date();
+    const currentYear = today.getFullYear();
+    const currentMonth = today.getMonth(); // 0-indexed
+
+    const incomeStartDate = income.startDate != null ? income.startDate : new Date();
+    const incomeStartYear = incomeStartDate.getFullYear();
+    const incomeStartMonth = incomeStartDate.getMonth();
+
+    const currentMonthStart = new Date(currentYear, currentMonth, 1);
+    const incomeEffectiveStart = new Date(incomeStartYear, incomeStartMonth, 1);
+
+    if (incomeEffectiveStart > currentMonthStart) {
+        return false;
+    }
+
+    if (income.end_date) {
+        const incomeEndDate = new Date(income.end_date);
+        const incomeEndYear = incomeEndDate.getFullYear();
+        const incomeEndMonth = incomeEndDate.getMonth();
+
+        const incomeEffectiveEnd = new Date(incomeEndYear, incomeEndMonth + 1, 0);
+
+        if (incomeEffectiveEnd < currentMonthStart) {
+            return false;
+        }
+    }
+    return true;
+};
+
+export const INCOME_CATEGORIES = [
+  'Work',
+  'SocialSecurity',
+  'Pension',
+  'Passive',
+  'Windfall',
+] as const;
+
+export type IncomeCategory = typeof INCOME_CATEGORIES[number];
+
+export const INCOME_COLORS_BACKGROUND: Record<IncomeCategory, string> = {
+    Work: "bg-chart-Fuchsia-50",
+    SocialSecurity: "bg-chart-Blue-50",
+    Pension: "bg-chart-Green-50",
+    Passive: "bg-chart-Yellow-50",
+    Windfall: "bg-chart-Red-50",
+};
+
+export const CLASS_TO_CATEGORY: Record<string, IncomeCategory> = {
+    [WorkIncome.name]: 'Work',
+    [SocialSecurityIncome.name]: 'SocialSecurity',
+    [CurrentSocialSecurityIncome.name]: 'SocialSecurity',
+    [FutureSocialSecurityIncome.name]: 'SocialSecurity',
+    [FERSPensionIncome.name]: 'Pension',
+    [CSRSPensionIncome.name]: 'Pension',
+    [PassiveIncome.name]: 'Passive',
+    [WindfallIncome.name]: 'Windfall'
+};
+
+// Map Categories to their color palettes (using Tailwind classes)
+// Uses 5-step gradients (1, 25, 50, 75, 100) defined in :root for SVG access
+const PALETTE_STEPS = [1, 25, 50, 75, 100];
+export const CATEGORY_PALETTES: Record<IncomeCategory, string[]> = {
+	Work: PALETTE_STEPS.map(i => `bg-chart-Fuchsia-${i}`),
+	SocialSecurity: PALETTE_STEPS.map(i => `bg-chart-Blue-${i}`),
+	Pension: PALETTE_STEPS.map(i => `bg-chart-Green-${i}`),
+	Passive: PALETTE_STEPS.map(i => `bg-chart-Yellow-${i}`),
+	Windfall: PALETTE_STEPS.map(i => `bg-chart-Red-${i}`),
+};
+
+export function reconstituteIncome(data: unknown): AnyIncome | null {
+    if (!hasClassName(data)) return null;
+
+    const startDate = parseDateRequired(data.startDate);
+    const endDate = parseDate(data.end_date);
+    const frequency = (data.frequency as IncomeFrequency) || 'Monthly';
+    const id = String(data.id ?? '');
+    const name = String(data.name ?? 'Unnamed Income');
+    const amount = Number(data.amount) || 0;
+    const earned_income = (data.earned_income as "Yes" | "No") || "No";
+    const startMilestoneId = data.startMilestoneId ? String(data.startMilestoneId) : undefined;
+    const endMilestoneId = data.endMilestoneId ? String(data.endMilestoneId) : undefined;
+
+    switch (data.className) {
+        case 'WorkIncome': {
+            // Map old 'none' value to 'custom' for backwards compatibility
+            const autoMax401k = data.autoMax401k === 'none' ? 'custom' : (data.autoMax401k || 'custom');
+            return new WorkIncome(
+                id, name, amount, frequency, earned_income,
+                Number(data.preTax401k) || 0, Number(data.insurance) || 0,
+                Number(data.roth401k) || 0, Number(data.employerMatch) || 0,
+                String(data.matchAccountId ?? ''), (data.taxType as TaxType) || null,
+                (data.contributionGrowthStrategy as ContributionGrowthStrategy) || 'FIXED',
+                startDate, endDate, Number(data.hsaContribution) || 0, autoMax401k as AutoMax401kOption,
+                (data.esppContributionType as ESPPContributionType) || 'NONE',
+                Number(data.esppContributionAmount) || 0,
+                Number(data.esppDiscountPercent ?? 15),
+                (data.esppHasLookback as boolean) ?? true,
+                Number(data.esppOfferingPeriodMonths ?? 6),
+                data.esppAccountId ? String(data.esppAccountId) : null,
+                Number(data.esppExpectedStockGrowth ?? 7),
+                (data.pensionSystem as PensionSystem) || 'NONE',
+                startMilestoneId, endMilestoneId,
+                (data.employerMatchType as EmployerMatchType) || 'fixed',
+                Number(data.employerMatchPercent) || 0,
+                Number(data.employerMatchMax) || 0,
+            );
+        }
+        case 'SocialSecurityIncome':
+            return new SocialSecurityIncome(
+                id, name, amount, frequency, Number(data.claimingAge) || 67,
+                Number(data.fullRetirementAgeBenefit) || 0, startDate, endDate,
+                startMilestoneId, endMilestoneId
+            );
+        case 'PassiveIncome':
+            return new PassiveIncome(
+                id, name, amount, frequency, earned_income,
+                (data.sourceType as PassiveIncome['sourceType']) || 'Other',
+                startDate, endDate, (data.isReinvested as boolean) ?? false,
+                startMilestoneId, endMilestoneId
+            );
+        case 'WindfallIncome':
+            return new WindfallIncome(id, name, amount, frequency, earned_income, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+        case 'CurrentSocialSecurityIncome':
+            return new CurrentSocialSecurityIncome(id, name, amount, frequency, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+        case 'FutureSocialSecurityIncome':
+            return new FutureSocialSecurityIncome(
+                id, name, Number(data.claimingAge) || 67,
+                Number(data.calculatedPIA) || 0, Number(data.calculationYear) || 0,
+                startDate, endDate, startMilestoneId, endMilestoneId,
+                Number(data.projectedPIA) || 0  // Preserve projectedPIA across save/reload
+            );
+        case 'FERSPensionIncome':
+            return new FERSPensionIncome(
+                id, name, Number(data.yearsOfService) || 0, Number(data.high3Salary) || 0,
+                Number(data.retirementAge) || 62, Number(data.birthYear) || 1970,
+                Number(data.calculatedBenefit) || 0, Number(data.fersSupplement) || 0,
+                Number(data.estimatedSSAt62) || 0, startDate, endDate,
+                (data.autoCalculateHigh3 as boolean) || false,
+                data.linkedIncomeId ? String(data.linkedIncomeId) : null,
+                startMilestoneId, endMilestoneId
+            );
+        case 'CSRSPensionIncome':
+            return new CSRSPensionIncome(
+                id, name, Number(data.yearsOfService) || 0, Number(data.high3Salary) || 0,
+                Number(data.retirementAge) || 55, Number(data.calculatedBenefit) || 0,
+                startDate, endDate, (data.autoCalculateHigh3 as boolean) || false,
+                data.linkedIncomeId ? String(data.linkedIncomeId) : null,
+                startMilestoneId, endMilestoneId
+            );
+        default:
+            return null;
+    }
+}

--- a/src/components/Objects/Taxes/TaxContext.tsx
+++ b/src/components/Objects/Taxes/TaxContext.tsx
@@ -1,0 +1,70 @@
+import { createContext, ReactNode, useMemo } from 'react';
+import { FilingStatus, max_year } from '../../../data/TaxData';
+import { usePersistedReducer } from '../../../hooks/usePersistedReducer';
+
+export type DeductionMethod = 'Standard' | 'Itemized' | 'Auto';
+
+export interface TaxState {
+  filingStatus: FilingStatus;
+  stateResidency: string;
+  deductionMethod: DeductionMethod;
+  fedOverride: number | null;
+  ficaOverride: number | null;
+  stateOverride: number | null;
+  year: number;
+}
+
+type Action =
+  | { type: 'SET_STATUS'; payload: FilingStatus }
+  | { type: 'SET_STATE'; payload: string }
+  | { type: 'SET_DEDUCTION_METHOD'; payload: DeductionMethod }
+  | { type: 'SET_FED_OVERRIDE'; payload: number | null }
+  | { type: 'SET_FICA_OVERRIDE'; payload: number | null }
+  | { type: 'SET_STATE_OVERRIDE'; payload: number | null }
+  | { type: 'SET_YEAR'; payload: number }
+  | { type: 'SET_BULK_DATA'; payload: TaxState };
+
+export const defaultTaxState: TaxState = {
+  filingStatus: 'Single',
+  stateResidency: 'DC',
+  deductionMethod: 'Auto',
+  fedOverride: null,
+  ficaOverride: null,
+  stateOverride: null,
+  year: max_year,
+};
+
+function taxReducer(state: TaxState, action: Action): TaxState {
+  switch (action.type) {
+    case 'SET_STATUS': return { ...state, filingStatus: action.payload };
+    case 'SET_STATE': return { ...state, stateResidency: action.payload };
+    case 'SET_DEDUCTION_METHOD': return { ...state, deductionMethod: action.payload };
+    case 'SET_FED_OVERRIDE': return { ...state, fedOverride: action.payload };
+    case 'SET_FICA_OVERRIDE': return { ...state, ficaOverride: action.payload };
+    case 'SET_STATE_OVERRIDE': return { ...state, stateOverride: action.payload };
+    case 'SET_YEAR': return { ...state, year: action.payload };
+    case 'SET_BULK_DATA': return { ...action.payload };
+    default: return state;
+  }
+}
+
+interface TaxContextProps {
+  state: TaxState;
+  dispatch: React.Dispatch<Action>;
+}
+
+export const TaxContext = createContext<TaxContextProps>({
+  state: defaultTaxState,
+  dispatch: () => null,
+});
+
+export function TaxProvider({ children }: { children: ReactNode }): React.ReactElement {
+  const [state, dispatch] = usePersistedReducer(taxReducer, defaultTaxState, {
+    storageKey: 'tax_settings',
+    // Merge with defaults to ensure new fields exist even with old saved data
+  });
+
+  const contextValue = useMemo(() => ({ state, dispatch }), [state, dispatch]);
+
+  return <TaxContext.Provider value={contextValue}>{children}</TaxContext.Provider>;
+}

--- a/src/components/Objects/Taxes/TaxService.tsx
+++ b/src/components/Objects/Taxes/TaxService.tsx
@@ -1,0 +1,48 @@
+/**
+ * Barrel re-exporting the focused tax service modules.
+ *
+ * The implementation lives in ./taxService/ — each domain has its own file:
+ *   - parameters.ts       getTaxParameters, getSALTCap
+ *   - incomeAggregation   gross / pre-tax / post-tax / FICA / SS income getters
+ *   - socialSecurity      getTaxableSocialSecurityBenefits
+ *   - deductions          getItemizedDeductions, getYesDeductions
+ *   - bracketTax          calculateTax + calculateTotalFederalTax (core engine)
+ *   - federalTax          calculateFederalTaxFromIncomes (orchestrator)
+ *   - stateTax            calculateStateTax, calculateUnifiedStateTax
+ *   - ficaTax             calculateFicaTax
+ *   - capitalGainsTax     calculateCapitalGainsTax
+ *   - marginalRates       getMarginalTaxRate, getCombinedMarginalRate
+ *   - esppTax             calculateESPPDispositionTax
+ *
+ * Many consumers use `import * as TaxService from '.../TaxService'` (namespace
+ * import), so this barrel must preserve every name that used to live in the
+ * monolithic file. Don't drop re-exports without checking the consumer set.
+ */
+
+export { getSALTCap, getTaxParameters } from "./taxService/parameters";
+export {
+    getGrossIncome,
+    getPreTaxExemptions,
+    getPostTaxEmployerMatch,
+    getPostTaxExemptions,
+    getFicaExemptions,
+    getEarnedIncome,
+    getSocialSecurityBenefits,
+} from "./taxService/incomeAggregation";
+export { getTaxableSocialSecurityBenefits } from "./taxService/socialSecurity";
+export { getItemizedDeductions, getYesDeductions } from "./taxService/deductions";
+export {
+    calculateTotalFederalTax,
+    calculateTax,
+    type TotalFederalTaxResult,
+} from "./taxService/bracketTax";
+export { calculateFederalTaxFromIncomes } from "./taxService/federalTax";
+export { calculateStateTax, calculateUnifiedStateTax } from "./taxService/stateTax";
+export { calculateFicaTax } from "./taxService/ficaTax";
+export { calculateCapitalGainsTax } from "./taxService/capitalGainsTax";
+export {
+    getMarginalTaxRate,
+    getCombinedMarginalRate,
+    type MarginalRateResult,
+} from "./taxService/marginalRates";
+export { calculateESPPDispositionTax } from "./taxService/esppTax";

--- a/src/components/Objects/Taxes/taxService/bracketTax.ts
+++ b/src/components/Objects/Taxes/taxService/bracketTax.ts
@@ -1,0 +1,172 @@
+/**
+ * The core bracket-walking federal tax calculation. Lives here (not in
+ * federalTax.ts) so that stateTax.ts can use `calculateTax` for its
+ * bracket math without creating a circular dependency back to the
+ * federal-from-incomes orchestrator.
+ */
+import { FilingStatus, TaxParameters } from "../../../../data/TaxData";
+import { getTaxableSocialSecurityBenefits } from "./socialSecurity";
+
+/** Result of the unified federal tax calculation */
+export interface TotalFederalTaxResult {
+    taxableSS: number;      // Taxable portion of SS benefits
+    ordinaryTax: number;    // Tax on ordinary income (wages, pensions, withdrawals, taxable SS, STCG)
+    ltcgTax: number;        // Tax on long-term capital gains + qualified dividends
+    niitTax: number;        // Net Investment Income Tax (3.8% on investment income above threshold)
+    totalTax: number;       // ordinaryTax + ltcgTax + niitTax
+}
+
+/** NIIT thresholds by filing status */
+const NIIT_THRESHOLDS: Record<FilingStatus, number> = {
+    'Single': 200000,
+    'Married Filing Jointly': 250000,
+    'Married Filing Separately': 125000,
+};
+
+/** NIIT rate */
+const NIIT_RATE = 0.038;
+
+/**
+ * Unified federal tax calculation that handles all income types and their interactions.
+ *
+ * This function properly handles:
+ * - Social Security taxability (provisional income calculation)
+ * - STCG taxed as ordinary income (but counted as investment income for NIIT)
+ * - LTCG stacking on top of ordinary income for bracket determination
+ * - NIIT (3.8% on investment income above threshold)
+ * - Standard deduction applied to ordinary income only
+ *
+ * Calculation order:
+ * 1. Calculate provisional income for SS taxability
+ * 2. Calculate taxable SS using getTaxableSocialSecurityBenefits
+ * 3. Calculate taxable ordinary income (includes STCG)
+ * 4. Calculate ordinary tax on taxable ordinary income
+ * 5. Calculate LTCG tax where gains "stack" on top of ordinary taxable income
+ * 6. Calculate NIIT on investment income above threshold
+ *
+ * @param ordinaryIncome - Wages, Traditional withdrawals, pensions, Roth conversions (NOT STCG)
+ * @param socialSecurityBenefits - Gross SS benefits (we calculate taxable portion internally)
+ * @param shortTermCapitalGains - STCG (taxed as ordinary income, but is investment income for NIIT)
+ * @param longTermCapitalGains - LTCG + qualified dividends
+ * @param preTaxDeductions - 401k, HSA contributions, etc.
+ * @param filingStatus - Tax filing status
+ * @param params - Federal tax parameters (brackets, standard deduction, LTCG brackets)
+ */
+export function calculateTotalFederalTax(
+    ordinaryIncome: number,
+    socialSecurityBenefits: number,
+    shortTermCapitalGains: number,
+    longTermCapitalGains: number,
+    preTaxDeductions: number,
+    filingStatus: FilingStatus,
+    params: TaxParameters,
+): TotalFederalTaxResult {
+    // STEP 1: Provisional income for SS taxability
+    // IRS formula: Provisional Income = AGI (excluding SS) + tax-exempt interest + 50% of SS
+    // Both STCG and LTCG count toward provisional income.
+    // Pre-tax deductions (401k, HSA, etc.) reduce AGI, so they must also reduce the
+    // AGI-excluding-SS portion of provisional income before adding half of SS benefits.
+    const provisionalIncome = Math.max(0, ordinaryIncome + shortTermCapitalGains + longTermCapitalGains - preTaxDeductions) + (socialSecurityBenefits * 0.5);
+
+    // STEP 2: Taxable portion of Social Security
+    // TODO: Verify all income types are included (LTCG, STCG, dividends, etc.)
+    const taxableSS = getTaxableSocialSecurityBenefits(
+        socialSecurityBenefits,
+        provisionalIncome - (socialSecurityBenefits * 0.5),
+        0, // taxExemptInterest - not currently tracked
+        filingStatus,
+    );
+
+    // STEP 3: Taxable ordinary income (includes STCG; LTCG does NOT get the standard deduction)
+    const totalOrdinaryIncome = ordinaryIncome + shortTermCapitalGains + taxableSS;
+    const adjustedOrdinary = Math.max(0, totalOrdinaryIncome - preTaxDeductions);
+    const taxableOrdinary = Math.max(0, adjustedOrdinary - params.standardDeduction);
+
+    // STEP 4: Ordinary income tax (includes STCG)
+    let ordinaryTax = 0;
+    for (let i = 0; i < params.brackets.length; i++) {
+        const current = params.brackets[i];
+        const next = params.brackets[i + 1];
+        const upperLimit = next ? next.threshold : Infinity;
+
+        if (taxableOrdinary > current.threshold) {
+            const amountInBracket = Math.min(taxableOrdinary, upperLimit) - current.threshold;
+            ordinaryTax += amountInBracket * current.rate;
+        }
+    }
+
+    // STEP 5: LTCG tax (stacks on top of ordinary income)
+    let ltcgTax = 0;
+    if (longTermCapitalGains > 0 && params.capitalGainsBrackets) {
+        const brackets = params.capitalGainsBrackets;
+        let remainingGains = longTermCapitalGains;
+        let incomeStack = taxableOrdinary;
+
+        for (let i = 0; i < brackets.length && remainingGains > 0; i++) {
+            const bracket = brackets[i];
+            const nextBracket = brackets[i + 1];
+            const upperLimit = nextBracket ? nextBracket.threshold : Infinity;
+
+            if (incomeStack >= upperLimit) continue;
+
+            const bracketFloor = Math.max(incomeStack, bracket.threshold);
+            const roomInBracket = upperLimit - bracketFloor;
+            const gainsInBracket = Math.min(remainingGains, roomInBracket);
+
+            ltcgTax += gainsInBracket * bracket.rate;
+
+            incomeStack += gainsInBracket;
+            remainingGains -= gainsInBracket;
+        }
+    }
+
+    // STEP 6: NIIT (Net Investment Income Tax)
+    // 3.8% on the LESSER of net investment income or MAGI exceeding threshold.
+    let niitTax = 0;
+    const niitThreshold = NIIT_THRESHOLDS[filingStatus];
+    const netInvestmentIncome = shortTermCapitalGains + longTermCapitalGains;
+
+    if (netInvestmentIncome > 0) {
+        // MAGI for NIIT purposes (approximated as AGI here)
+        const magi = ordinaryIncome + shortTermCapitalGains + longTermCapitalGains + taxableSS - preTaxDeductions;
+        const magiExcess = Math.max(0, magi - niitThreshold);
+
+        if (magiExcess > 0) {
+            const niitBase = Math.min(netInvestmentIncome, magiExcess);
+            niitTax = niitBase * NIIT_RATE;
+        }
+    }
+
+    return {
+        taxableSS,
+        ordinaryTax,
+        ltcgTax,
+        niitTax,
+        totalTax: ordinaryTax + ltcgTax + niitTax,
+    };
+}
+
+/**
+ * Legacy tax calculation function for backwards compatibility.
+ * Use calculateTotalFederalTax for new code that needs SS/LTCG/NIIT handling.
+ *
+ * @param grossIncome - Gross income before deductions
+ * @param preTaxDeductions - 401k, HSA, etc.
+ * @param params - Tax parameters
+ * @returns Tax amount (ordinary income tax only, no SS/LTCG/NIIT)
+ */
+export function calculateTax(
+    grossIncome: number,
+    preTaxDeductions: number,
+    params: TaxParameters,
+): number {
+    return calculateTotalFederalTax(
+        grossIncome,
+        0,
+        0,
+        0,
+        preTaxDeductions,
+        'Single', // filing status doesn't matter when SS=0 and no investment income
+        params,
+    ).ordinaryTax;
+}

--- a/src/components/Objects/Taxes/taxService/capitalGainsTax.ts
+++ b/src/components/Objects/Taxes/taxService/capitalGainsTax.ts
@@ -1,0 +1,79 @@
+import { TaxState } from "../TaxContext";
+import { AssumptionsState } from "../../Assumptions/AssumptionsContext";
+import { getTaxParameters } from "./parameters";
+import { TaxParameters } from "../../../../data/TaxData";
+
+/**
+ * Get the long-term capital gains rate that applies at a given ordinary income
+ * level. LTCG stack on top of ordinary income, so the applicable rate is the
+ * highest capital-gains bracket whose threshold the ordinary income reaches.
+ *
+ * Walks brackets high→low and returns the first whose threshold is met
+ * (>=). Falls back to a flat 15% when no capital-gains brackets are available,
+ * and to 0% when the bracket array is empty.
+ *
+ * @param ordinaryIncome - Ordinary income that positions the gains in a bracket
+ * @param fedParams - Federal tax parameters (supplying capitalGainsBrackets)
+ * @returns The applicable LTCG rate (decimal)
+ */
+export function getLTCGRate(ordinaryIncome: number, fedParams: TaxParameters | null | undefined): number {
+    if (!fedParams?.capitalGainsBrackets) return 0.15;
+
+    const brackets = fedParams.capitalGainsBrackets;
+    for (let i = brackets.length - 1; i >= 0; i--) {
+        if (ordinaryIncome >= brackets[i].threshold) {
+            return brackets[i].rate;
+        }
+    }
+    return brackets[0]?.rate ?? 0;
+}
+
+/**
+ * Calculate capital gains tax on long-term gains.
+ * Capital gains are taxed based on your total taxable income bracket.
+ * The gains "stack on top" of ordinary income to determine the applicable rate.
+ *
+ * @param gains - Amount of long-term capital gains
+ * @param ordinaryTaxableIncome - Taxable income from ordinary sources (after deductions)
+ * @param taxState - Filing status and other tax state
+ * @param year - Tax year
+ * @param assumptions - Assumptions for inflation adjustments
+ * @returns The tax owed on the capital gains
+ */
+export function calculateCapitalGainsTax(
+    gains: number,
+    ordinaryTaxableIncome: number,
+    taxState: TaxState,
+    year: number,
+    assumptions?: AssumptionsState,
+): number {
+    if (gains <= 0) return 0;
+
+    const fedParams = getTaxParameters(year, taxState.filingStatus, 'federal', undefined, assumptions);
+    if (!fedParams || !fedParams.capitalGainsBrackets) {
+        // Fallback to flat 15% if no brackets available
+        return gains * 0.15;
+    }
+
+    const brackets = fedParams.capitalGainsBrackets;
+    let remainingGains = gains;
+    let totalTax = 0;
+    let incomeLevel = Math.max(0, ordinaryTaxableIncome);
+
+    for (let i = 0; i < brackets.length && remainingGains > 0; i++) {
+        const currentBracket = brackets[i];
+        const nextBracket = brackets[i + 1];
+        const upperLimit = nextBracket ? nextBracket.threshold : Infinity;
+
+        if (incomeLevel >= upperLimit) continue;
+
+        const roomInBracket = upperLimit - incomeLevel;
+        const gainsInBracket = Math.min(remainingGains, roomInBracket);
+        totalTax += gainsInBracket * currentBracket.rate;
+
+        incomeLevel += gainsInBracket;
+        remainingGains -= gainsInBracket;
+    }
+
+    return totalTax;
+}

--- a/src/components/Objects/Taxes/taxService/deductions.ts
+++ b/src/components/Objects/Taxes/taxService/deductions.ts
@@ -1,0 +1,33 @@
+import { AnyExpense, MortgageExpense, getExpenseActiveMultiplier } from "../../Expense/models";
+
+export function getItemizedDeductions(expenses: AnyExpense[], year: number): number {
+    return expenses
+        .filter(
+            (exp) =>
+                "is_tax_deductible" in exp &&
+                exp.is_tax_deductible === "Itemized" &&
+                getExpenseActiveMultiplier(exp, year) > 0,
+        )
+        .reduce((val, exp) => {
+            if (exp instanceof MortgageExpense) {
+                return val + exp.calculateAnnualAmortization(year).totalInterest;
+            }
+            return val + exp.getProratedAnnual((exp as any).tax_deductible || 0, year);
+        }, 0);
+}
+
+export function getYesDeductions(expenses: AnyExpense[], year: number): number {
+    return expenses
+        .filter(
+            (exp) =>
+                "is_tax_deductible" in exp &&
+                exp.is_tax_deductible === "Yes" &&
+                getExpenseActiveMultiplier(exp, year) > 0,
+        )
+        .reduce((val, exp) => {
+            if (exp instanceof MortgageExpense) {
+                return val + exp.calculateAnnualAmortization(year).totalInterest;
+            }
+            return val + exp.getProratedAnnual((exp as any).tax_deductible || 0, year);
+        }, 0);
+}

--- a/src/components/Objects/Taxes/taxService/esppTax.ts
+++ b/src/components/Objects/Taxes/taxService/esppTax.ts
@@ -1,0 +1,80 @@
+/**
+ * Calculate ESPP disposition tax breakdown.
+ *
+ * ESPP shares have special tax treatment based on holding periods:
+ *
+ * **Qualifying Disposition** (held 2 years from grant AND 1 year from purchase):
+ * - Ordinary income = lesser of: (1) discount at grant price, or (2) actual gain
+ * - Capital gains = remainder (long-term)
+ *
+ * **Disqualifying Disposition** (sold before meeting both holding periods):
+ * - Ordinary income = FMV at purchase - purchase price (the "bargain element")
+ * - Capital gains = sale price - FMV at purchase (can be short or long term)
+ *
+ * TODO: This function is exported and tested but not used in the app.
+ * Either wire it up to the ESPP account UI (e.g., lot sale preview) or delete it.
+ *
+ * @param sharesToSell - Number of shares being sold
+ * @param salePrice - Sale price per share
+ * @param purchasePrice - Original purchase price per share
+ * @param fmvAtGrant - Fair market value at grant date
+ * @param fmvAtPurchase - Fair market value at purchase date
+ * @param isQualifying - Whether this is a qualifying disposition
+ * @param isLongTermCG - Whether capital gains portion qualifies as long-term
+ * @returns Tax breakdown with ordinary income and capital gains amounts
+ */
+export function calculateESPPDispositionTax(
+    sharesToSell: number,
+    salePrice: number,
+    purchasePrice: number,
+    fmvAtGrant: number,
+    fmvAtPurchase: number,
+    isQualifying: boolean,
+    isLongTermCG: boolean,
+): {
+    ordinaryIncome: number;
+    shortTermCapitalGains: number;
+    longTermCapitalGains: number;
+    totalTaxableGain: number;
+} {
+    const totalSaleProceeds = sharesToSell * salePrice;
+    const totalCostBasis = sharesToSell * purchasePrice;
+    const totalGain = totalSaleProceeds - totalCostBasis;
+
+    let ordinaryIncome = 0;
+    let shortTermCapitalGains = 0;
+    let longTermCapitalGains = 0;
+
+    if (totalGain <= 0) {
+        // Loss scenario - all goes to capital gains (loss)
+        if (isLongTermCG) {
+            longTermCapitalGains = totalGain;
+        } else {
+            shortTermCapitalGains = totalGain;
+        }
+    } else if (isQualifying) {
+        // Qualifying disposition
+        // Ordinary income = lesser of grant discount or actual gain
+        const grantDiscount = fmvAtGrant * 0.15 * sharesToSell; // Typical 15% discount
+        ordinaryIncome = Math.min(grantDiscount, totalGain);
+        longTermCapitalGains = totalGain - ordinaryIncome;
+    } else {
+        // Disqualifying disposition
+        const bargainElement = (fmvAtPurchase - purchasePrice) * sharesToSell;
+        ordinaryIncome = Math.max(0, bargainElement);
+
+        const capitalGain = totalGain - bargainElement;
+        if (isLongTermCG) {
+            longTermCapitalGains = capitalGain;
+        } else {
+            shortTermCapitalGains = capitalGain;
+        }
+    }
+
+    return {
+        ordinaryIncome,
+        shortTermCapitalGains,
+        longTermCapitalGains,
+        totalTaxableGain: ordinaryIncome + shortTermCapitalGains + longTermCapitalGains,
+    };
+}

--- a/src/components/Objects/Taxes/taxService/federalTax.ts
+++ b/src/components/Objects/Taxes/taxService/federalTax.ts
@@ -1,0 +1,98 @@
+import { AnyExpense } from "../../Expense/models";
+import { AnyIncome } from "../../Income/models";
+import { TaxState } from "../TaxContext";
+import { AssumptionsState, getBirthYear } from "../../Assumptions/AssumptionsContext";
+import { getTaxParameters, getSALTCap } from "./parameters";
+import {
+    getGrossIncome,
+    getPreTaxExemptions,
+    getSocialSecurityBenefits,
+} from "./incomeAggregation";
+import { getItemizedDeductions, getYesDeductions } from "./deductions";
+import { calculateTotalFederalTax } from "./bracketTax";
+import { calculateStateTax, calculateUnifiedStateTax } from "./stateTax";
+
+/**
+ * Calculate federal tax from income/expense objects using calculateTotalFederalTax.
+ *
+ * Orchestrates the full federal tax computation: extracts values from incomes
+ * + expenses, threads them through `calculateTotalFederalTax`, handles SALT
+ * cap interaction with state tax, and picks the best of Standard / Itemized
+ * deduction when `deductionMethod === 'Auto'`.
+ *
+ * @param state - Tax state (filing status, overrides, deduction method)
+ * @param incomes - Income objects (SS, pensions, work income)
+ * @param expenses - Expense objects (for itemized deductions)
+ * @param additionalOrdinaryIncome - Traditional withdrawals + Roth conversions + RMDs (default 0)
+ * @param year - Tax year
+ * @param assumptions - Assumptions for inflation adjustments
+ * @param stcg - Short-term capital gains (default 0)
+ * @param ltcg - Long-term capital gains (default 0)
+ * @returns Federal tax amount
+ */
+export function calculateFederalTaxFromIncomes(
+    state: TaxState,
+    incomes: AnyIncome[],
+    expenses: AnyExpense[],
+    additionalOrdinaryIncome: number = 0,
+    year: number,
+    assumptions?: AssumptionsState,
+    stcg: number = 0,
+    ltcg: number = 0,
+): number {
+    if (state.fedOverride !== null) {
+        return state.fedOverride;
+    }
+
+    const incomeGross = getGrossIncome(incomes, year);
+    const age = assumptions?.milestones ? year - getBirthYear(assumptions.milestones) : undefined;
+
+    const incomePreTaxDeductions = getPreTaxExemptions(incomes, year, age);
+    const expenseAboveLineDeductions = getYesDeductions(expenses, year);
+    const totalPreTaxDeductions = incomePreTaxDeductions + expenseAboveLineDeductions;
+
+    const totalSSBenefits = getSocialSecurityBenefits(incomes, year);
+    const nonSSGross = incomeGross - totalSSBenefits;
+    const ordinaryIncome = nonSSGross + additionalOrdinaryIncome;
+
+    const fedParams = getTaxParameters(year, state.filingStatus, "federal", undefined, assumptions);
+    if (!fedParams) return 0;
+
+    // SALT cap interaction with state tax
+    const stateTax = additionalOrdinaryIncome > 0
+        ? calculateUnifiedStateTax(state, incomes, expenses, additionalOrdinaryIncome, year, assumptions)
+        : calculateStateTax(state, incomes, expenses, year, assumptions);
+
+    const saltCap = getSALTCap(year, state.filingStatus);
+    const cappedStateTax = Math.min(stateTax, saltCap);
+
+    const itemizedTotal = getItemizedDeductions(expenses, year) + cappedStateTax;
+
+    const calcTaxWithDeduction = (deductionAmount: number): number => {
+        const paramsWithDeduction = {
+            ...fedParams,
+            standardDeduction: deductionAmount,
+        };
+        return calculateTotalFederalTax(
+            ordinaryIncome,
+            totalSSBenefits,
+            stcg,
+            ltcg,
+            totalPreTaxDeductions,
+            state.filingStatus,
+            paramsWithDeduction,
+        ).totalTax;
+    };
+
+    if (state.deductionMethod === "Auto") {
+        const taxWithStandard = calcTaxWithDeduction(fedParams.standardDeduction);
+        const taxWithItemized = calcTaxWithDeduction(itemizedTotal);
+        return Math.min(taxWithStandard, taxWithItemized);
+    }
+
+    const appliedDeduction = state.deductionMethod === "Standard"
+        ? fedParams.standardDeduction
+        : itemizedTotal;
+
+    return calcTaxWithDeduction(appliedDeduction);
+}

--- a/src/components/Objects/Taxes/taxService/ficaTax.ts
+++ b/src/components/Objects/Taxes/taxService/ficaTax.ts
@@ -1,0 +1,35 @@
+import { AnyIncome } from "../../Income/models";
+import { TaxState } from "../TaxContext";
+import { AssumptionsState } from "../../Assumptions/AssumptionsContext";
+import { getTaxParameters } from "./parameters";
+import { getEarnedIncome, getFicaExemptions } from "./incomeAggregation";
+
+export function calculateFicaTax(
+    state: TaxState,
+    incomes: AnyIncome[],
+    year: number,
+    assumptions?: AssumptionsState,
+): number {
+    if (state.ficaOverride !== null) {
+        return state.ficaOverride;
+    }
+
+    const earnedGross = getEarnedIncome(incomes, year);
+    const ficaExemptions = getFicaExemptions(incomes, year);
+    const fedParams = getTaxParameters(year, state.filingStatus, "federal", undefined, assumptions);
+
+    if (!fedParams) return 0;
+
+    const taxableBase = Math.max(0, earnedGross - ficaExemptions);
+    const ssTax =
+        Math.min(taxableBase, fedParams.socialSecurityWageBase) *
+        fedParams.socialSecurityTaxRate;
+    const medicareTax = taxableBase * fedParams.medicareTaxRate;
+
+    const additionalMedicareThreshold =
+        state.filingStatus === 'Married Filing Jointly' ? 250000 :
+        state.filingStatus === 'Married Filing Separately' ? 125000 : 200000;
+    const additionalMedicareTax = Math.max(0, taxableBase - additionalMedicareThreshold) * 0.009;
+
+    return ssTax + medicareTax + additionalMedicareTax;
+}

--- a/src/components/Objects/Taxes/taxService/incomeAggregation.ts
+++ b/src/components/Objects/Taxes/taxService/incomeAggregation.ts
@@ -1,0 +1,108 @@
+import {
+    AnyIncome,
+    WorkIncome,
+    SocialSecurityIncome,
+    CurrentSocialSecurityIncome,
+    FutureSocialSecurityIncome,
+} from "../../Income/models";
+
+export function getGrossIncome(incomes: AnyIncome[], year: number): number {
+    return incomes.reduce((acc, inc) => {
+        let currentIncome = inc.amount;
+        if (inc instanceof WorkIncome && inc.taxType === "Roth 401k") {
+            currentIncome += inc.employerMatch;
+        }
+        return acc + inc.getProratedAnnual(currentIncome, year);
+    }, 0);
+}
+
+/**
+ * Get pre-tax exemptions (401k, insurance, HSA) from work incomes.
+ * @param useStoredValue - If true, reads stored preTax401k directly instead of calling getEffective401k().
+ *                         Use true in simulation (after increment() has run), false for UI preview.
+ */
+export function getPreTaxExemptions(
+    incomes: AnyIncome[],
+    year: number,
+    age?: number,
+    useStoredValue: boolean = false,
+): number {
+    return incomes
+        .filter((inc) => inc instanceof WorkIncome)
+        .reduce((acc, inc) => {
+            const preTax401k = useStoredValue
+                ? inc.preTax401k
+                : (age !== undefined ? inc.getEffective401k(year, age).preTax : inc.preTax401k);
+            return (
+                acc +
+                inc.getProratedAnnual(preTax401k, year) +
+                inc.getProratedAnnual(inc.insurance, year) +
+                inc.getProratedAnnual(inc.hsaContribution, year)
+            );
+        }, 0);
+}
+
+export function getPostTaxEmployerMatch(incomes: AnyIncome[], year: number): number {
+    return incomes.reduce((acc, inc) => {
+        if (inc instanceof WorkIncome && inc.taxType === "Roth 401k") {
+            return acc + inc.getEffectiveAnnualEmployerMatch(year);
+        }
+        return acc;
+    }, 0);
+}
+
+/**
+ * Get post-tax exemptions (Roth 401k) from work incomes.
+ * @param useStoredValue - If true, reads stored roth401k directly instead of calling getEffective401k().
+ *                         Use true in simulation (after increment() has run), false for UI preview.
+ */
+export function getPostTaxExemptions(
+    incomes: AnyIncome[],
+    year: number,
+    age?: number,
+    useStoredValue: boolean = false,
+): number {
+    return incomes
+        .filter((inc) => inc instanceof WorkIncome)
+        .reduce((acc, inc) => {
+            const roth401k = useStoredValue
+                ? inc.roth401k
+                : (age !== undefined ? inc.getEffective401k(year, age).roth : inc.roth401k);
+            return acc + inc.getProratedAnnual(roth401k, year);
+        }, 0);
+}
+
+export function getFicaExemptions(incomes: AnyIncome[], year: number): number {
+    return incomes
+        .filter((inc) => inc instanceof WorkIncome)
+        .reduce((acc, inc) => {
+            return (
+                acc +
+                inc.getProratedAnnual(inc.insurance, year) +
+                inc.getProratedAnnual(inc.hsaContribution, year)
+            );
+        }, 0);
+}
+
+export function getEarnedIncome(incomes: AnyIncome[], year: number): number {
+    return incomes
+        .filter((inc) => inc.earned_income === "Yes")
+        .reduce((acc, inc) => {
+            return acc + inc.getProratedAnnual(inc.amount, year);
+        }, 0);
+}
+
+/**
+ * Get total Social Security benefits received in the year.
+ */
+export function getSocialSecurityBenefits(incomes: AnyIncome[], year: number): number {
+    return incomes
+        .filter((inc) =>
+            inc instanceof SocialSecurityIncome ||
+            inc instanceof CurrentSocialSecurityIncome ||
+            inc instanceof FutureSocialSecurityIncome,
+        )
+        .reduce((acc, inc) => {
+            return acc + inc.getProratedAnnual(inc.amount, year);
+        }, 0);
+}

--- a/src/components/Objects/Taxes/taxService/marginalRates.ts
+++ b/src/components/Objects/Taxes/taxService/marginalRates.ts
@@ -1,0 +1,116 @@
+import { TaxParameters } from "../../../../data/TaxData";
+import { TaxState } from "../TaxContext";
+import { AssumptionsState } from "../../Assumptions/AssumptionsContext";
+import { getTaxParameters } from "./parameters";
+
+/** Result of marginal tax rate calculation */
+export interface MarginalRateResult {
+    rate: number;           // Decimal rate (e.g., 0.22 for 22%)
+    bracketStart: number;   // Taxable income where this bracket starts
+    bracketEnd: number;     // Taxable income where this bracket ends (Infinity for top)
+    headroom: number;       // $ remaining until next bracket
+}
+
+/**
+ * Get the marginal tax rate for a given taxable income.
+ *
+ * @param taxableIncome - Income after deductions (not gross income)
+ * @param params - Tax parameters containing brackets
+ * @returns Marginal rate info including headroom to next bracket
+ */
+export function getMarginalTaxRate(
+    taxableIncome: number,
+    params: TaxParameters,
+): MarginalRateResult {
+    if (taxableIncome <= 0) {
+        const first = params.brackets[0];
+        const second = params.brackets[1];
+        return {
+            rate: first.rate,
+            bracketStart: first.threshold,
+            bracketEnd: second ? second.threshold : Infinity,
+            headroom: second ? second.threshold : Infinity,
+        };
+    }
+
+    for (let i = 0; i < params.brackets.length; i++) {
+        const current = params.brackets[i];
+        const next = params.brackets[i + 1];
+        const upperLimit = next ? next.threshold : Infinity;
+
+        if (taxableIncome >= current.threshold && taxableIncome < upperLimit) {
+            return {
+                rate: current.rate,
+                bracketStart: current.threshold,
+                bracketEnd: upperLimit,
+                headroom: upperLimit === Infinity ? Infinity : upperLimit - taxableIncome,
+            };
+        }
+    }
+
+    const top = params.brackets[params.brackets.length - 1];
+    return {
+        rate: top.rate,
+        bracketStart: top.threshold,
+        bracketEnd: Infinity,
+        headroom: Infinity,
+    };
+}
+
+/**
+ * Get combined marginal tax rate (federal + state + FICA if applicable).
+ *
+ * @param grossIncome - Gross income before deductions
+ * @param preTaxDeductions - 401k, HSA, etc.
+ * @param taxState - Tax configuration
+ * @param year - Tax year
+ * @param assumptions - Assumptions for inflation adjustment
+ * @param includesFICA - Whether to include FICA taxes (true for earned income)
+ * @returns Combined marginal rate breakdown
+ */
+export function getCombinedMarginalRate(
+    grossIncome: number,
+    preTaxDeductions: number,
+    taxState: TaxState,
+    year: number,
+    assumptions: AssumptionsState,
+    includesFICA: boolean = true,
+): {
+    federal: number;
+    state: number;
+    fica: number;
+    combined: number;
+    federalHeadroom: number;
+} {
+    const fedParams = getTaxParameters(year, taxState.filingStatus, 'federal', undefined, assumptions);
+    const stateParams = getTaxParameters(year, taxState.filingStatus, 'state', taxState.stateResidency, assumptions);
+
+    const adjustedGross = Math.max(0, grossIncome - preTaxDeductions);
+    const fedStdDed = fedParams?.standardDeduction || 14600;
+    const stateStdDed = stateParams?.standardDeduction || 0;
+
+    const fedTaxableIncome = Math.max(0, adjustedGross - fedStdDed);
+    const stateTaxableIncome = Math.max(0, adjustedGross - stateStdDed);
+
+    const fedMarginal = fedParams ? getMarginalTaxRate(fedTaxableIncome, fedParams) : { rate: 0, headroom: Infinity };
+    const stateMarginal = stateParams ? getMarginalTaxRate(stateTaxableIncome, stateParams) : { rate: 0, headroom: Infinity };
+
+    // FICA: 6.2% SS (up to wage base) + 1.45% Medicare
+    let ficaRate = 0;
+    if (includesFICA && fedParams) {
+        const ssWageBase = fedParams.socialSecurityWageBase || 168600;
+        if (grossIncome < ssWageBase) {
+            ficaRate = fedParams.socialSecurityTaxRate + fedParams.medicareTaxRate;
+        } else {
+            ficaRate = fedParams.medicareTaxRate;
+        }
+    }
+
+    return {
+        federal: fedMarginal.rate,
+        state: stateMarginal.rate,
+        fica: ficaRate,
+        combined: fedMarginal.rate + stateMarginal.rate + ficaRate,
+        federalHeadroom: fedMarginal.headroom,
+    };
+}

--- a/src/components/Objects/Taxes/taxService/parameters.ts
+++ b/src/components/Objects/Taxes/taxService/parameters.ts
@@ -1,0 +1,148 @@
+import {
+    TaxParameters,
+    TAX_DATABASE,
+    getClosestTaxYear,
+    max_year,
+    FilingStatus,
+    AuthorityData,
+} from "../../../../data/TaxData";
+import {
+    AssumptionsState,
+    defaultAssumptions,
+} from "../../Assumptions/AssumptionsContext";
+
+/** Tax years when TCJA SALT cap was in effect ($10k/$5k MFS) */
+const TCJA_SALT_START_YEAR = 2018;
+const TCJA_SALT_END_YEAR = 2024;
+
+/** Tax years when OBBBA raised SALT cap ($40k/$20k MFS with 1% annual inflation) */
+const OBBBA_SALT_START_YEAR = 2025;
+const OBBBA_SALT_END_YEAR = 2029;
+
+/** SALT cap amounts */
+const SALT_CAP_TCJA_JOINT = 10000;
+const SALT_CAP_TCJA_MFS = 5000;
+const SALT_CAP_OBBBA_JOINT = 40000;
+const SALT_CAP_OBBBA_MFS = 20000;
+const SALT_CAP_ANNUAL_INCREASE = 0.01; // 1% annual increase under OBBBA
+
+/**
+ * SALT (State and Local Tax) deduction cap.
+ *
+ * History:
+ * - TCJA 2017 (effective 2018-2024): $10,000 cap ($5,000 MFS)
+ * - One Big Beautiful Bill Act 2025 (effective 2025-2029): $40,000 cap ($20,000 MFS)
+ *   with 1% annual increase starting 2026
+ * - 2030+: Reverts to $10,000
+ *
+ * Note: The 2025 law includes income phase-outs starting at $500k MAGI, but we don't
+ * implement those here for simplicity. The cap still provides a minimum of $10,000.
+ */
+export function getSALTCap(year: number, filingStatus: FilingStatus): number {
+    const isMFS = filingStatus === 'Married Filing Separately';
+
+    // Pre-TCJA: No cap
+    if (year < TCJA_SALT_START_YEAR) {
+        return Infinity;
+    }
+
+    // TCJA cap period (2018-2024)
+    if (year >= TCJA_SALT_START_YEAR && year <= TCJA_SALT_END_YEAR) {
+        return isMFS ? SALT_CAP_TCJA_MFS : SALT_CAP_TCJA_JOINT;
+    }
+
+    // OBBBA raised cap period (2025-2029) with 1% annual increase starting 2026
+    if (year >= OBBBA_SALT_START_YEAR && year <= OBBBA_SALT_END_YEAR) {
+        const yearsOfIncrease = Math.max(0, year - OBBBA_SALT_START_YEAR);
+        const inflationFactor = Math.pow(1 + SALT_CAP_ANNUAL_INCREASE, yearsOfIncrease);
+        const baseCap = isMFS ? SALT_CAP_OBBBA_MFS : SALT_CAP_OBBBA_JOINT;
+        return Math.round(baseCap * inflationFactor);
+    }
+
+    // 2030+: Reverts to original TCJA cap
+    return isMFS ? SALT_CAP_TCJA_MFS : SALT_CAP_TCJA_JOINT;
+}
+
+export function getTaxParameters(
+    year: number,
+    filingStatus: FilingStatus,
+    authority: "federal" | "state",
+    stateResidency?: string,
+    assumptions: AssumptionsState = {
+        ...defaultAssumptions,
+        macro: { ...defaultAssumptions.macro, inflationAdjusted: false },
+    }
+): TaxParameters | undefined {
+    const inflation = assumptions.macro.inflationRate / 100;
+    const inflationAdjusted = assumptions.macro.inflationAdjusted;
+
+    let sourceData: AuthorityData;
+    if (authority === "federal") {
+        sourceData = TAX_DATABASE.federal;
+    } else if (stateResidency && TAX_DATABASE.states[stateResidency]) {
+        sourceData = TAX_DATABASE.states[stateResidency];
+    } else {
+        return undefined;
+    }
+
+    const closestYear = getClosestTaxYear(year);
+
+    if (inflationAdjusted && year > max_year) {
+        // A state's table may not include the federal max_year row. Resolve the
+        // nearest year actually present and inflate from there (same nearest-year
+        // logic used by the non-inflation path below) instead of throwing.
+        let baseYear = max_year;
+        if (!sourceData[max_year]) {
+            const availableYears = Object.keys(sourceData)
+                .map(Number)
+                .filter((y) => !Number.isNaN(y));
+            if (availableYears.length === 0) return undefined;
+            baseYear = availableYears.reduce((best, y) =>
+                Math.abs(y - max_year) < Math.abs(best - max_year) ? y : best
+            );
+        }
+
+        const baseYearParams = sourceData[baseYear][filingStatus];
+        if (!baseYearParams) return undefined;
+
+        const yearsToCompound = year - baseYear;
+        const inflationMultiplier = Math.pow(1 + inflation, yearsToCompound);
+
+        const inflatedBrackets = baseYearParams.brackets.map((bracket) => ({
+            ...bracket,
+            threshold: Math.round(bracket.threshold * inflationMultiplier),
+        }));
+
+        return {
+            ...baseYearParams,
+            standardDeduction: Math.round(
+                baseYearParams.standardDeduction * inflationMultiplier
+            ),
+            socialSecurityWageBase: Math.round(
+                baseYearParams.socialSecurityWageBase * inflationMultiplier
+            ),
+            brackets: inflatedBrackets,
+            capitalGainsBrackets: baseYearParams.capitalGainsBrackets?.map((bracket) => ({
+                ...bracket,
+                threshold: Math.round(bracket.threshold * inflationMultiplier),
+            })),
+        };
+    }
+
+    if (sourceData[closestYear]) {
+        return sourceData[closestYear][filingStatus];
+    }
+
+    // State tables may not cover every federal year (e.g. California has no 2024
+    // entry), so getClosestTaxYear — which only knows federal years — can resolve
+    // to a year missing from this authority's table. Fall back to the nearest year
+    // actually present so the gap doesn't return undefined → $0 tax.
+    const availableYears = Object.keys(sourceData)
+        .map(Number)
+        .filter((y) => !Number.isNaN(y));
+    if (availableYears.length === 0) return undefined;
+    const nearestYear = availableYears.reduce((best, y) =>
+        Math.abs(y - year) < Math.abs(best - year) ? y : best
+    );
+    return sourceData[nearestYear]?.[filingStatus];
+}

--- a/src/components/Objects/Taxes/taxService/socialSecurity.ts
+++ b/src/components/Objects/Taxes/taxService/socialSecurity.ts
@@ -1,0 +1,85 @@
+import { FilingStatus } from "../../../../data/TaxData";
+
+/** Social Security combined income thresholds for benefit taxation */
+const SS_THRESHOLDS_SINGLE = { first: 25000, second: 34000 };
+const SS_THRESHOLDS_JOINT = { first: 32000, second: 44000 };
+
+/** Social Security taxation rates */
+const SS_TIER1_TAXABLE_RATE = 0.5;  // 50% of excess taxable in tier 1
+const SS_TIER2_TAXABLE_RATE = 0.85; // 85% of excess taxable in tier 2
+const SS_MAX_TAXABLE_RATE = 0.85;   // Maximum 85% of benefits can be taxed
+
+/**
+ * Calculate taxable portion of Social Security benefits.
+ *
+ * Combined Income = otherIncome + taxExemptInterest + 50% of SS Benefits
+ *
+ * Thresholds (not inflation-adjusted since 1984/1993):
+ * Single/MFS:
+ *   < $25,000: 0% taxable
+ *   $25,000-$34,000: Up to 50% taxable
+ *   > $34,000: Up to 85% taxable
+ *
+ * Married Filing Jointly:
+ *   < $32,000: 0% taxable
+ *   $32,000-$44,000: Up to 50% taxable
+ *   > $44,000: Up to 85% taxable
+ *
+ * @param totalSSBenefits - Gross Social Security benefits received
+ * @param otherIncome - All taxable income EXCEPT SS. Must include:
+ *                      - Wages and salaries
+ *                      - Pension income
+ *                      - Traditional IRA/401k withdrawals
+ *                      - Roth conversions
+ *                      - Long-term capital gains
+ *                      - Short-term capital gains
+ *                      - Qualified dividends
+ *                      - Ordinary dividends
+ *                      - Interest income
+ *                      - Rental income
+ *                      - Any other taxable income
+ * @param taxExemptInterest - Municipal bond interest. Not taxed federally, but DOES count
+ *                            toward SS combined income calculation. Pass 0 if not tracking.
+ *                            TODO: System does not currently track tax-exempt interest separately.
+ * @param filingStatus - Tax filing status (Single, MFJ, MFS)
+ * @returns Taxable portion of SS benefits (0 to 85% of totalSSBenefits)
+ */
+export function getTaxableSocialSecurityBenefits(
+    totalSSBenefits: number,
+    otherIncome: number,
+    taxExemptInterest: number,
+    filingStatus: FilingStatus,
+): number {
+    if (totalSSBenefits === 0) return 0;
+
+    // Combined income = otherIncome + taxExemptInterest + 50% of SS Benefits
+    const combinedIncome = otherIncome + taxExemptInterest + (totalSSBenefits * SS_TIER1_TAXABLE_RATE);
+
+    // Select thresholds based on filing status
+    const useSingleThresholds = filingStatus === 'Single' || filingStatus === 'Married Filing Separately';
+    const thresholds = useSingleThresholds ? SS_THRESHOLDS_SINGLE : SS_THRESHOLDS_JOINT;
+
+    // No SS benefits are taxable below first threshold
+    if (combinedIncome < thresholds.first) {
+        return 0;
+    }
+
+    // Up to 50% of SS benefits are taxable between first and second threshold
+    if (combinedIncome < thresholds.second) {
+        const excessAboveFirst = combinedIncome - thresholds.first;
+        const taxable50Percent = Math.min(
+            excessAboveFirst * SS_TIER1_TAXABLE_RATE,
+            totalSSBenefits * SS_TIER1_TAXABLE_RATE,
+        );
+        return Math.min(taxable50Percent, totalSSBenefits);
+    }
+
+    // Up to 85% of SS benefits are taxable above second threshold
+    const excessAboveSecond = combinedIncome - thresholds.second;
+    const tier1Amount = Math.min((thresholds.second - thresholds.first) * SS_TIER1_TAXABLE_RATE, totalSSBenefits * SS_TIER1_TAXABLE_RATE);
+    const tier2Amount = excessAboveSecond * SS_TIER2_TAXABLE_RATE;
+    const totalTaxable = tier1Amount + tier2Amount;
+
+    // Cap at 85% of total benefits
+    return Math.min(totalTaxable, totalSSBenefits * SS_MAX_TAXABLE_RATE);
+}

--- a/src/components/Objects/Taxes/taxService/stateTax.ts
+++ b/src/components/Objects/Taxes/taxService/stateTax.ts
@@ -1,0 +1,207 @@
+import { AnyExpense } from "../../Expense/models";
+import { AnyIncome } from "../../Income/models";
+import { TaxState } from "../TaxContext";
+import { AssumptionsState, getBirthYear } from "../../Assumptions/AssumptionsContext";
+import { getTaxParameters } from "./parameters";
+import {
+    getGrossIncome,
+    getPreTaxExemptions,
+    getSocialSecurityBenefits,
+} from "./incomeAggregation";
+import { getTaxableSocialSecurityBenefits } from "./socialSecurity";
+import { getItemizedDeductions, getYesDeductions } from "./deductions";
+import { calculateTax } from "./bracketTax";
+
+export function calculateStateTax(
+    state: TaxState,
+    incomes: AnyIncome[],
+    expenses: AnyExpense[],
+    year: number,
+    assumptions?: AssumptionsState,
+) {
+    if (state.stateOverride !== null) {
+        return state.stateOverride;
+    }
+
+    const annualGross = getGrossIncome(incomes, year);
+    const age = assumptions?.milestones ? year - getBirthYear(assumptions.milestones) : undefined;
+    const incomePreTaxDeductions = getPreTaxExemptions(incomes, year, age);
+    const expenseAboveLineDeductions = getYesDeductions(expenses, year);
+    const totalPreTaxDeductions = incomePreTaxDeductions + expenseAboveLineDeductions;
+
+    const itemizedTotal = getItemizedDeductions(expenses, year);
+    const stateParams = getTaxParameters(
+        year,
+        state.filingStatus,
+        "state",
+        state.stateResidency,
+        assumptions,
+    );
+
+    if (!stateParams) return 0;
+
+    // Social Security handling — data-driven `socialSecurityTreatment` defaults to 'exempt'.
+    const ssTreatment = stateParams.socialSecurityTreatment ?? 'exempt';
+    const totalSSBenefits = getSocialSecurityBenefits(incomes, year);
+    let adjustedGrossForState = annualGross;
+
+    if (totalSSBenefits > 0) {
+        if (ssTreatment === 'taxable') {
+            // States that tax SS: use only the taxable portion (like federal)
+            const nonSSGross = annualGross - totalSSBenefits;
+            const agiExcludingSS = nonSSGross - totalPreTaxDeductions;
+            // TODO: Verify all income types are included (LTCG, STCG, dividends, etc.)
+            const taxableSSBenefits = getTaxableSocialSecurityBenefits(
+                totalSSBenefits,
+                agiExcludingSS,
+                0,
+                state.filingStatus,
+            );
+            adjustedGrossForState = annualGross - totalSSBenefits + taxableSSBenefits;
+        } else if (ssTreatment === 'income-based') {
+            // TODO: Implement income-based SS exemption for states like CO, CT, etc.
+            // For now, treat as exempt (conservative).
+            adjustedGrossForState = annualGross - totalSSBenefits;
+        } else {
+            // 'exempt' — exclude SS benefits entirely
+            adjustedGrossForState = annualGross - totalSSBenefits;
+        }
+    }
+
+    // Senior deduction: per-person variants (e.g., Virginia) get doubled for MFJ
+    // (assumes both spouses meet the age threshold).
+    let seniorDeductionAmount = 0;
+    if (stateParams.seniorDeduction && age !== undefined) {
+        const seniorAge = stateParams.seniorAge ?? 65;
+        if (age >= seniorAge) {
+            seniorDeductionAmount = stateParams.seniorDeduction;
+            if (stateParams.seniorDeductionPerPerson && state.filingStatus === 'Married Filing Jointly') {
+                seniorDeductionAmount *= 2;
+            }
+        }
+    }
+
+    const stateStandardDeduction = (stateParams.standardDeduction || 0) + seniorDeductionAmount;
+
+    if (state.deductionMethod === "Auto") {
+        const taxWithStandard = calculateTax(adjustedGrossForState, totalPreTaxDeductions, {
+            ...stateParams,
+            standardDeduction: stateStandardDeduction,
+        });
+        const taxWithItemized = calculateTax(adjustedGrossForState, totalPreTaxDeductions, {
+            ...stateParams,
+            standardDeduction: itemizedTotal + seniorDeductionAmount,
+        });
+        return Math.min(taxWithStandard, taxWithItemized);
+    }
+
+    const stateAppliedMainDeduction =
+        state.deductionMethod === "Standard"
+            ? stateStandardDeduction
+            : itemizedTotal + seniorDeductionAmount;
+
+    return calculateTax(adjustedGrossForState, totalPreTaxDeductions, {
+        ...stateParams,
+        standardDeduction: stateAppliedMainDeduction,
+    });
+}
+
+/**
+ * Calculate state tax including additional ordinary income from withdrawals.
+ *
+ * @param state - Tax state
+ * @param incomes - Original income objects
+ * @param expenses - Expenses (for deductions)
+ * @param additionalOrdinaryIncome - Traditional withdrawals + Roth conversions + RMDs
+ * @param year - Tax year
+ * @param assumptions - Assumptions for inflation adjustments
+ * @returns State tax including all income sources
+ */
+export function calculateUnifiedStateTax(
+    state: TaxState,
+    incomes: AnyIncome[],
+    expenses: AnyExpense[],
+    additionalOrdinaryIncome: number,
+    year: number,
+    assumptions?: AssumptionsState,
+): number {
+    if (state.stateOverride !== null) {
+        return state.stateOverride;
+    }
+
+    const stateParams = getTaxParameters(
+        year,
+        state.filingStatus,
+        "state",
+        state.stateResidency,
+        assumptions,
+    );
+
+    if (!stateParams) return 0;
+
+    const incomeGross = getGrossIncome(incomes, year);
+    const annualGross = incomeGross + additionalOrdinaryIncome;
+
+    const age = assumptions?.milestones ? year - getBirthYear(assumptions.milestones) : undefined;
+    const incomePreTaxDeductions = getPreTaxExemptions(incomes, year, age);
+    const expenseAboveLineDeductions = getYesDeductions(expenses, year);
+    const totalPreTaxDeductions = incomePreTaxDeductions + expenseAboveLineDeductions;
+
+    const ssTreatment = stateParams.socialSecurityTreatment ?? 'exempt';
+    const totalSSBenefits = getSocialSecurityBenefits(incomes, year);
+    let adjustedGross = annualGross;
+
+    if (totalSSBenefits > 0) {
+        if (ssTreatment === 'taxable') {
+            const nonSSGross = annualGross - totalSSBenefits;
+            const agiExcludingSS = nonSSGross - totalPreTaxDeductions;
+            // TODO: Verify all income types are included (LTCG, STCG, dividends, etc.)
+            const taxableSSBenefits = getTaxableSocialSecurityBenefits(
+                totalSSBenefits,
+                agiExcludingSS,
+                0,
+                state.filingStatus,
+            );
+            adjustedGross = annualGross - totalSSBenefits + taxableSSBenefits;
+        } else if (ssTreatment === 'income-based') {
+            // TODO: Implement income-based SS exemption (CO, CT, etc.)
+            adjustedGross = annualGross - totalSSBenefits;
+        } else {
+            adjustedGross = annualGross - totalSSBenefits;
+        }
+    }
+
+    let seniorDeductionAmount = 0;
+    if (stateParams.seniorDeduction && age !== undefined) {
+        const seniorAge = stateParams.seniorAge ?? 65;
+        if (age >= seniorAge) {
+            seniorDeductionAmount = stateParams.seniorDeduction;
+            if (stateParams.seniorDeductionPerPerson && state.filingStatus === 'Married Filing Jointly') {
+                seniorDeductionAmount *= 2;
+            }
+        }
+    }
+
+    const itemizedTotal = getItemizedDeductions(expenses, year);
+    const stateStandardDeduction = (stateParams.standardDeduction || 0) + seniorDeductionAmount;
+
+    if (state.deductionMethod === "Auto") {
+        const taxWithStandard = calculateTax(adjustedGross, totalPreTaxDeductions, {
+            ...stateParams,
+            standardDeduction: stateStandardDeduction,
+        });
+        const taxWithItemized = calculateTax(adjustedGross, totalPreTaxDeductions, {
+            ...stateParams,
+            standardDeduction: itemizedTotal + seniorDeductionAmount,
+        });
+        return Math.min(taxWithStandard, taxWithItemized);
+    }
+
+    const stateAppliedMainDeduction =
+        state.deductionMethod === "Standard" ? stateStandardDeduction : itemizedTotal + seniorDeductionAmount;
+
+    return calculateTax(adjustedGross, totalPreTaxDeductions, {
+        ...stateParams,
+        standardDeduction: stateAppliedMainDeduction,
+    });
+}

--- a/src/data/ContributionLimits.ts
+++ b/src/data/ContributionLimits.ts
@@ -1,0 +1,181 @@
+/**
+ * Retirement Account Contribution Limits
+ *
+ * IRS contribution limits for 401k, IRA, and HSA accounts by year.
+ * Used for tax optimization recommendations.
+ */
+
+export interface YearlyContributionLimits {
+  // 401k limits
+  traditional401k: number;      // Also applies to Roth 401k (combined limit)
+  catchUp401k: number;          // Additional amount for age 50+
+
+  // IRA limits
+  traditionalIRA: number;       // Also applies to Roth IRA (combined limit)
+  catchUpIRA: number;           // Additional amount for age 50+
+
+  // HSA limits
+  hsaIndividual: number;        // Self-only coverage
+  hsaFamily: number;            // Family coverage
+  catchUpHSA: number;           // Additional amount for age 55+
+
+  // §415(c) annual-additions limit: combined cap on employee (pre-tax + Roth)
+  // + employer contributions to a single defined-contribution plan.
+  // Catch-up contributions are ON TOP of this limit (handled via get415cLimit).
+  section415c: number;
+}
+
+const CONTRIBUTION_LIMITS: Record<number, YearlyContributionLimits> = {
+  2024: {
+    traditional401k: 23000,
+    catchUp401k: 7500,
+    traditionalIRA: 7000,
+    catchUpIRA: 1000,
+    hsaIndividual: 4150,
+    hsaFamily: 8300,
+    catchUpHSA: 1000,
+    section415c: 69000,
+  },
+  2025: {
+    traditional401k: 23500,
+    catchUp401k: 7500,
+    traditionalIRA: 7000,
+    catchUpIRA: 1000,
+    hsaIndividual: 4300,
+    hsaFamily: 8550,
+    catchUpHSA: 1000,
+    section415c: 70000,
+  },
+  2026: {
+    traditional401k: 24500,     // Projected
+    catchUp401k: 7500,
+    traditionalIRA: 7500,
+    catchUpIRA: 1000,
+    hsaIndividual: 4400,        // Projected
+    hsaFamily: 8750,            // Projected
+    catchUpHSA: 1000,
+    section415c: 71000,         // Projected
+  },
+};
+
+/**
+ * Get contribution limits for a specific year.
+ * Falls back to closest available year if exact year not found.
+ *
+ * @param year - The tax year to get limits for
+ * @param inflationAdjusted - If true (default), projects future years with ~2.5% growth.
+ *                            If false, uses latest known values without projection.
+ */
+export function getContributionLimits(year: number, inflationAdjusted: boolean = true): YearlyContributionLimits {
+  if (CONTRIBUTION_LIMITS[year]) {
+    return CONTRIBUTION_LIMITS[year];
+  }
+
+  // Find closest year
+  const years = Object.keys(CONTRIBUTION_LIMITS).map(Number).sort((a, b) => a - b);
+
+  if (year < years[0]) {
+    return CONTRIBUTION_LIMITS[years[0]];
+  }
+
+  // For future years beyond our data
+  const latestYear = years[years.length - 1];
+  const latestLimits = CONTRIBUTION_LIMITS[latestYear];
+
+  // If not inflation adjusted (real dollars mode), use latest known values
+  if (!inflationAdjusted) {
+    return latestLimits;
+  }
+
+  // Project forward with assumed ~2.5% annual increase
+  const yearsAhead = year - latestYear;
+  const inflationFactor = Math.pow(1.025, yearsAhead);
+
+  return {
+    traditional401k: Math.round(latestLimits.traditional401k * inflationFactor / 500) * 500,
+    catchUp401k: latestLimits.catchUp401k,  // Catch-up tends to stay flat
+    traditionalIRA: Math.round(latestLimits.traditionalIRA * inflationFactor / 500) * 500,
+    catchUpIRA: latestLimits.catchUpIRA,
+    hsaIndividual: Math.round(latestLimits.hsaIndividual * inflationFactor / 50) * 50,
+    hsaFamily: Math.round(latestLimits.hsaFamily * inflationFactor / 50) * 50,
+    catchUpHSA: latestLimits.catchUpHSA,
+    section415c: Math.round(latestLimits.section415c * inflationFactor / 1000) * 1000,
+  };
+}
+
+/**
+ * Get the 401k contribution limit for a specific year and age.
+ */
+export function get401kLimit(year: number, age: number, inflationAdjusted: boolean = true): number {
+  const limits = getContributionLimits(year, inflationAdjusted);
+  const base = limits.traditional401k;
+  const catchUp = age >= 50 ? (age >= 60 && age <= 63 ? Math.round(limits.catchUp401k * 1.5) : limits.catchUp401k) : 0;
+  return base + catchUp;
+}
+
+/**
+ * Get the §415(c) annual-additions limit for a specific year and age.
+ *
+ * This caps the COMBINED employee (pre-tax + Roth) + employer contributions to
+ * a single defined-contribution (401k) plan. Per IRS rules, age 50+ catch-up
+ * contributions are allowed ON TOP of the §415(c) limit, so we add the same
+ * catch-up amount used by get401kLimit (including the 60-63 super catch-up).
+ */
+export function get415cLimit(year: number, age: number, inflationAdjusted: boolean = true): number {
+  const limits = getContributionLimits(year, inflationAdjusted);
+  const base = limits.section415c;
+  const catchUp = age >= 50 ? (age >= 60 && age <= 63 ? Math.round(limits.catchUp401k * 1.5) : limits.catchUp401k) : 0;
+  return base + catchUp;
+}
+
+/**
+ * Get the IRA contribution limit for a specific year and age.
+ */
+export function getIRALimit(year: number, age: number, inflationAdjusted: boolean = true): number {
+  const limits = getContributionLimits(year, inflationAdjusted);
+  const base = limits.traditionalIRA;
+  const catchUp = age >= 50 ? limits.catchUpIRA : 0;
+  return base + catchUp;
+}
+
+/**
+ * Get the HSA contribution limit for a specific year, age, and coverage type.
+ */
+export function getHSALimit(
+  year: number,
+  age: number,
+  coverage: 'individual' | 'family',
+  inflationAdjusted: boolean = true
+): number {
+  const limits = getContributionLimits(year, inflationAdjusted);
+  const base = coverage === 'family' ? limits.hsaFamily : limits.hsaIndividual;
+  const catchUp = age >= 55 ? limits.catchUpHSA : 0;
+  return base + catchUp;
+}
+
+/**
+ * Calculate potential tax savings from maxing out a retirement account.
+ */
+export function calculateContributionTaxSavings(
+  currentContribution: number,
+  limit: number,
+  marginalTaxRate: number
+): { additionalContribution: number; taxSavings: number } {
+  const additionalContribution = Math.max(0, limit - currentContribution);
+  const taxSavings = additionalContribution * marginalTaxRate;
+  return { additionalContribution, taxSavings };
+}
+
+/**
+ * Get the ESPP (Employee Stock Purchase Plan) FMV limit.
+ *
+ * IRS limits ESPP purchases to $25,000 of stock Fair Market Value per calendar year.
+ * This is measured at the grant date FMV, not the purchase date.
+ * Note: This is not the amount you can contribute, but the FMV of shares you can acquire.
+ *
+ * @returns Annual ESPP FMV limit ($25,000)
+ */
+export function getESPPLimit(): number {
+  // ESPP limit is fixed at $25,000 FMV and is not adjusted for inflation
+  return 25000;
+}

--- a/src/data/PensionData.tsx
+++ b/src/data/PensionData.tsx
@@ -1,0 +1,396 @@
+/**
+ * Federal Pension Data - FERS and CSRS
+ *
+ * This file contains official federal pension data used for calculating retirement benefits:
+ * - FERS (Federal Employees Retirement System) - for employees hired after 1983
+ * - CSRS (Civil Service Retirement System) - for employees hired before 1984
+ *
+ * Sources:
+ * - OPM FERS: https://www.opm.gov/retirement-center/fers-information/
+ * - OPM CSRS: https://www.opm.gov/retirement-center/csrs-information/
+ * - OPM FERS Supplement: https://www.opm.gov/retirement-center/fers-information/types-of-retirement/#annuity-supplement
+ */
+
+export type PensionSystem = 'FERS' | 'CSRS';
+
+/**
+ * FERS Minimum Retirement Age (MRA) by Birth Year
+ *
+ * The MRA is the earliest age at which a FERS employee can retire
+ * with an immediate (unreduced) annuity with at least 30 years of service.
+ *
+ * For those born 1970 or later: MRA = 57
+ */
+const FERS_MRA_BY_BIRTH_YEAR: Record<number, number> = {
+  1948: 55.167, // 55 years 2 months
+  1949: 55.333, // 55 years 4 months
+  1950: 55.5,   // 55 years 6 months
+  1951: 55.667, // 55 years 8 months
+  1952: 55.833, // 55 years 10 months
+  1953: 56,
+  1954: 56,
+  1955: 56,
+  1956: 56,
+  1957: 56,
+  1958: 56,
+  1959: 56,
+  1960: 56,
+  1961: 56,
+  1962: 56,
+  1963: 56,
+  1964: 56,
+  1965: 56.167, // 56 years 2 months
+  1966: 56.333, // 56 years 4 months
+  1967: 56.5,   // 56 years 6 months
+  1968: 56.667, // 56 years 8 months
+  1969: 56.833, // 56 years 10 months
+  // All birth years 1970+ have MRA of 57
+};
+
+/**
+ * Get FERS MRA for a given birth year
+ * Returns 57 for birth years 1970 and later
+ */
+export function getFERSMRA(birthYear: number): number {
+  if (birthYear >= 1970) return 57;
+  if (birthYear < 1948) return 55;
+  return FERS_MRA_BY_BIRTH_YEAR[birthYear] || 57;
+}
+
+/**
+ * FERS Retirement Eligibility Rules
+ *
+ * Immediate, unreduced retirement:
+ * - Age 62 with 5+ years of service
+ * - Age 60 with 20+ years of service
+ * - MRA with 30+ years of service
+ *
+ * Immediate, reduced retirement (MRA+10):
+ * - MRA with 10+ years of service (reduced by 5% per year under 62)
+ *
+ * Early retirement (RIF/VERA):
+ * - Age 50 with 20+ years, or any age with 25+ years (during RIF/VERA)
+ */
+export interface FERSEligibilityResult {
+  eligible: boolean;
+  reductionPercent: number;
+  message: string;
+}
+
+/**
+ * Check FERS retirement eligibility and calculate any reduction
+ */
+export function checkFERSEligibility(
+  age: number,
+  yearsOfService: number,
+  birthYear: number
+): FERSEligibilityResult {
+  const mra = getFERSMRA(birthYear);
+
+  // Age 62 with 5+ years - full benefit
+  if (age >= 62 && yearsOfService >= 5) {
+    return { eligible: true, reductionPercent: 0, message: 'Full retirement at 62 with 5+ years' };
+  }
+
+  // Age 60 with 20+ years - full benefit
+  if (age >= 60 && yearsOfService >= 20) {
+    return { eligible: true, reductionPercent: 0, message: 'Full retirement at 60 with 20+ years' };
+  }
+
+  // MRA with 30+ years - full benefit
+  if (age >= mra && yearsOfService >= 30) {
+    return { eligible: true, reductionPercent: 0, message: 'Full retirement at MRA with 30+ years' };
+  }
+
+  // MRA with 10-29 years - reduced benefit (5% per year under 62)
+  if (age >= mra && yearsOfService >= 10) {
+    const yearsUnder62 = Math.max(0, 62 - age);
+    const reduction = yearsUnder62 * 5;
+    return {
+      eligible: true,
+      reductionPercent: reduction,
+      message: `MRA+10 retirement with ${reduction}% reduction`
+    };
+  }
+
+  return { eligible: false, reductionPercent: 0, message: 'Not yet eligible for retirement' };
+}
+
+/**
+ * FERS Basic Benefit Calculation
+ *
+ * Formula: Years of Service × High-3 × Multiplier
+ *
+ * Multiplier:
+ * - 1% per year of service
+ * - 1.1% per year if retiring at age 62+ with 20+ years of service
+ *
+ * @param yearsOfService Total years of creditable federal service
+ * @param high3 Average of highest 3 consecutive years of basic pay
+ * @param retirementAge Age at retirement
+ * @returns Annual pension amount before any reductions
+ */
+export function calculateFERSBasicBenefit(
+  yearsOfService: number,
+  high3: number,
+  retirementAge: number
+): number {
+  // 1.1% multiplier if retiring at 62+ with 20+ years
+  const multiplier = (retirementAge >= 62 && yearsOfService >= 20) ? 0.011 : 0.01;
+  return yearsOfService * high3 * multiplier;
+}
+
+/**
+ * FERS Supplement Calculation
+ *
+ * The FERS Supplement is a temporary benefit paid from retirement until age 62,
+ * designed to bridge the gap until Social Security becomes available.
+ *
+ * Formula: (Years of FERS service / 40) × Estimated SS benefit at age 62
+ *
+ * Notes:
+ * - Only available if retiring before age 62
+ * - Subject to Social Security earnings test if working
+ * - Ends at age 62 (when actual SS becomes available)
+ * - Not available for MRA+10 (early reduced) retirees unless they meet exception
+ *
+ * @param yearsOfService Total years of FERS service
+ * @param estimatedSSAt62 Estimated monthly Social Security benefit at age 62
+ * @returns Annual FERS Supplement amount
+ */
+export function calculateFERSSupplement(
+  yearsOfService: number,
+  estimatedSSAt62: number
+): number {
+  // Monthly supplement = (years / 40) × monthly SS at 62
+  const monthlySupplementAmount = (yearsOfService / 40) * estimatedSSAt62;
+  return monthlySupplementAmount * 12;
+}
+
+/**
+ * FERS COLA (Cost of Living Adjustment)
+ *
+ * FERS retirees under age 62 do not receive COLA.
+ * FERS retirees 62+ receive:
+ * - CPI < 2%: Full COLA
+ * - CPI 2-3%: 2% COLA
+ * - CPI > 3%: CPI - 1% COLA
+ *
+ * @param inflation Annual inflation rate (as decimal, e.g., 0.03 for 3%)
+ * @param age Current age of retiree
+ * @returns COLA rate to apply (as decimal)
+ */
+export function getFERSCOLA(inflation: number, age: number): number {
+  // No COLA for FERS retirees under 62
+  if (age < 62) return 0;
+
+  // Full COLA if inflation under 2%
+  if (inflation <= 0.02) return inflation;
+
+  // 2% if inflation between 2-3%
+  if (inflation <= 0.03) return 0.02;
+
+  // CPI - 1% if inflation over 3%
+  return inflation - 0.01;
+}
+
+/**
+ * CSRS Basic Benefit Calculation
+ *
+ * CSRS uses a more generous graduated formula:
+ * - 1.5% × High-3 × first 5 years of service
+ * - 1.75% × High-3 × next 5 years of service (years 6-10)
+ * - 2.0% × High-3 × all years over 10
+ *
+ * Maximum benefit is capped at 80% of High-3.
+ *
+ * @param yearsOfService Total years of creditable federal service
+ * @param high3 Average of highest 3 consecutive years of basic pay
+ * @returns Annual pension amount
+ */
+export function calculateCSRSBasicBenefit(
+  yearsOfService: number,
+  high3: number
+): number {
+  let benefit = 0;
+
+  // First 5 years at 1.5%
+  const first5 = Math.min(yearsOfService, 5);
+  benefit += first5 * high3 * 0.015;
+
+  // Years 6-10 at 1.75%
+  if (yearsOfService > 5) {
+    const next5 = Math.min(yearsOfService - 5, 5);
+    benefit += next5 * high3 * 0.0175;
+  }
+
+  // Years 11+ at 2.0%
+  if (yearsOfService > 10) {
+    const remaining = yearsOfService - 10;
+    benefit += remaining * high3 * 0.02;
+  }
+
+  // Cap at 80% of High-3
+  const maxBenefit = high3 * 0.80;
+  return Math.min(benefit, maxBenefit);
+}
+
+/**
+ * CSRS Retirement Eligibility
+ *
+ * Immediate retirement:
+ * - Age 62 with 5+ years
+ * - Age 60 with 20+ years
+ * - Age 55 with 30+ years
+ *
+ * Early retirement (voluntary):
+ * - Age 50 with 20+ years, or any age with 25+ years (reduced 2% per year under 55)
+ */
+export interface CSRSEligibilityResult {
+  eligible: boolean;
+  reductionPercent: number;
+  message: string;
+}
+
+export function checkCSRSEligibility(
+  age: number,
+  yearsOfService: number
+): CSRSEligibilityResult {
+  // Age 62 with 5+ years - full benefit
+  if (age >= 62 && yearsOfService >= 5) {
+    return { eligible: true, reductionPercent: 0, message: 'Full retirement at 62 with 5+ years' };
+  }
+
+  // Age 60 with 20+ years - full benefit
+  if (age >= 60 && yearsOfService >= 20) {
+    return { eligible: true, reductionPercent: 0, message: 'Full retirement at 60 with 20+ years' };
+  }
+
+  // Age 55 with 30+ years - full benefit
+  if (age >= 55 && yearsOfService >= 30) {
+    return { eligible: true, reductionPercent: 0, message: 'Full retirement at 55 with 30+ years' };
+  }
+
+  // Early retirement: Age 50 with 20+ years, or any age with 25+ years
+  if ((age >= 50 && yearsOfService >= 20) || yearsOfService >= 25) {
+    const yearsUnder55 = Math.max(0, 55 - age);
+    const reduction = yearsUnder55 * 2;
+    return {
+      eligible: true,
+      reductionPercent: Math.min(reduction, 10), // Cap reduction
+      message: `Early retirement with ${reduction}% reduction`
+    };
+  }
+
+  return { eligible: false, reductionPercent: 0, message: 'Not yet eligible for retirement' };
+}
+
+/**
+ * CSRS COLA (Cost of Living Adjustment)
+ *
+ * CSRS retirees receive full CPI-based COLA regardless of age.
+ * Calculated on the anniversary of retirement.
+ *
+ * @param inflation Annual inflation rate (as decimal, e.g., 0.03 for 3%)
+ * @returns COLA rate to apply (same as inflation)
+ */
+export function getCSRSCOLA(inflation: number): number {
+  return inflation;
+}
+
+/**
+ * Calculate High-3 from salary history
+ *
+ * The High-3 is the average of the highest 3 consecutive years of basic pay.
+ * For employees with less than 3 years, it's the average of their entire career.
+ *
+ * @param salaryHistory Array of annual salaries in chronological order
+ * @returns High-3 average
+ */
+export function calculateHigh3(salaryHistory: number[]): number {
+  if (salaryHistory.length === 0) return 0;
+  if (salaryHistory.length < 3) {
+    // Average of entire history if less than 3 years
+    return salaryHistory.reduce((a, b) => a + b, 0) / salaryHistory.length;
+  }
+
+  // Find highest 3 consecutive years
+  let maxAverage = 0;
+  for (let i = 0; i <= salaryHistory.length - 3; i++) {
+    const threeYearSum = salaryHistory[i] + salaryHistory[i + 1] + salaryHistory[i + 2];
+    const average = threeYearSum / 3;
+    maxAverage = Math.max(maxAverage, average);
+  }
+
+  return maxAverage;
+}
+
+/**
+ * Estimate High-3 from current salary and expected years until retirement
+ *
+ * Projects future salary growth to estimate what High-3 will be at retirement.
+ *
+ * @param currentSalary Current annual salary
+ * @param yearsUntilRetirement Years until planned retirement
+ * @param salaryGrowthRate Annual salary growth rate (default 2%)
+ * @returns Estimated High-3 at retirement
+ */
+export function estimateHigh3(
+  currentSalary: number,
+  yearsUntilRetirement: number,
+  salaryGrowthRate: number = 0.02
+): number {
+  if (yearsUntilRetirement <= 0) return currentSalary;
+
+  // Project salaries for the final 3 years before retirement
+  const year1 = currentSalary * Math.pow(1 + salaryGrowthRate, yearsUntilRetirement - 2);
+  const year2 = currentSalary * Math.pow(1 + salaryGrowthRate, yearsUntilRetirement - 1);
+  const year3 = currentSalary * Math.pow(1 + salaryGrowthRate, yearsUntilRetirement);
+
+  return (year1 + year2 + year3) / 3;
+}
+
+/**
+ * Early Retirement Reduction for FERS MRA+10
+ *
+ * If retiring at MRA with 10-29 years of service, benefit is reduced:
+ * - 5% for each year under age 62
+ * - Can be avoided by postponing annuity commencement until age 62
+ *
+ * @param retirementAge Age at retirement
+ * @returns Reduction factor (e.g., 0.75 for 25% reduction)
+ */
+export function getFERSEarlyReduction(retirementAge: number): number {
+  if (retirementAge >= 62) return 1.0;
+
+  const yearsUnder62 = 62 - retirementAge;
+  const reductionPercent = yearsUnder62 * 5; // 5% per year under 62
+  return 1 - (reductionPercent / 100);
+}
+
+/**
+ * Summary of pension system differences
+ */
+export const PENSION_SYSTEM_COMPARISON = {
+  FERS: {
+    name: 'Federal Employees Retirement System',
+    establishedYear: 1987,
+    components: ['Basic Benefit (defined benefit)', 'Social Security', 'TSP (401k-like)'],
+    basicBenefitFormula: '1% (or 1.1% at 62+/20yr) × High-3 × Years',
+    cola: 'Reduced (CPI-1% if CPI > 3%)',
+    socialSecurity: 'Yes, covered',
+    supplement: 'FERS Supplement available until age 62',
+    maxBenefit: 'No explicit cap (but practical limits based on years)',
+  },
+  CSRS: {
+    name: 'Civil Service Retirement System',
+    establishedYear: 1920,
+    closedYear: 1987,
+    components: ['Basic Benefit only (no SS, no TSP match)'],
+    basicBenefitFormula: '1.5%×5yr + 1.75%×5yr + 2%×remaining',
+    cola: 'Full CPI',
+    socialSecurity: 'No, not covered',
+    supplement: 'N/A (no SS to bridge to)',
+    maxBenefit: '80% of High-3',
+  },
+};

--- a/src/data/RMDData.ts
+++ b/src/data/RMDData.ts
@@ -1,0 +1,159 @@
+/**
+ * Required Minimum Distribution (RMD) Data and Calculations
+ *
+ * Based on IRS Uniform Lifetime Table (Table III)
+ * Used for account owners whose spouse is not more than 10 years younger
+ * or is not the sole beneficiary.
+ *
+ * SECURE Act 2.0 (2023): RMD age increased to 73
+ * Starting 2033: RMD age increases to 75
+ */
+
+// IRS Uniform Lifetime Table - Distribution Period by Age
+// Source: IRS Publication 590-B (updated for 2022+)
+const UNIFORM_LIFETIME_TABLE: Record<number, number> = {
+  72: 27.4,
+  73: 26.5,
+  74: 25.5,
+  75: 24.6,
+  76: 23.7,
+  77: 22.9,
+  78: 22.0,
+  79: 21.1,
+  80: 20.2,
+  81: 19.4,
+  82: 18.5,
+  83: 17.7,
+  84: 16.8,
+  85: 16.0,
+  86: 15.2,
+  87: 14.4,
+  88: 13.7,
+  89: 12.9,
+  90: 12.2,
+  91: 11.5,
+  92: 10.8,
+  93: 10.1,
+  94: 9.5,
+  95: 8.9,
+  96: 8.4,
+  97: 7.8,
+  98: 7.3,
+  99: 6.8,
+  100: 6.4,
+  101: 6.0,
+  102: 5.6,
+  103: 5.2,
+  104: 4.9,
+  105: 4.6,
+  106: 4.3,
+  107: 4.1,
+  108: 3.9,
+  109: 3.7,
+  110: 3.5,
+  111: 3.4,
+  112: 3.3,
+  113: 3.1,
+  114: 3.0,
+  115: 2.9,
+  116: 2.8,
+  117: 2.7,
+  118: 2.5,
+  119: 2.3,
+  120: 2.0,
+};
+
+/**
+ * Get the RMD starting age based on birth year
+ * SECURE Act 2.0 rules:
+ * - Born 1950 or earlier: Age 72
+ * - Born 1951-1959: Age 73
+ * - Born 1960 or later: Age 75 (starting 2033)
+ */
+export function getRMDStartAge(birthYear: number): number {
+  if (birthYear <= 1950) {
+    return 72;
+  } else if (birthYear <= 1959) {
+    return 73;
+  } else {
+    return 75;
+  }
+}
+
+/**
+ * Get the distribution period (life expectancy factor) for a given age
+ * Returns the divisor used to calculate RMD amount
+ */
+export function getDistributionPeriod(age: number): number {
+  // For ages below 72, no RMD required (but return a value for calculations)
+  if (age < 72) {
+    return UNIFORM_LIFETIME_TABLE[72];
+  }
+
+  // For ages above 120, use the 120 factor
+  if (age > 120) {
+    return UNIFORM_LIFETIME_TABLE[120];
+  }
+
+  return UNIFORM_LIFETIME_TABLE[age] ?? UNIFORM_LIFETIME_TABLE[120];
+}
+
+/**
+ * Calculate the Required Minimum Distribution for a single account
+ *
+ * @param priorYearEndBalance - Account balance as of December 31 of prior year
+ * @param age - Owner's age at end of current year
+ * @returns RMD amount for the year
+ */
+export function calculateRMD(priorYearEndBalance: number, age: number): number {
+  if (priorYearEndBalance <= 0 || age < 72) {
+    return 0;
+  }
+
+  const distributionPeriod = getDistributionPeriod(age);
+  return priorYearEndBalance / distributionPeriod;
+}
+
+/**
+ * Check if an account type is subject to RMDs
+ * Traditional accounts require RMDs; Roth accounts do not (during owner's lifetime)
+ */
+export function isAccountSubjectToRMD(taxType: string): boolean {
+  return taxType === 'Traditional 401k' || taxType === 'Traditional IRA';
+}
+
+/**
+ * Calculate the RMD penalty for failing to take the full distribution
+ * SECURE Act 2.0 reduced the penalty from 50% to 25%
+ * Can be further reduced to 10% if corrected within correction window
+ */
+export function calculateRMDPenalty(shortfall: number, correctedTimely: boolean = false): number {
+  if (shortfall <= 0) return 0;
+
+  const penaltyRate = correctedTimely ? 0.10 : 0.25;
+  return shortfall * penaltyRate;
+}
+
+/**
+ * Determine if RMDs are required for the given year based on age and birth year
+ */
+export function isRMDRequired(currentAge: number, birthYear: number): boolean {
+  const rmdStartAge = getRMDStartAge(birthYear);
+  return currentAge >= rmdStartAge;
+}
+
+export interface RMDCalculation {
+  accountName: string;
+  accountId: string;
+  priorYearBalance: number;
+  distributionPeriod: number;
+  rmdAmount: number;
+}
+
+export interface RMDSummary {
+  totalRMD: number;
+  accountBreakdown: RMDCalculation[];
+  rmdStartAge: number;
+  currentAge: number;
+  isRequired: boolean;
+}

--- a/src/data/SocialSecurityData.tsx
+++ b/src/data/SocialSecurityData.tsx
@@ -1,0 +1,484 @@
+/**
+ * Social Security Administration (SSA) Historical Data
+ *
+ * This file contains official SSA data used for calculating Social Security benefits:
+ * - Wage indexing factors (for adjusting historical earnings to current wage levels)
+ * - Bend points (thresholds used in Primary Insurance Amount calculation)
+ * - Maximum taxable earnings (Social Security wage base)
+ * - Full Retirement Age by birth year
+ *
+ * Sources:
+ * - SSA National Average Wage Index: https://www.ssa.gov/oact/cola/AWI.html
+ * - SSA Bend Points: https://www.ssa.gov/oact/cola/bendpoints.html
+ * - SSA Contribution and Benefit Base: https://www.ssa.gov/oact/cola/cbb.html
+ */
+
+/**
+ * Average Wage Index Factors
+ *
+ * Used to index historical earnings to age-60 wage levels.
+ * Formula: IndexedEarnings = ActualEarnings × (AvgWageAtAge60 / AvgWageInEarningYear)
+ *
+ * For earnings after age 60, no indexing is applied (factor = 1.0).
+ * The indexing year is typically when the worker turns 60.
+ *
+ * Example: For someone turning 62 in 2024 (born 1962):
+ * - They turned 60 in 2022
+ * - 2022 Average Wage Index = $63,795.13
+ * - For earnings in 2000 ($40,000): IndexedEarnings = $40,000 × (63795.13 / 32154.82) = $79,323
+ */
+const WAGE_INDEX_FACTORS: Record<number, number> = {
+  // Historical data from SSA (actual values)
+  1951: 2951.92,
+  1952: 3098.68,
+  1953: 3273.42,
+  1954: 3293.80,
+  1955: 3378.29,
+  1956: 3594.55,
+  1957: 3724.29,
+  1958: 3784.05,
+  1959: 3920.37,
+  1960: 4050.21,
+  1961: 4123.36,
+  1962: 4304.62,
+  1963: 4403.72,
+  1964: 4598.99,
+  1965: 4723.99,
+  1966: 4965.38,
+  1967: 5185.60,
+  1968: 5580.78,
+  1969: 5940.18,
+  1970: 6334.04,
+  1971: 6642.00,
+  1972: 7168.35,
+  1973: 7686.50,
+  1974: 8251.89,
+  1975: 8675.58,
+  1976: 9249.13,
+  1977: 9779.44,
+  1978: 10556.03,
+  1979: 11554.58,
+  1980: 12696.77,
+  1981: 13977.05,
+  1982: 14878.34,
+  1983: 15589.64,
+  1984: 16555.07,
+  1985: 17275.54,
+  1986: 17962.59,
+  1987: 18788.17,
+  1988: 19793.23,
+  1989: 20571.40,
+  1990: 21458.48,
+  1991: 21831.01,
+  1992: 22577.16,
+  1993: 23139.07,
+  1994: 23829.05,
+  1995: 24715.39,
+  1996: 25821.08,
+  1997: 27354.84,
+  1998: 29010.71,
+  1999: 30491.62,
+  2000: 32154.82,
+  2001: 32974.62,
+  2002: 33544.66,
+  2003: 34535.35,
+  2004: 35797.14,
+  2005: 36917.82,
+  2006: 38744.11,
+  2007: 40649.27,
+  2008: 41639.48,
+  2009: 40729.68,
+  2010: 41641.61,
+  2011: 42892.19,
+  2012: 44321.67,
+  2013: 44888.16,
+  2014: 46199.29,
+  2015: 47826.74,
+  2016: 48617.80,
+  2017: 50326.69,
+  2018: 52145.80,
+  2019: 54099.99,
+  2020: 55628.60,
+  2021: 58177.46,
+  2022: 63795.13,
+  2023: 66621.80, // Estimated based on SSA projections
+  2024: 68000.00, // Estimated
+  2025: 69700.00, // Projected (assume ~2.5% annual growth)
+  2026: 71400.00,
+  2027: 73200.00,
+  2028: 75000.00,
+  2029: 76900.00,
+  2030: 78800.00,
+};
+
+/**
+ * Bend Points by Year
+ *
+ * Used in the Primary Insurance Amount (PIA) calculation formula:
+ * PIA = (90% × first bend point) + (32% × amount between bend points) + (15% × amount above second bend point)
+ *
+ * Example for 2024:
+ * If AIME = $5,000/month:
+ * PIA = (0.90 × $1,115) + (0.32 × ($5,000 - $1,115)) + (0.15 × 0)
+ *     = $1,003.50 + $1,243.20 + $0
+ *     = $2,246.70/month
+ */
+const BEND_POINTS: Record<number, { first: number; second: number }> = {
+  2000: { first: 531, second: 3202 },
+  2001: { first: 561, second: 3381 },
+  2002: { first: 592, second: 3567 },
+  2003: { first: 606, second: 3653 },
+  2004: { first: 612, second: 3689 },
+  2005: { first: 627, second: 3779 },
+  2006: { first: 656, second: 3955 },
+  2007: { first: 680, second: 4100 },
+  2008: { first: 711, second: 4288 },
+  2009: { first: 744, second: 4483 },
+  2010: { first: 761, second: 4586 },
+  2011: { first: 749, second: 4517 },
+  2012: { first: 767, second: 4624 },
+  2013: { first: 791, second: 4768 },
+  2014: { first: 816, second: 4917 },
+  2015: { first: 826, second: 4980 },
+  2016: { first: 856, second: 5157 },
+  2017: { first: 885, second: 5336 },
+  2018: { first: 895, second: 5397 },
+  2019: { first: 926, second: 5583 },
+  2020: { first: 960, second: 5785 },
+  2021: { first: 996, second: 6002 },
+  2022: { first: 1024, second: 6172 },
+  2023: { first: 1115, second: 6721 },
+  2024: { first: 1174, second: 7078 },
+  2025: { first: 1200, second: 7240 }, // Projected based on wage growth
+  2026: { first: 1230, second: 7420 },
+  2027: { first: 1260, second: 7600 },
+  2028: { first: 1290, second: 7790 },
+  2029: { first: 1325, second: 7990 },
+  2030: { first: 1360, second: 8200 },
+};
+
+/**
+ * Social Security Wage Base (Maximum Taxable Earnings)
+ *
+ * The maximum amount of earnings subject to Social Security tax each year.
+ * Earnings above this cap are not taxed for Social Security and do not count toward benefit calculations.
+ *
+ * Example: In 2024, if you earn $200,000:
+ * - Only $168,600 counts for Social Security tax
+ * - Only $168,600 counts toward your benefit calculation
+ */
+const SS_WAGE_BASE: Record<number, number> = {
+  2000: 76200,
+  2001: 80400,
+  2002: 84900,
+  2003: 87000,
+  2004: 87900,
+  2005: 90000,
+  2006: 94200,
+  2007: 97500,
+  2008: 102000,
+  2009: 106800,
+  2010: 106800,
+  2011: 106800,
+  2012: 110100,
+  2013: 113700,
+  2014: 117000,
+  2015: 118500,
+  2016: 118500,
+  2017: 127200,
+  2018: 128400,
+  2019: 132900,
+  2020: 137700,
+  2021: 142800,
+  2022: 147000,
+  2023: 160200,
+  2024: 168600,
+  2025: 176100, // Projected
+  2026: 184500,
+  2027: 192600,
+  2028: 201300,
+  2029: 210400,
+  2030: 219900,
+};
+
+/**
+ * Full Retirement Age (FRA) by Birth Year
+ *
+ * The age at which you're entitled to 100% of your calculated Social Security benefit.
+ * Claiming before FRA reduces benefits; claiming after FRA increases them.
+ *
+ * Birth Year → FRA (in years, decimal for months)
+ * 1960+: 67 years
+ * 1959: 66 years 10 months = 66.833...
+ * 1958: 66 years 8 months = 66.666...
+ * 1955-1956: 66 years 2 months = 66.166...
+ * 1943-1954: 66 years
+ */
+const FRA_BY_BIRTH_YEAR: Record<number, number> = {
+  1937: 65,
+  1938: 65.167, // 65 years 2 months
+  1939: 65.333, // 65 years 4 months
+  1940: 65.5,   // 65 years 6 months
+  1941: 65.667, // 65 years 8 months
+  1942: 65.833, // 65 years 10 months
+  1943: 66,
+  1944: 66,
+  1945: 66,
+  1946: 66,
+  1947: 66,
+  1948: 66,
+  1949: 66,
+  1950: 66,
+  1951: 66,
+  1952: 66,
+  1953: 66,
+  1954: 66,
+  1955: 66.167, // 66 years 2 months
+  1956: 66.333, // 66 years 4 months
+  1957: 66.5,   // 66 years 6 months
+  1958: 66.667, // 66 years 8 months
+  1959: 66.833, // 66 years 10 months
+  1960: 67,
+  1961: 67,
+  1962: 67,
+  1963: 67,
+  1964: 67,
+  1965: 67,
+  1966: 67,
+  1967: 67,
+  1968: 67,
+  1969: 67,
+  1970: 67,
+  1971: 67,
+  1972: 67,
+  1973: 67,
+  1974: 67,
+  1975: 67,
+  1976: 67,
+  1977: 67,
+  1978: 67,
+  1979: 67,
+  1980: 67,
+  1981: 67,
+  1982: 67,
+  1983: 67,
+  1984: 67,
+  1985: 67,
+  1986: 67,
+  1987: 67,
+  1988: 67,
+  1989: 67,
+  1990: 67,
+  1991: 67,
+  1992: 67,
+  1993: 67,
+  1994: 67,
+  1995: 67,
+  1996: 67,
+  1997: 67,
+  1998: 67,
+  1999: 67,
+  2000: 67,
+  2001: 67,
+  2002: 67,
+  2003: 67,
+  2004: 67,
+  2005: 67,
+};
+
+/**
+ * Claiming Age Adjustment Factors
+ *
+ * Multipliers applied to PIA based on claiming age:
+ * - Age 62: 70% (30% reduction for claiming 5 years early)
+ * - Age 63: 75% (25% reduction)
+ * - Age 64: 80% (20% reduction)
+ * - Age 65: 86.7% (13.3% reduction)
+ * - Age 66: 93.3% (6.7% reduction)
+ * - Age 67 (FRA): 100% (no adjustment)
+ * - Age 68: 108% (8% increase per year)
+ * - Age 69: 116%
+ * - Age 70: 124% (maximum, 24% increase)
+ *
+ * Early claiming (before FRA): ~6.67% reduction per year (actually 5/9 of 1% per month for first 36 months, then 5/12 of 1%)
+ * Delayed claiming (after FRA): 8% increase per year (actually 2/3 of 1% per month)
+ */
+/**
+ * Helper function to get claiming age adjustment factor.
+ * Calculates the benefit adjustment based on claiming age relative to Full Retirement Age (FRA).
+ *
+ * Early claiming (before FRA):
+ *   - First 36 months early: 5/9 of 1% reduction per month
+ *   - Additional months early: 5/12 of 1% reduction per month
+ *
+ * Delayed claiming (after FRA):
+ *   - 2/3 of 1% increase per month (8% per year)
+ *
+ * Valid claiming range: 62-70. Ages outside this range use the boundary values.
+ */
+export function getClaimingAdjustment(claimingAge: number, fra: number = 67): number {
+  // Clamp to valid claiming range (62-70)
+  const effectiveAge = Math.max(62, Math.min(70, claimingAge));
+
+  const monthsFromFRA = (effectiveAge - fra) * 12;
+
+  if (effectiveAge < fra) {
+    // Early claiming reduction
+    // First 36 months: 5/9 of 1% per month
+    // Additional months: 5/12 of 1% per month
+    const firstReduction = Math.min(36, Math.abs(monthsFromFRA)) * (5 / 9) * 0.01;
+    const additionalReduction = Math.max(0, Math.abs(monthsFromFRA) - 36) * (5 / 12) * 0.01;
+    return 1.0 - firstReduction - additionalReduction;
+  } else {
+    // Delayed claiming increase
+    // 2/3 of 1% per month (8% per year)
+    const increase = monthsFromFRA * (2 / 3) * 0.01;
+    return 1.0 + increase;
+  }
+}
+
+/**
+ * Helper function to get Full Retirement Age for a birth year
+ * Returns 67 for birth years 1960 and later
+ */
+export function getFRA(birthYear: number): number {
+  if (birthYear >= 1960) return 67;
+  if (birthYear < 1937) return 65;
+  return FRA_BY_BIRTH_YEAR[birthYear] || 67;
+}
+
+/**
+ * Generic helper to look up yearly data with future projection support.
+ * Reduces code duplication across getWageIndexFactor, getBendPoints, getWageBase, etc.
+ */
+export function lookupYearlyData<T>(
+  data: Record<number, T>,
+  year: number,
+  projectFuture: (baseValue: T, growthMultiplier: number) => T,
+  wageGrowthRate: number,
+  inflationAdjusted: boolean
+): T {
+  if (data[year]) {
+    return data[year];
+  }
+
+  const years = Object.keys(data).map(Number);
+  const latestYear = Math.max(...years);
+  const earliestYear = Math.min(...years);
+
+  if (year > latestYear) {
+    const baseValue = data[latestYear];
+    if (!inflationAdjusted) {
+      return baseValue;
+    }
+    const yearsToProject = year - latestYear;
+    const growthMultiplier = Math.pow(1 + wageGrowthRate, yearsToProject);
+    return projectFuture(baseValue, growthMultiplier);
+  }
+
+  return data[earliestYear];
+}
+
+/**
+ * Helper function to get wage index factor for a given year.
+ * For future years beyond available data, projects based on wage growth.
+ */
+export function getWageIndexFactor(
+  year: number,
+  wageGrowthRate: number = 0.025,
+  inflationAdjusted: boolean = true
+): number {
+  return lookupYearlyData(
+    WAGE_INDEX_FACTORS,
+    year,
+    (base, multiplier) => Math.round(base * multiplier * 100) / 100,
+    wageGrowthRate,
+    inflationAdjusted
+  );
+}
+
+/**
+ * Helper function to get bend points for a given year.
+ * For future years, uses projection based on wage growth.
+ */
+export function getBendPoints(
+  year: number,
+  wageGrowthRate: number = 0.025,
+  inflationAdjusted: boolean = true
+): { first: number; second: number } {
+  return lookupYearlyData(
+    BEND_POINTS,
+    year,
+    (base, multiplier) => ({
+      first: Math.round(base.first * multiplier),
+      second: Math.round(base.second * multiplier)
+    }),
+    wageGrowthRate,
+    inflationAdjusted
+  );
+}
+
+/**
+ * Helper function to get wage base for a given year.
+ * For future years, projects based on wage growth.
+ */
+export function getWageBase(
+  year: number,
+  wageGrowthRate: number = 0.025,
+  inflationAdjusted: boolean = true
+): number {
+  return lookupYearlyData(
+    SS_WAGE_BASE,
+    year,
+    (base, multiplier) => Math.round(base * multiplier / 100) * 100,
+    wageGrowthRate,
+    inflationAdjusted
+  );
+}
+
+/**
+ * Earnings Test Limits
+ *
+ * Annual earnings limits for the Social Security Retirement Earnings Test (RET).
+ * If you claim benefits before Full Retirement Age (FRA) and continue working:
+ * - Before FRA: $1 withheld for every $2 earned above limit
+ * - Year of FRA (before month of FRA): $1 withheld for every $3 earned above higher limit
+ * - After FRA: No earnings test applies
+ *
+ * Source: https://www.ssa.gov/oact/cola/rtea.html
+ */
+const EARNINGS_TEST_LIMITS: Record<number, { beforeFRA: number; yearOfFRA: number }> = {
+  2020: { beforeFRA: 18240, yearOfFRA: 48600 },
+  2021: { beforeFRA: 18960, yearOfFRA: 50520 },
+  2022: { beforeFRA: 19560, yearOfFRA: 51960 },
+  2023: { beforeFRA: 21240, yearOfFRA: 56520 },
+  2024: { beforeFRA: 22320, yearOfFRA: 59520 },
+  2025: { beforeFRA: 23400, yearOfFRA: 62160 },
+  // Future projections based on wage growth
+  2026: { beforeFRA: 24000, yearOfFRA: 63700 },
+  2027: { beforeFRA: 24600, yearOfFRA: 65300 },
+  2028: { beforeFRA: 25200, yearOfFRA: 67000 },
+  2029: { beforeFRA: 25850, yearOfFRA: 68700 },
+  2030: { beforeFRA: 26500, yearOfFRA: 70500 },
+};
+
+/**
+ * Helper function to get earnings test limit for a given year.
+ * For future years, projects based on wage growth.
+ */
+export function getEarningsTestLimit(
+  year: number,
+  wageGrowthRate: number = 0.025,
+  inflationAdjusted: boolean = true
+): { beforeFRA: number; yearOfFRA: number } {
+  return lookupYearlyData(
+    EARNINGS_TEST_LIMITS,
+    year,
+    (base, multiplier) => ({
+      beforeFRA: Math.round(base.beforeFRA * multiplier / 100) * 100,
+      yearOfFRA: Math.round(base.yearOfFRA * multiplier / 100) * 100
+    }),
+    wageGrowthRate,
+    inflationAdjusted
+  );
+}

--- a/src/data/TaxData.tsx
+++ b/src/data/TaxData.tsx
@@ -1,0 +1,873 @@
+export type FilingStatus = 'Single' | 'Married Filing Jointly' | 'Married Filing Separately';
+
+export interface TaxBracket {
+  threshold: number; // The income level where this rate begins
+  rate: number;      // Decimal (0.10 for 10%)
+}
+
+// State-specific Social Security treatment
+export type SocialSecurityTreatment = 'exempt' | 'taxable' | 'income-based';
+
+// State-specific long-term capital gains treatment
+export type LTCGTreatment = 'ordinary' | 'preferential' | 'exempt';
+
+// Retirement income exemption configuration
+export interface RetirementIncomeExemption {
+  amount: number;
+  appliesTo: ('pension' | '401k' | 'ira' | 'all')[];
+  ageRequirement?: number;
+  perPerson: boolean;
+}
+
+// Social Security exemption phaseout thresholds
+export interface SSExemptionPhaseout {
+  start: number;
+  end: number;
+}
+
+export interface TaxParameters {
+  standardDeduction: number;
+  brackets: TaxBracket[];
+  socialSecurityTaxRate: number; // FICA
+  socialSecurityWageBase: number;
+  medicareTaxRate: number;
+  // Long-term capital gains brackets (based on taxable income thresholds)
+  capitalGainsBrackets?: TaxBracket[];
+
+  // State-specific fields (all optional, for state use):
+  socialSecurityTreatment?: SocialSecurityTreatment;
+  ssExemptionThreshold?: number;
+  ssExemptionPhaseout?: SSExemptionPhaseout;
+  ltcgTreatment?: LTCGTreatment;
+  retirementIncomeExemption?: RetirementIncomeExemption;
+  seniorDeduction?: number;
+  seniorAge?: number;
+  seniorDeductionPerPerson?: boolean;  // If true, MFJ gets double the deduction (assumes both spouses same age)
+}
+
+export const max_year = 2026;
+
+
+/** * Hierarchical Lookups:
+ * AuthorityData: Year -> FilingStatus -> Parameters
+ */
+export type YearConfig = Record<FilingStatus, TaxParameters>;
+export type AuthorityData = Record<number, YearConfig>;
+
+export interface GlobalTaxDatabase {
+  federal: AuthorityData;
+  states: Record<string, AuthorityData>;
+}
+
+
+export const TAX_DATABASE: GlobalTaxDatabase = {
+    federal: {
+        2024: {
+            Single: {
+                standardDeduction: 14600,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 11600, rate: 0.12 },
+                    { threshold: 47151, rate: 0.22 },
+                    { threshold: 100526, rate: 0.24 },
+                    { threshold: 191951, rate: 0.32 },
+                    { threshold: 243726, rate: 0.35 },
+                    { threshold: 609350, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 47025, rate: 0.15 },
+                    { threshold: 518900, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 168600,
+                medicareTaxRate: 0.0145
+            },
+            'Married Filing Jointly': {
+                standardDeduction: 29200,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 23200, rate: 0.12 },
+                    { threshold: 94300, rate: 0.22 },
+                    { threshold: 201050, rate: 0.24 },
+                    { threshold: 383900, rate: 0.32 },
+                    { threshold: 487450, rate: 0.35 },
+                    { threshold: 731200, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 94050, rate: 0.15 },
+                    { threshold: 583750, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 168600,
+                medicareTaxRate: 0.0145
+            },
+            'Married Filing Separately': {
+                standardDeduction: 14600,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 11600, rate: 0.12 },
+                    { threshold: 47150, rate: 0.22 },
+                    { threshold: 100525, rate: 0.24 },
+                    { threshold: 191950, rate: 0.32 },
+                    { threshold: 243725, rate: 0.35 },
+                    { threshold: 365600, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 47025, rate: 0.15 },
+                    { threshold: 291850, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 168600,
+                medicareTaxRate: 0.0145
+            }
+        },
+        2025: {
+            Single: {
+                standardDeduction: 15750,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 11925, rate: 0.12 },
+                    { threshold: 48475, rate: 0.22 },
+                    { threshold: 103350, rate: 0.24 },
+                    { threshold: 197300, rate: 0.32 },
+                    { threshold: 250525, rate: 0.35 },
+                    { threshold: 626350, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 48350, rate: 0.15 },
+                    { threshold: 533400, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 176100,
+                medicareTaxRate: 0.0145
+            },
+            'Married Filing Jointly': {
+                standardDeduction: 31500,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 23850, rate: 0.12 },
+                    { threshold: 96950, rate: 0.22 },
+                    { threshold: 206700, rate: 0.24 },
+                    { threshold: 394600, rate: 0.32 },
+                    { threshold: 501050, rate: 0.35 },
+                    { threshold: 751600, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 96700, rate: 0.15 },
+                    { threshold: 600050, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 176100,
+                medicareTaxRate: 0.0145
+            },
+            'Married Filing Separately': {
+                standardDeduction: 15750,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 11925, rate: 0.12 },
+                    { threshold: 48475, rate: 0.22 },
+                    { threshold: 103350, rate: 0.24 },
+                    { threshold: 197300, rate: 0.32 },
+                    { threshold: 250525, rate: 0.35 },
+                    { threshold: 375800, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 48350, rate: 0.15 },
+                    { threshold: 300000, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 176100,
+                medicareTaxRate: 0.0145
+            }
+        },
+        2026: {
+            Single: {
+                standardDeduction: 16100,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 12400, rate: 0.12 },
+                    { threshold: 50400, rate: 0.22 },
+                    { threshold: 105700, rate: 0.24 },
+                    { threshold: 201775, rate: 0.32 },
+                    { threshold: 256225, rate: 0.35 },
+                    { threshold: 640600, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 49450, rate: 0.15 },
+                    { threshold: 545500, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 184500,
+                medicareTaxRate: 0.0145
+            },
+            'Married Filing Jointly': {
+                standardDeduction: 32200,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 24800, rate: 0.12 },
+                    { threshold: 100800, rate: 0.22 },
+                    { threshold: 211400, rate: 0.24 },
+                    { threshold: 403550, rate: 0.32 },
+                    { threshold: 512450, rate: 0.35 },
+                    { threshold: 768700, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 98900, rate: 0.15 },
+                    { threshold: 613700, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 184500,
+                medicareTaxRate: 0.0145
+            },
+            'Married Filing Separately': {
+                standardDeduction: 16100,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 12400, rate: 0.12 },
+                    { threshold: 50400, rate: 0.22 },
+                    { threshold: 105700, rate: 0.24 },
+                    { threshold: 201775, rate: 0.32 },
+                    { threshold: 256225, rate: 0.35 },
+                    { threshold: 384350, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 49450, rate: 0.15 },
+                    { threshold: 306850, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 184500,
+                medicareTaxRate: 0.0145
+            }
+        }
+    },
+    states: {
+        "California": {
+            2025: {
+                Single: {
+                    standardDeduction: 5540,
+                    brackets: [
+                        { threshold: 0, rate: 0.01 },
+                        { threshold: 10_757, rate: 0.02 },
+                        { threshold: 25_500, rate: 0.04 },
+                        { threshold: 40_246, rate: 0.06 },
+                        { threshold: 55_867, rate: 0.08 },
+                        { threshold: 70_607, rate: 0.093 },
+                        { threshold: 360_660, rate: 0.103 },
+                        { threshold: 432_788, rate: 0.113 },
+                        { threshold: 721_315, rate: 0.123 },
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 11080,
+                    brackets: [
+                        { threshold: 0, rate: 0.01 },
+                        { threshold: 21_513, rate: 0.02 },
+                        { threshold: 50_999, rate: 0.04 },
+                        { threshold: 80_491, rate: 0.06 },
+                        { threshold: 111_733, rate: 0.08 },
+                        { threshold: 141_213, rate: 0.093 },
+                        { threshold: 721_319, rate: 0.103 },
+                        { threshold: 865_575, rate: 0.113 },
+                        { threshold: 1_442_629, rate: 0.123 },
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 5540,
+                    brackets: [
+                        { threshold: 0, rate: 0.01 },
+                        { threshold: 10_757, rate: 0.02 },
+                        { threshold: 25_500, rate: 0.04 },
+                        { threshold: 40_246, rate: 0.06 },
+                        { threshold: 55_867, rate: 0.08 },
+                        { threshold: 70_607, rate: 0.093 },
+                        { threshold: 360_660, rate: 0.103 },
+                        { threshold: 432_788, rate: 0.113 },
+                        { threshold: 721_315, rate: 0.123 },
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                }
+            },
+            2026: {
+                Single: {
+                    standardDeduction: 5669,
+                    brackets: [
+                        { threshold: 0, rate: 0.01 },
+                        { threshold: 11_015, rate: 0.02 },
+                        { threshold: 26_111, rate: 0.04 },
+                        { threshold: 41_212, rate: 0.06 },
+                        { threshold: 57_208, rate: 0.08 },
+                        { threshold: 72_272, rate: 0.093 },
+                        { threshold: 369_156, rate: 0.103 },
+                        { threshold: 443_175, rate: 0.113 },
+                        { threshold: 738_628, rate: 0.123 },
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 11_338,
+                    brackets: [
+                        { threshold: 0, rate: 0.01 },
+                        { threshold: 22_030, rate: 0.02 },
+                        { threshold: 52_223, rate: 0.04 },
+                        { threshold: 82_423, rate: 0.06 },
+                        { threshold: 114_414, rate: 0.08 },
+                        { threshold: 144_542, rate: 0.093 },
+                        { threshold: 738_310, rate: 0.103 },
+                        { threshold: 885_974, rate: 0.113 },
+                        { threshold: 1_477_252, rate: 0.123 },
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 5669,
+                    brackets: [
+                        { threshold: 0, rate: 0.01 },
+                        { threshold: 11_015, rate: 0.02 },
+                        { threshold: 26_111, rate: 0.04 },
+                        { threshold: 41_212, rate: 0.06 },
+                        { threshold: 57_208, rate: 0.08 },
+                        { threshold: 72_272, rate: 0.093 },
+                        { threshold: 369_156, rate: 0.103 },
+                        { threshold: 443_175, rate: 0.113 },
+                        { threshold: 738_628, rate: 0.123 },
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                }
+            }
+        },
+        "DC": {
+            2024: {
+                Single: {
+                    standardDeduction: 14600,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 29200,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 14600,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+            },
+            2025: {
+                Single: {
+                    standardDeduction: 15000,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 30000,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 15000,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+            },
+            2026: {
+                Single: {
+                    standardDeduction: 15000,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 30000,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 15000,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+            }
+        },
+        "Texas": {
+            2024: {
+                Single: {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+            },
+            2025: {
+                Single: {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+            },
+            2026: {
+                Single: {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+            }
+        },
+        "North Carolina": {
+            // NC has a flat tax rate - 4.5% in 2024, 4.25% in 2025, 3.99% in 2026+
+            2024: {
+                Single: {
+                    standardDeduction: 12750,
+                    brackets: [
+                        { threshold: 0, rate: 0.045 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 25500,
+                    brackets: [
+                        { threshold: 0, rate: 0.045 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 12750,
+                    brackets: [
+                        { threshold: 0, rate: 0.045 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+            },
+            2025: {
+                Single: {
+                    standardDeduction: 12750,
+                    brackets: [
+                        { threshold: 0, rate: 0.0425 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 25500,
+                    brackets: [
+                        { threshold: 0, rate: 0.0425 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 12750,
+                    brackets: [
+                        { threshold: 0, rate: 0.0425 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+            },
+            2026: {
+                Single: {
+                    standardDeduction: 12750,
+                    brackets: [
+                        { threshold: 0, rate: 0.0399 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 25500,
+                    brackets: [
+                        { threshold: 0, rate: 0.0399 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 12750,
+                    brackets: [
+                        { threshold: 0, rate: 0.0399 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+            }
+        },
+        "Virginia": {
+            // VA has 4 brackets: 2%, 3%, 5%, 5.75%
+            // VA also has a $12k senior deduction at age 65+
+            2024: {
+                Single: {
+                    standardDeduction: 8500,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 17000,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true  // $24k total for MFJ (both spouses 65+)
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 8500,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true
+                },
+            },
+            2025: {
+                Single: {
+                    standardDeduction: 8750,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 17500,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true  // $24k total for MFJ (both spouses 65+)
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 8750,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true
+                },
+            },
+            2026: {
+                Single: {
+                    standardDeduction: 8750,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 17500,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true  // $24k total for MFJ (both spouses 65+)
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 8750,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true
+                },
+            }
+        }
+    }
+};
+
+export const getClosestTaxYear = (year: number): number => {
+    const availableYears = Object.keys(TAX_DATABASE.federal).map(Number);
+    if (availableYears.length === 0) {
+        throw new Error("No tax data available.");
+    }
+
+    return availableYears.reduce((prev, curr) => {
+        return (Math.abs(curr - year) < Math.abs(prev - year) ? curr : prev);
+    });
+ };

--- a/src/services/simulation/AccountGrowth.ts
+++ b/src/services/simulation/AccountGrowth.ts
@@ -1,0 +1,321 @@
+import { AnyAccount, InvestedAccount, SavedAccount, ESPPAccount, PropertyAccount, DebtAccount, DeficitDebtAccount, ESPPLot } from "../../components/Objects/Accounts/models";
+import { AnyExpense, MortgageExpense, LoanExpense } from "../../components/Objects/Expense/models";
+import { AnyIncome, WorkIncome, getIncomeActiveMultiplier } from "../../components/Objects/Income/models";
+import { AssumptionsState } from "../../components/Objects/Assumptions/AssumptionsContext";
+import { getESPPLimit, get415cLimit } from "../../data/ContributionLimits";
+import { WithdrawalState } from "./types";
+
+export interface InflowResult {
+    totalEmployerMatch: number;
+    totalBucketAllocations: number;
+    bucketDetail: Record<string, number>;
+    esppLots: Record<string, ESPPLot[]>;
+    discretionaryCash: number;
+    deficitDebtPayment: number;
+    logs: string[];
+}
+
+/**
+ * Process payroll contributions, employer match, ESPP purchases,
+ * deficit debt payments, and priority bucket allocations.
+ */
+export function processInflows(
+    incomesWithEarningsTest: AnyIncome[],
+    accounts: AnyAccount[],
+    assumptions: AssumptionsState,
+    year: number,
+    withdrawalState: WithdrawalState,
+    discretionaryCash: number,
+    _existingDeficitDebt: DeficitDebtAccount | undefined,
+    _totalLivingExpenses: number,
+    currentAge: number,
+    logs: string[]
+): InflowResult {
+    const bucketDetail: Record<string, number> = {};
+    let totalEmployerMatch = 0;
+    let totalBucketAllocations = 0;
+    const esppLots: Record<string, ESPPLot[]> = {};
+    let deficitDebtPayment = 0;
+
+    // 5a. Payroll & Match
+    incomesWithEarningsTest.forEach(inc => {
+        if (inc instanceof WorkIncome && inc.matchAccountId) {
+            const activeMultiplier = getIncomeActiveMultiplier(inc, year);
+            if (activeMultiplier === 0) return;
+
+            const currentSelf = withdrawalState.userInflows[inc.matchAccountId] || 0;
+            const currentMatch = withdrawalState.employerInflows[inc.matchAccountId] || 0;
+
+            // preTax401k/roth401k are per pay period; getProratedAnnual converts to the
+            // annual deposit (and already folds in the active-period multiplier).
+            const selfContribution = inc.getProratedAnnual(inc.preTax401k + inc.roth401k, year);
+            let employerMatch = inc.getEffectiveAnnualEmployerMatch() * activeMultiplier;
+
+            // Bug #11: enforce the §415(c) combined annual-additions limit
+            // (employee pre-tax + Roth + employer) for this 401k account. The
+            // §402(g) elective-deferral limit is handled at the income-model
+            // level (get401kLimit / getEffective401k); this is the separate,
+            // higher combined cap. Excess is removed from the employer match
+            // first, since the employee's own deferrals are already capped and
+            // are the participant's money. We clamp using the additions already
+            // routed to this account this year (currentSelf/currentMatch) plus
+            // this income's new contributions, so multiple incomes feeding one
+            // account share a single limit.
+            const limit415c = get415cLimit(year, currentAge, assumptions.macro.inflationAdjusted);
+            const totalAdditions = currentSelf + currentMatch + selfContribution + employerMatch;
+            if (totalAdditions > limit415c) {
+                const excess = totalAdditions - limit415c;
+                const trimmedMatch = Math.max(0, employerMatch - excess);
+                if (trimmedMatch < employerMatch) {
+                    logs.push(`[WARN] §415(c) limit: ${inc.name} employer match reduced by $${(employerMatch - trimmedMatch).toLocaleString(undefined, { maximumFractionDigits: 0 })} to stay within combined $${limit415c.toLocaleString()} 401k limit`);
+                }
+                employerMatch = trimmedMatch;
+            }
+
+            totalEmployerMatch += employerMatch;
+
+            withdrawalState.userInflows[inc.matchAccountId] = currentSelf + selfContribution;
+            withdrawalState.employerInflows[inc.matchAccountId] = currentMatch + employerMatch;
+        }
+    });
+
+    // 5a-2. ESPP Purchase Processing
+    let totalESPPFMVThisYear = 0;
+    const esppLimit = getESPPLimit();
+
+    incomesWithEarningsTest.forEach(inc => {
+        if (!(inc instanceof WorkIncome)) return;
+        if (inc.esppContributionType === 'NONE') return;
+        if (!inc.esppAccountId) return;
+
+        const activeMultiplier = getIncomeActiveMultiplier(inc, year);
+        if (activeMultiplier === 0) return;
+
+        const annualContribution = inc.getAnnualESPPContribution() * activeMultiplier;
+        if (annualContribution <= 0) return;
+
+        const esppAccount = accounts.find(acc => acc.id === inc.esppAccountId && acc instanceof ESPPAccount) as ESPPAccount | undefined;
+        if (!esppAccount) {
+            logs.push(`[WARN] ESPP account ${inc.esppAccountId} not found for ${inc.name}`);
+            return;
+        }
+
+        const purchaseContribution = annualContribution / 2;
+        const stockGrowthRate = inc.esppExpectedStockGrowth / 100;
+
+        for (let purchaseNum = 0; purchaseNum < 2; purchaseNum++) {
+            const grantMonth = purchaseNum * 6;
+            const purchaseMonth = grantMonth + 5;
+            const grantDate = new Date(Date.UTC(year, grantMonth, 1));
+            const purchaseDate = new Date(Date.UTC(year, purchaseMonth, 28));
+
+            const fmvAtGrant = 100;
+            const growthOverPeriod = Math.pow(1 + stockGrowthRate, 0.5);
+            const fmvAtPurchase = fmvAtGrant * growthOverPeriod;
+
+            let basePriceForDiscount: number;
+            if (inc.esppHasLookback) {
+                basePriceForDiscount = Math.min(fmvAtGrant, fmvAtPurchase);
+            } else {
+                basePriceForDiscount = fmvAtPurchase;
+            }
+
+            const discountPercent = inc.esppDiscountPercent / 100;
+            const purchasePrice = basePriceForDiscount * (1 - discountPercent);
+            const discountAmount = basePriceForDiscount - purchasePrice;
+
+            const shares = purchaseContribution / purchasePrice;
+            const fmvOfShares = shares * fmvAtPurchase;
+
+            if (totalESPPFMVThisYear + fmvOfShares > esppLimit) {
+                const remainingFMV = Math.max(0, esppLimit - totalESPPFMVThisYear);
+                if (remainingFMV <= 0) {
+                    logs.push(`[WARN] ESPP: ${inc.name} hit $25k annual limit - purchase skipped`);
+                    continue;
+                }
+                const reducedShares = remainingFMV / fmvAtPurchase;
+                const reducedContribution = reducedShares * purchasePrice;
+                logs.push(`[WARN] ESPP: ${inc.name} purchase reduced to stay within $25k limit`);
+
+                const lot: ESPPLot = {
+                    id: `LOT-${year}-${purchaseNum}-${inc.id}`,
+                    grantDate,
+                    purchaseDate,
+                    fmvAtGrant,
+                    fmvAtPurchase,
+                    purchasePrice,
+                    shares: reducedShares,
+                    totalCost: reducedContribution,
+                    discountAmount
+                };
+
+                withdrawalState.userInflows[esppAccount.id] = (withdrawalState.userInflows[esppAccount.id] || 0) + (reducedShares * fmvAtPurchase);
+                totalESPPFMVThisYear += remainingFMV;
+
+                if (!esppLots[esppAccount.id]) esppLots[esppAccount.id] = [];
+                esppLots[esppAccount.id].push(lot);
+            } else {
+                const lot: ESPPLot = {
+                    id: `LOT-${year}-${purchaseNum}-${inc.id}`,
+                    grantDate,
+                    purchaseDate,
+                    fmvAtGrant,
+                    fmvAtPurchase,
+                    purchasePrice,
+                    shares,
+                    totalCost: purchaseContribution,
+                    discountAmount
+                };
+
+                withdrawalState.userInflows[esppAccount.id] = (withdrawalState.userInflows[esppAccount.id] || 0) + fmvOfShares;
+                totalESPPFMVThisYear += fmvOfShares;
+
+                if (!esppLots[esppAccount.id]) esppLots[esppAccount.id] = [];
+                esppLots[esppAccount.id].push(lot);
+
+                logs.push(`[FLOW] ESPP: ${inc.name} purchased ${shares.toFixed(2)} shares @ $${purchasePrice.toFixed(2)} (${(discountPercent * 100).toFixed(0)}% discount${inc.esppHasLookback ? ' + lookback' : ''})`);
+            }
+        }
+    });
+
+    // Note: Deficit debt paydown and priority waterfall are handled by
+    // SurplusAllocator.allocateSurplus() in the V2 YearSolver path.
+
+    return {
+        totalEmployerMatch,
+        totalBucketAllocations,
+        bucketDetail,
+        esppLots,
+        discretionaryCash,
+        deficitDebtPayment,
+        logs
+    };
+}
+
+/**
+ * Grow all accounts: apply inflows, compound growth, handle ESPP lots, and linked data.
+ */
+export function growAccounts(
+    accounts: AnyAccount[],
+    expenses: AnyExpense[],
+    withdrawalState: WithdrawalState,
+    conversionDeposits: Record<string, number>,
+    esppLots: Record<string, ESPPLot[]>,
+    deficitDebtPayment: number,
+    existingDeficitDebt: DeficitDebtAccount | undefined,
+    assumptions: AssumptionsState,
+    year: number,
+    returnOverride: number | undefined,
+    _logs: string[]
+): AnyAccount[] {
+    const DEFICIT_DEBT_ID = 'system-deficit-debt';
+    const DEFICIT_DEBT_NAME = 'Uncovered Deficit';
+
+    // 6. LINKED DATA (Mortgages/Loans)
+    const linkedData = new Map<string, { balance: number; value?: number }>();
+    expenses.forEach(exp => {
+        if (exp instanceof MortgageExpense && exp.linkedAccountId) {
+            linkedData.set(exp.linkedAccountId, { balance: exp.loan_balance, value: exp.valuation });
+        } else if (exp instanceof LoanExpense && exp.linkedAccountId) {
+            linkedData.set(exp.linkedAccountId, { balance: exp.amount });
+        }
+    });
+
+    // 7. GROW ACCOUNTS
+    let nextAccounts: AnyAccount[] = accounts.map(acc => {
+        const userIn = withdrawalState.userInflows[acc.id] || 0;
+        const employerIn = withdrawalState.employerInflows[acc.id] || 0;
+        const totalIn = userIn + employerIn;
+
+        const linkedState = linkedData.get(acc.id);
+
+        if (acc instanceof PropertyAccount) {
+            let finalLoanBalance = linkedState?.balance;
+            if (finalLoanBalance !== undefined && totalIn > 0) {
+                finalLoanBalance = Math.max(0, finalLoanBalance - totalIn);
+            }
+            return acc.increment(assumptions, { newLoanBalance: finalLoanBalance, newValue: linkedState?.value });
+        }
+
+        if (acc instanceof DeficitDebtAccount) {
+            const newBalance = Math.max(0, acc.amount - deficitDebtPayment);
+            return acc.increment(assumptions, newBalance);
+        }
+
+        if (acc instanceof DebtAccount) {
+            let finalBalance = linkedState?.balance ?? (acc.amount * (1 + acc.apr / 100));
+            if (totalIn > 0) finalBalance = Math.max(0, finalBalance - totalIn);
+            return acc.increment(assumptions, finalBalance);
+        }
+
+        if (acc instanceof InvestedAccount) {
+            const convAmount = conversionDeposits[acc.id] || 0;
+            return acc.increment(assumptions, userIn, employerIn, returnOverride, convAmount, year);
+        }
+
+        if (acc instanceof SavedAccount) {
+            return acc.increment(assumptions, totalIn);
+        }
+
+        if (acc instanceof ESPPAccount) {
+            let workingAccount: ESPPAccount = acc;
+
+            // Apply any withdrawal (sale) recorded for this account: sell shares at the
+            // current (start-of-year) FMV per share before growth, using the account's
+            // configured lot-selling order. This keeps the ESPP balance conserved.
+            const grossWithdrawn = userIn < 0 ? -userIn : 0;
+            if (grossWithdrawn > 0) {
+                const totalShares = workingAccount.lots.reduce((sum, lot) => sum + lot.shares, 0);
+                const fmvPerShare = totalShares > 0 ? workingAccount.amount / totalShares : 0;
+                if (fmvPerShare > 0) {
+                    const sharesToSell = Math.min(totalShares, grossWithdrawn / fmvPerShare);
+                    // removeSoldShares only accepts 'fifo' | 'disqualifying_first' | 'qualifying_first'.
+                    // ESPPWithdrawalPreference also includes 'dont_sell_until_qualifying', which has no
+                    // direct sell-order equivalent here, so it falls back to 'fifo'.
+                    const pref = workingAccount.withdrawalPreference;
+                    const lotOrder: 'fifo' | 'disqualifying_first' | 'qualifying_first' =
+                        pref === 'disqualifying_first' || pref === 'qualifying_first' || pref === 'fifo'
+                            ? pref
+                            : 'fifo';
+                    workingAccount = workingAccount.removeSoldShares(sharesToSell, fmvPerShare, undefined, lotOrder);
+                }
+            }
+
+            let grownAccount = workingAccount.increment(assumptions, returnOverride);
+
+            const newLots = esppLots[acc.id] || [];
+            if (newLots.length > 0) {
+                for (const lot of newLots) {
+                    grownAccount = grownAccount.addLot(lot);
+                }
+            }
+
+            return grownAccount;
+        }
+
+        const _exhaustiveCheck: never = acc;
+        return _exhaustiveCheck;
+    });
+
+    // Handle deficit debt: either update existing, add new, or remove
+    if (existingDeficitDebt) {
+        const finalDeficitDebtBalance = existingDeficitDebt.amount - deficitDebtPayment;
+        const hasDeficitDebtInAccounts = nextAccounts.some(acc => acc.id === DEFICIT_DEBT_ID);
+
+        if (finalDeficitDebtBalance > 0) {
+            if (hasDeficitDebtInAccounts) {
+                nextAccounts = nextAccounts.map(acc =>
+                    acc.id === DEFICIT_DEBT_ID
+                        ? new DeficitDebtAccount(DEFICIT_DEBT_ID, DEFICIT_DEBT_NAME, finalDeficitDebtBalance)
+                        : acc
+                );
+            } else {
+                nextAccounts = [...nextAccounts, new DeficitDebtAccount(DEFICIT_DEBT_ID, DEFICIT_DEBT_NAME, finalDeficitDebtBalance)];
+            }
+        } else {
+            nextAccounts = nextAccounts.filter(acc => acc.id !== DEFICIT_DEBT_ID);
+        }
+    }
+
+    return nextAccounts;
+}

--- a/src/services/simulation/CashflowDetailBuilder.ts
+++ b/src/services/simulation/CashflowDetailBuilder.ts
@@ -1,0 +1,183 @@
+import {
+    AnyIncome,
+    WorkIncome,
+    PassiveIncome,
+    SocialSecurityIncome,
+    CurrentSocialSecurityIncome,
+    FutureSocialSecurityIncome,
+    FERSPensionIncome,
+    CSRSPensionIncome,
+} from "../../components/Objects/Income/models";
+import {
+    AnyExpense,
+    MortgageExpense,
+    CLASS_TO_CATEGORY,
+} from "../../components/Objects/Expense/models";
+import { AnyAccount, InvestedAccount } from "../../components/Objects/Accounts/models";
+import {
+    CashflowDetail,
+    CashflowIncomeKind,
+    CashflowIncomeSource,
+} from "./types";
+
+const MIN_AMOUNT = 0.005;
+
+interface BuildCashflowDetailInput {
+    /** Active incomes after earnings test, including RMD-sourced PassiveIncomes (shown as income). */
+    incomes: AnyIncome[];
+    /** Expenses after lifestyle creep + GK trim. */
+    expenses: AnyExpense[];
+    /** All accounts (used to resolve match account taxType and reinvested-income destinations). */
+    accounts: AnyAccount[];
+    /** Total payroll insurance deduction for the year. */
+    insurance: number;
+    year: number;
+    /**
+     * Sum of `w.tax` over the year's brokerage/ESPP withdrawals — the planner's
+     * LTCG estimate that was baked into the gross-up. Routed straight to the
+     * government, never lands as user cash. Stored on CashflowDetail so the
+     * Sankey can subtract it from the gross withdrawal inflow.
+     */
+    brokerageLTCGFromGross: number;
+    /**
+     * The ACTUAL employer match the sim deposited, keyed by destination account id
+     * (withdrawalState.employerInflows) — already §415(c)-trimmed by
+     * AccountGrowth.processInflows, so it is authoritative. When present, the
+     * Roth/pretax match split is derived from this map instead of recomputing via
+     * getEffectiveAnnualEmployerMatch (which ignores the §415(c) trim and overstates
+     * the match, breaking inflow=outflow for high earners at the combined 401k limit).
+     */
+    employerInflows?: Record<string, number>;
+}
+
+/**
+ * Build the per-year cashflow detail consumed by the Sankey chart.
+ *
+ * The sim already does all this math while running — this just packages
+ * the per-source breakdown into a stable shape so the chart doesn't have
+ * to re-derive it (and drift from the sim's actual values).
+ */
+export function buildCashflowDetail(input: BuildCashflowDetailInput): CashflowDetail {
+    const { incomes, expenses, accounts, insurance, year, brokerageLTCGFromGross, employerInflows } = input;
+
+    const incomeBySource: CashflowIncomeSource[] = [];
+    let userPreTax401k = 0;
+    let userRoth401k = 0;
+    let employerMatchPreTax = 0;
+    let employerMatchRoth = 0;
+
+    for (const inc of incomes) {
+        const amount = inc.getProratedAnnual ? inc.getProratedAnnual(inc.amount, year) : 0;
+
+        if (inc instanceof WorkIncome) {
+            // Track work-income contributions even when amount==0 is impossible here
+            // (inactive work incomes are filtered upstream by milestones / earnings test).
+            if (amount >= MIN_AMOUNT) {
+                incomeBySource.push({ name: inc.name, amount, kind: 'work' });
+            }
+            userPreTax401k += inc.getProratedAnnual(inc.preTax401k, year);
+            userRoth401k += inc.getProratedAnnual(inc.roth401k, year);
+
+            if (inc.matchAccountId && !employerInflows) {
+                const match = inc.getEffectiveAnnualEmployerMatch(year);
+                if (match >= MIN_AMOUNT) {
+                    const matchAccount = accounts.find(a => a.id === inc.matchAccountId);
+                    const isRoth = matchAccount instanceof InvestedAccount &&
+                        (matchAccount.taxType === 'Roth 401k' || matchAccount.taxType === 'Roth IRA');
+                    if (isRoth) {
+                        employerMatchRoth += match;
+                    } else {
+                        employerMatchPreTax += match;
+                    }
+                }
+            }
+            continue;
+        }
+
+        if (amount < MIN_AMOUNT) continue;
+
+        if (inc instanceof PassiveIncome) {
+            // RMDs are surfaced as spendable income (they drain the Traditional account
+            // via userInflows, but cash-flow-wise they're a required distribution that
+            // funds expenses, with any surplus reinvested). They are deliberately NOT in
+            // cashflow.withdrawalDetail, so showing them here is the single representation.
+            const kind: CashflowIncomeKind = inc.isReinvested ? 'reinvested' : 'passive';
+            const source: CashflowIncomeSource = { name: inc.name, amount, kind };
+
+            if (inc.isReinvested) {
+                // Interest incomes have ids of the form `interest-{accountId}-{year}`.
+                // Resolve the account so the chart can label the destination correctly.
+                const idParts = inc.id.startsWith('interest-') ? inc.id.split('-') : null;
+                const accountId = idParts && idParts.length >= 3
+                    ? idParts.slice(1, -1).join('-')
+                    : null;
+                const account = accountId ? accounts.find(a => a.id === accountId) : null;
+                source.accountName = account?.name ?? inc.name.replace(' Interest', '');
+            }
+
+            incomeBySource.push(source);
+        } else if (
+            inc instanceof SocialSecurityIncome ||
+            inc instanceof CurrentSocialSecurityIncome ||
+            inc instanceof FutureSocialSecurityIncome
+        ) {
+            incomeBySource.push({ name: inc.name, amount, kind: 'ss' });
+        } else if (inc instanceof FERSPensionIncome) {
+            // Include the MRA-to-62 supplement so the Sankey matches spendable income.
+            incomeBySource.push({ name: inc.name, amount: inc.getTotalAnnualAmount(year), kind: 'pension' });
+        } else if (inc instanceof CSRSPensionIncome) {
+            incomeBySource.push({ name: inc.name, amount, kind: 'pension' });
+        } else {
+            incomeBySource.push({ name: inc.name, amount, kind: 'passive' });
+        }
+    }
+
+    // When the sim's actual deposited match is available, derive the Roth/pretax
+    // split from it (per destination account, already §415(c)-trimmed) so the Sankey
+    // matches what AccountGrowth deposited rather than an untrimmed recompute.
+    if (employerInflows) {
+        for (const [accountId, match] of Object.entries(employerInflows)) {
+            if (match < MIN_AMOUNT) continue;
+            const matchAccount = accounts.find(a => a.id === accountId);
+            const isRoth = matchAccount instanceof InvestedAccount &&
+                (matchAccount.taxType === 'Roth 401k' || matchAccount.taxType === 'Roth IRA');
+            if (isRoth) {
+                employerMatchRoth += match;
+            } else {
+                employerMatchPreTax += match;
+            }
+        }
+    }
+
+    let mortgagePrincipal = 0;
+    let mortgageInterestEscrow = 0;
+    for (const exp of expenses) {
+        if (exp instanceof MortgageExpense) {
+            const amort = exp.calculateAnnualAmortization(year);
+            mortgagePrincipal += amort.totalPrincipal;
+            mortgageInterestEscrow += amort.totalPayment - amort.totalPrincipal;
+        }
+    }
+
+    const expensesByCategory: Record<string, number> = {};
+    for (const exp of expenses) {
+        if (exp instanceof MortgageExpense) continue;
+        const amount = exp.getAnnualAmount(year);
+        if (amount < MIN_AMOUNT) continue;
+        const category = CLASS_TO_CATEGORY[exp.constructor.name] || 'Other';
+        expensesByCategory[category] = (expensesByCategory[category] || 0) + amount;
+    }
+
+    return {
+        incomeBySource,
+        userPreTax401k,
+        userRoth401k,
+        employerMatchPreTax,
+        employerMatchRoth,
+        insurance,
+        mortgagePrincipal,
+        mortgageInterestEscrow,
+        expensesByCategory,
+        brokerageLTCGFromGross,
+    };
+}

--- a/src/services/simulation/IncomeClassifier.ts
+++ b/src/services/simulation/IncomeClassifier.ts
@@ -1,0 +1,162 @@
+/**
+ * IncomeClassifier.ts
+ *
+ * Classifies income into spendable vs reinvested categories for deficit calculation.
+ *
+ * Income Classification Rules:
+ * - Spendable: Cash available to cover expenses (wages, SS, pensions, rental, etc.)
+ * - Reinvested: Taxable but not available as cash (reinvested dividends/interest)
+ * - RMD Income: Required distributions - always spendable and taxable
+ * - Conversion Income: Roth conversions - taxable but NOT spendable (it's a transfer)
+ */
+
+import { AnyIncome, PassiveIncome, WorkIncome, SocialSecurityIncome, CurrentSocialSecurityIncome, FutureSocialSecurityIncome, FERSPensionIncome, CSRSPensionIncome, WindfallIncome } from "../../components/Objects/Income/models";
+import { ClassifiedIncome, IncomeClassificationResult, DecisionLogEntry } from "./types";
+
+/**
+ * Classifies all active incomes for a simulation year.
+ *
+ * @param incomes - All income objects for the year
+ * @param rmdAmount - Total RMD amount for the year (from RMD processing)
+ * @param conversionAmount - Total Roth conversion amount (taxable but not spendable)
+ * @param year - Current simulation year
+ * @returns Classified income breakdown
+ */
+export function classifyIncome(
+    incomes: AnyIncome[],
+    rmdAmount: number,
+    conversionAmount: number,
+    year: number // Current simulation year for date-based filtering
+): IncomeClassificationResult {
+    const decisions: DecisionLogEntry[] = [];
+
+    // Initialize breakdown
+    const breakdown = {
+        wages: 0,
+        socialSecurity: 0,
+        pensions: 0,
+        passive: 0,
+        rmd: rmdAmount,
+        reinvested: 0,
+    };
+
+    let spendable = 0;
+    let reinvested = 0;
+
+    for (const income of incomes) {
+        // Pass year to apply date-based filtering (incomes outside their date range return 0)
+        const annualAmount = income.getAnnualAmount(year);
+        if (annualAmount <= 0) continue;
+
+        if (income instanceof WorkIncome) {
+            // Work income is always spendable
+            spendable += annualAmount;
+            breakdown.wages += annualAmount;
+        } else if (income instanceof SocialSecurityIncome ||
+            income instanceof CurrentSocialSecurityIncome ||
+            income instanceof FutureSocialSecurityIncome) {
+            // Social Security is always spendable
+            spendable += annualAmount;
+            breakdown.socialSecurity += annualAmount;
+        } else if (income instanceof FERSPensionIncome) {
+            // FERS pension is always spendable; include the MRA-to-62 supplement.
+            const fersTotal = income.getTotalAnnualAmount(year);
+            spendable += fersTotal;
+            breakdown.pensions += fersTotal;
+        } else if (income instanceof CSRSPensionIncome) {
+            // CSRS pension is always spendable
+            spendable += annualAmount;
+            breakdown.pensions += annualAmount;
+        } else if (income instanceof PassiveIncome) {
+            // PassiveIncome can be reinvested or spendable based on isReinvested flag
+            if (income.isReinvested) {
+                reinvested += annualAmount;
+                breakdown.reinvested += annualAmount;
+            } else {
+                spendable += annualAmount;
+                breakdown.passive += annualAmount;
+            }
+
+            // Special handling for RMD-sourced passive income
+            // Note: RMD creates a PassiveIncome with sourceType 'RMD', but the actual RMD amount
+            // is passed in separately to avoid double-counting. We skip RMD-sourced passive income.
+            if (income.sourceType === 'RMD') {
+                // RMD amount is passed in separately, don't double-count
+                // Actually, let's undo what we just added since RMD is tracked separately
+                if (income.isReinvested) {
+                    reinvested -= annualAmount;
+                    breakdown.reinvested -= annualAmount;
+                } else {
+                    spendable -= annualAmount;
+                    breakdown.passive -= annualAmount;
+                }
+            }
+        } else if (income instanceof WindfallIncome) {
+            // Windfalls are spendable
+            spendable += annualAmount;
+            breakdown.passive += annualAmount;
+        } else {
+            // Default: treat as spendable passive income
+            spendable += annualAmount;
+            breakdown.passive += annualAmount;
+        }
+    }
+
+    // RMD is always spendable (passed in separately)
+    spendable += rmdAmount;
+
+    // Calculate taxable total:
+    // - All spendable income is taxable
+    // - Reinvested income is taxable
+    // - RMD is already included in spendable
+    // - Conversion is taxable but not spendable
+    const taxableTotal = spendable + reinvested + conversionAmount;
+
+    const classified: ClassifiedIncome = {
+        spendable,
+        reinvested,
+        rmdIncome: rmdAmount,
+        conversionIncome: conversionAmount,
+        taxableTotal,
+        breakdown,
+    };
+
+    // Log significant classifications
+    if (reinvested > 0) {
+        decisions.push({
+            category: 'tax',
+            amount: reinvested,
+            description: `Reinvested income of $${reinvested.toLocaleString()} is taxable but not available for spending.`,
+        });
+    }
+
+    if (conversionAmount > 0) {
+        decisions.push({
+            category: 'conversion',
+            amount: conversionAmount,
+            description: `Roth conversion of $${conversionAmount.toLocaleString()} is taxable but not spendable (transfer between accounts).`,
+        });
+    }
+
+    return {
+        classified,
+        logs: decisions.map(d => d.description),
+    };
+}
+
+/**
+ * Get total Social Security benefits from incomes.
+ * Used for SS taxability calculation (not the same as taxable SS).
+ */
+export function getTotalSSBenefits(incomes: AnyIncome[], year: number): number {
+    let total = 0;
+    for (const income of incomes) {
+        if (income instanceof SocialSecurityIncome ||
+            income instanceof CurrentSocialSecurityIncome ||
+            income instanceof FutureSocialSecurityIncome) {
+            total += income.getAnnualAmount(year);
+        }
+    }
+    return total;
+}
+

--- a/src/services/simulation/IncomeProjection.ts
+++ b/src/services/simulation/IncomeProjection.ts
@@ -1,0 +1,335 @@
+import { AnyIncome, WorkIncome, FutureSocialSecurityIncome, FERSPensionIncome, CSRSPensionIncome, PassiveIncome } from "../../components/Objects/Income/models";
+import { AnyAccount, SavedAccount } from "../../components/Objects/Accounts/models";
+import { AssumptionsState, getRetirementAge, getLifeExpectancy, getBirthYear } from "../../components/Objects/Assumptions/AssumptionsContext";
+import { calculateHigh3, checkFERSEligibility, checkCSRSEligibility, calculateFERSBasicBenefit, calculateCSRSBasicBenefit } from "../../data/PensionData";
+import { calculateAIME, extractEarningsFromSimulation, calculateEarningsTestReduction } from "../SocialSecurityCalculator";
+import { getFRA } from "../../data/SocialSecurityData";
+import * as TaxService from "../../components/Objects/Taxes/TaxService";
+import { SimulationYear } from "./types";
+
+export interface IncomeProjectionResult {
+    nextIncomes: AnyIncome[];
+    interestIncomes: PassiveIncome[];
+    allIncomes: AnyIncome[];
+    logs: string[];
+}
+
+/**
+ * Project incomes for the next year: grow work income, calculate pensions,
+ * determine Social Security benefits, apply earnings test, and compute interest income.
+ */
+export function projectIncomes(
+    year: number,
+    incomes: AnyIncome[],
+    accounts: AnyAccount[],
+    assumptions: AssumptionsState,
+    previousSimulation: SimulationYear[],
+    currentAge: number,
+    isRetired: boolean,
+    logs: string[]
+): IncomeProjectionResult {
+    // Filter out previous year's interest and RMD income - they're regenerated fresh each year
+    const regularIncomes = incomes.filter(inc => {
+        if (inc instanceof PassiveIncome && (inc.sourceType === 'Interest' || inc.sourceType === 'RMD')) {
+            return false;
+        }
+        return true;
+    });
+
+    const nextIncomes = regularIncomes.map(inc => {
+        // End work income at retirement if no end date is set
+        if (inc instanceof WorkIncome && isRetired && !inc.end_date) {
+            const retirementYear = getBirthYear(assumptions.milestones) + getRetirementAge(assumptions.milestones);
+
+            return new WorkIncome(
+                inc.id,
+                inc.name,
+                0, // Zero out the income
+                inc.frequency,
+                inc.earned_income,
+                0, // Zero out preTax401k
+                0, // Zero out insurance
+                0, // Zero out roth401k
+                0, // Zero out employerMatch
+                inc.matchAccountId,
+                inc.taxType,
+                inc.contributionGrowthStrategy,
+                inc.startDate,
+                new Date(Date.UTC(retirementYear - 1, 11, 31)),
+                0, // hsaContribution
+                inc.autoMax401k,
+                inc.esppContributionType,
+                0, // esppContributionAmount
+                inc.esppDiscountPercent,
+                inc.esppHasLookback,
+                inc.esppOfferingPeriodMonths,
+                inc.esppAccountId,
+                inc.esppExpectedStockGrowth,
+                inc.pensionSystem,
+                inc.startMilestoneId,
+                inc.endMilestoneId,  // CRITICAL: Preserve milestone IDs
+                inc.employerMatchType,
+                inc.employerMatchPercent,
+                inc.employerMatchMax,
+            );
+        }
+
+        // Handle FERS Pension
+        if (inc instanceof FERSPensionIncome) {
+            if (inc.autoCalculateHigh3 && inc.linkedIncomeId) {
+                // Build salary history from prior simulation years. The linked WorkIncome is
+                // filtered out of `incomes` once the user retires, so the High-3 calculation
+                // must NOT depend on it still being present in the current year's incomes.
+                const salaryHistory: number[] = previousSimulation
+                    .map(simYear => {
+                        const prevLinked = simYear.incomes.find(i => i.id === inc.linkedIncomeId);
+                        if (prevLinked instanceof WorkIncome) {
+                            return prevLinked.getAnnualAmount(simYear.year);
+                        }
+                        return 0;
+                    })
+                    .filter(s => s > 0);
+
+                // If the linked income is still active this year, include its salary too.
+                const linkedIncome = incomes.find(i => i.id === inc.linkedIncomeId);
+                if (linkedIncome instanceof WorkIncome) {
+                    const currentSalary = linkedIncome.getAnnualAmount(year);
+                    if (currentSalary > 0) salaryHistory.push(currentSalary);
+                }
+
+                if (currentAge === inc.retirementAge && salaryHistory.length > 0) {
+                    const high3 = calculateHigh3(salaryHistory);
+                    const baseBenefit = calculateFERSBasicBenefit(inc.yearsOfService, high3, inc.retirementAge);
+                    const eligibility = checkFERSEligibility(inc.retirementAge, inc.yearsOfService, inc.birthYear);
+                    const reductionFactor = 1 - (eligibility.reductionPercent / 100);
+                    const actualBenefit = baseBenefit * reductionFactor;
+
+                    logs.push(`[PENSION] FERS Pension started: High-3 calculated as $${high3.toLocaleString()}/yr from ${salaryHistory.length} years of salary history`);
+                    if (eligibility.reductionPercent > 0) {
+                        logs.push(`   Base benefit: $${baseBenefit.toLocaleString()}/yr, reduced by ${eligibility.reductionPercent}% (${eligibility.message})`);
+                    }
+                    logs.push(`   Annual benefit: $${actualBenefit.toLocaleString()}/yr`);
+
+                    return new FERSPensionIncome(
+                        inc.id, inc.name, inc.yearsOfService, high3,
+                        inc.retirementAge, inc.birthYear, actualBenefit,
+                        inc.fersSupplement, inc.estimatedSSAt62,
+                        inc.startDate, inc.end_date,
+                        inc.autoCalculateHigh3, inc.linkedIncomeId,
+                        inc.startMilestoneId, inc.endMilestoneId
+                    );
+                }
+            }
+            return inc.increment(assumptions, year, currentAge);
+        }
+
+        // Handle CSRS Pension
+        if (inc instanceof CSRSPensionIncome) {
+            if (inc.autoCalculateHigh3 && inc.linkedIncomeId) {
+                // Build salary history from prior simulation years. The linked WorkIncome is
+                // filtered out of `incomes` once the user retires, so the High-3 calculation
+                // must NOT depend on it still being present in the current year's incomes.
+                const salaryHistory: number[] = previousSimulation
+                    .map(simYear => {
+                        const prevLinked = simYear.incomes.find(i => i.id === inc.linkedIncomeId);
+                        if (prevLinked instanceof WorkIncome) {
+                            return prevLinked.getAnnualAmount(simYear.year);
+                        }
+                        return 0;
+                    })
+                    .filter(s => s > 0);
+
+                // If the linked income is still active this year, include its salary too.
+                const linkedIncome = incomes.find(i => i.id === inc.linkedIncomeId);
+                if (linkedIncome instanceof WorkIncome) {
+                    const currentSalary = linkedIncome.getAnnualAmount(year);
+                    if (currentSalary > 0) salaryHistory.push(currentSalary);
+                }
+
+                if (currentAge === inc.retirementAge && salaryHistory.length > 0) {
+                    const high3 = calculateHigh3(salaryHistory);
+                    const baseBenefit = calculateCSRSBasicBenefit(inc.yearsOfService, high3);
+
+                    const eligibility = checkCSRSEligibility(inc.retirementAge, inc.yearsOfService);
+                    const reductionFactor = 1 - (eligibility.reductionPercent / 100);
+                    const actualBenefit = baseBenefit * reductionFactor;
+
+                    logs.push(`[PENSION] CSRS Pension started: High-3 calculated as $${high3.toLocaleString()}/yr from ${salaryHistory.length} years of salary history`);
+                    if (eligibility.reductionPercent > 0) {
+                        logs.push(`   Base benefit: $${baseBenefit.toLocaleString()}/yr, reduced by ${eligibility.reductionPercent}% (${eligibility.message})`);
+                    }
+                    logs.push(`   Annual benefit: $${actualBenefit.toLocaleString()}/yr`);
+
+                    return new CSRSPensionIncome(
+                        inc.id, inc.name, inc.yearsOfService, high3,
+                        inc.retirementAge, actualBenefit,
+                        inc.startDate, inc.end_date,
+                        inc.autoCalculateHigh3, inc.linkedIncomeId,
+                        inc.startMilestoneId, inc.endMilestoneId
+                    );
+                }
+            }
+            return inc.increment(assumptions);
+        }
+
+        if (inc instanceof FutureSocialSecurityIncome) {
+            // Recalculate PIA every year until claiming age so it reflects growing earnings history.
+            // After claiming age (or if already activated), fall through to inc.increment() for COLA.
+            // Only enter this block if: (before claiming) OR (at claiming and not yet activated)
+            const shouldRecalculate = currentAge < inc.claimingAge ||
+                (currentAge === inc.claimingAge && inc.calculatedPIA === 0);
+
+            if (shouldRecalculate) {
+                try {
+                    const inflationAdjusted = assumptions.macro.inflationAdjusted;
+                    const earningsHistory = extractEarningsFromSimulation(
+                        previousSimulation,
+                        assumptions.demographics.priorEarnings,
+                        inflationAdjusted,
+                        incomes
+                    );
+
+                    const birthYear = getBirthYear(assumptions.milestones);
+                    const wageGrowthRate = assumptions.macro.inflationRate / 100;
+                    const aimeCalc = calculateAIME(earningsHistory, year, inc.claimingAge, birthYear, wageGrowthRate, inflationAdjusted);
+
+                    const fundingPercent = (assumptions.income?.socialSecurityFundingPercent ?? 100) / 100;
+                    const adjustedMonthlyBenefit = aimeCalc.adjustedBenefit * fundingPercent;
+
+                    logs.push(`Social Security PIA calculated: $${adjustedMonthlyBenefit.toFixed(2)}/month (claiming at age ${inc.claimingAge})`);
+                    logs.push(`  AIME: $${aimeCalc.aime.toFixed(2)}, PIA: $${aimeCalc.pia.toFixed(2)}${fundingPercent < 1 ? `, Funding: ${fundingPercent * 100}%` : ''}`);
+
+                    if (currentAge === inc.claimingAge) {
+                        // At claiming age - activate the income
+                        // Set both calculatedPIA (feeds amount) and projectedPIA
+                        const endDate = new Date(Date.UTC(
+                            birthYear + getLifeExpectancy(assumptions.milestones),
+                            11, 31
+                        ));
+                        return new FutureSocialSecurityIncome(
+                            inc.id,
+                            inc.name,
+                            inc.claimingAge,
+                            adjustedMonthlyBenefit,  // calculatedPIA - activates income (amount = PIA * 12)
+                            year,
+                            new Date(Date.UTC(year, 0, 1)),
+                            endDate,
+                            inc.startMilestoneId,
+                            inc.endMilestoneId,
+                            adjustedMonthlyBenefit   // projectedPIA - same as calculatedPIA at activation
+                        );
+                    } else {
+                        // Before claiming age - store projectedPIA for planning, but keep amount = 0
+                        // calculatedPIA = 0 so amount stays 0 (income not yet active)
+                        // projectedPIA = calculated value for Roth conversion planning
+                        const claimingYear = birthYear + inc.claimingAge;
+                        const futureStartDate = new Date(Date.UTC(claimingYear, 0, 1));
+                        return new FutureSocialSecurityIncome(
+                            inc.id,
+                            inc.name,
+                            inc.claimingAge,
+                            0,  // calculatedPIA = 0 (amount stays 0, income not active)
+                            year,  // calculationYear = current year when PIA was calculated
+                            futureStartDate,
+                            inc.end_date,
+                            inc.startMilestoneId,
+                            inc.endMilestoneId,
+                            adjustedMonthlyBenefit  // projectedPIA = calculated value for planning
+                        );
+                    }
+                } catch (error) {
+                    console.error('Error calculating Social Security benefits:', error);
+                    logs.push(`[WARN] Error calculating Social Security benefits: ${error}`);
+                    return inc.increment(assumptions);
+                }
+            }
+            // After claiming age (or already activated): falls through to inc.increment() below for COLA
+        }
+
+        // Pass year and age for WorkIncome to support TRACK_ANNUAL_MAX strategy
+        if (inc instanceof WorkIncome) {
+            return inc.increment(assumptions, year, currentAge);
+        }
+
+        return inc.increment(assumptions);
+    });
+
+    // Apply earnings test to FutureSocialSecurityIncome if claiming before FRA
+    const incomesWithEarningsTest = nextIncomes.map(inc => {
+        if (inc instanceof FutureSocialSecurityIncome && inc.calculatedPIA > 0) {
+            const birthYear = getBirthYear(assumptions.milestones);
+            const fra = getFRA(birthYear);
+
+            if (currentAge < fra) {
+                const earnedIncome = TaxService.getEarnedIncome(nextIncomes, year);
+                const annualSSBenefit = inc.getProratedAnnual(inc.amount, year);
+                const wageGrowthRate = assumptions.macro.inflationRate / 100;
+                const inflationAdjusted = assumptions.macro.inflationAdjusted;
+
+                const earningsTest = calculateEarningsTestReduction(
+                    annualSSBenefit,
+                    earnedIncome,
+                    currentAge,
+                    fra,
+                    year,
+                    wageGrowthRate,
+                    inflationAdjusted
+                );
+
+                if (earningsTest.appliesTest && earningsTest.amountWithheld > 0) {
+                    const monthlyReduced = earningsTest.reducedBenefit / 12;
+
+                    logs.push(`[WARN] Earnings test applied: SS benefit reduced from $${(annualSSBenefit/12).toFixed(2)}/month to $${monthlyReduced.toFixed(2)}/month`);
+                    logs.push(`  ${earningsTest.reason}`);
+                    logs.push(`  Amount withheld: $${earningsTest.amountWithheld.toLocaleString()}/year`);
+                    logs.push(`  Note: Withheld benefits would be recalculated at FRA (not yet implemented)`);
+
+                    return new FutureSocialSecurityIncome(
+                        inc.id,
+                        inc.name,
+                        inc.claimingAge,
+                        monthlyReduced,
+                        inc.calculationYear,
+                        inc.startDate,
+                        inc.end_date,
+                        inc.startMilestoneId,
+                        inc.endMilestoneId,
+                        inc.projectedPIA
+                    );
+                }
+            }
+        }
+        return inc;
+    });
+
+    // Calculate interest income from savings accounts (before they grow)
+    const interestIncomes: PassiveIncome[] = [];
+    for (const acc of accounts) {
+        if (acc instanceof SavedAccount && acc.apr > 0 && acc.amount > 0) {
+            const interestEarned = acc.amount * (acc.apr / 100);
+            if (interestEarned > 0.01) {
+                interestIncomes.push(new PassiveIncome(
+                    `interest-${acc.id}-${year}`,
+                    `${acc.name} Interest`,
+                    interestEarned,
+                    'Annually',
+                    'No',
+                    'Interest',
+                    new Date(year, 0, 1),
+                    new Date(year, 11, 31),
+                    true  // isReinvested
+                ));
+            }
+        }
+    }
+
+    // Combine regular incomes with interest income for tax calculations
+    const allIncomes = [...incomesWithEarningsTest, ...interestIncomes];
+
+    return {
+        nextIncomes: incomesWithEarningsTest,
+        interestIncomes,
+        allIncomes,
+        logs
+    };
+}

--- a/src/services/simulation/MilestoneEvaluator.ts
+++ b/src/services/simulation/MilestoneEvaluator.ts
@@ -1,0 +1,401 @@
+import { AnyAccount, InvestedAccount, SavedAccount, DebtAccount, PropertyAccount, ESPPAccount, DeficitDebtAccount } from "../../components/Objects/Accounts/models";
+import { MortgageExpense, LoanExpense, AnyExpense } from "../../components/Objects/Expense/models";
+import { CustomMilestone, MilestoneCondition, MilestoneReachEvent } from "./types";
+import { getTaxParameters, calculateTotalFederalTax } from "../../components/Objects/Taxes/TaxService";
+import { FilingStatus } from "../../data/TaxData";
+
+/**
+ * Context for evaluating milestone conditions
+ */
+export interface MilestoneContext {
+    accounts: AnyAccount[];
+    expenses: AnyExpense[];
+    year: number;
+    age: number;
+    milestoneReachYears?: Map<string, number>;  // milestoneId -> year reached (for YEARS_AFTER_MILESTONE)
+    filingStatus?: FilingStatus;  // user's filing status, for the EXPENSES_GROSSED_UP tax gross-up (defaults to Single)
+}
+
+/**
+ * Calculate total net worth: all assets minus all liabilities
+ */
+export function calculateNetWorth(accounts: AnyAccount[], expenses: AnyExpense[]): number {
+    let assets = 0;
+    let liabilities = 0;
+
+    accounts.forEach(account => {
+        if (account instanceof DeficitDebtAccount) {
+            liabilities += account.amount;
+        } else if (account instanceof DebtAccount) {
+            liabilities += account.amount;
+        } else if (account instanceof PropertyAccount) {
+            // Property value minus loan balance
+            assets += account.amount; // Value
+            liabilities += account.loanAmount || 0;
+        } else if (account instanceof InvestedAccount || account instanceof SavedAccount || account instanceof ESPPAccount) {
+            assets += account.amount;
+        }
+    });
+
+    // Build set of expense ids that are linked to an account (so the loan is
+    // already counted on the account side) to avoid double-counting.
+    const linkedExpenseIds = new Set<string>();
+    accounts.forEach(a => {
+        if ((a instanceof PropertyAccount || a instanceof DebtAccount) && a.linkedAccountId) {
+            linkedExpenseIds.add(a.linkedAccountId);
+        }
+    });
+
+    // Also include mortgage and loan balances from standalone expenses
+    // (skip those linked to an account, already counted above).
+    expenses.forEach(expense => {
+        if (expense instanceof MortgageExpense) {
+            if (!linkedExpenseIds.has(expense.id)) liabilities += expense.loan_balance;
+        } else if (expense instanceof LoanExpense) {
+            if (!linkedExpenseIds.has(expense.id)) liabilities += expense.amount;
+        }
+    });
+
+    return assets - liabilities;
+}
+
+/**
+ * Calculate liquid net worth: only Brokerage + Savings accounts
+ * (Not retirement accounts like 401k, IRA, etc.)
+ */
+export function calculateLiquidNetWorth(accounts: AnyAccount[]): number {
+    let liquid = 0;
+
+    accounts.forEach(account => {
+        if (account instanceof SavedAccount) {
+            liquid += account.amount;
+        } else if (account instanceof InvestedAccount && account.taxType === 'Brokerage') {
+            liquid += account.amount;
+        } else if (account instanceof ESPPAccount) {
+            // ESPP is liquid (publicly traded stock)
+            liquid += account.amount;
+        }
+    });
+
+    return liquid;
+}
+
+/**
+ * Calculate total debt: all debt accounts + mortgage/loan balances
+ */
+export function calculateTotalDebt(accounts: AnyAccount[], expenses: AnyExpense[]): number {
+    let debt = 0;
+
+    accounts.forEach(account => {
+        if (account instanceof DeficitDebtAccount) {
+            debt += account.amount;
+        } else if (account instanceof DebtAccount) {
+            debt += account.amount;
+        } else if (account instanceof PropertyAccount) {
+            debt += account.loanAmount || 0;
+        }
+    });
+
+    // Build set of expense ids that are linked to an account (so the loan is
+    // already counted on the account side) to avoid double-counting.
+    const linkedExpenseIds = new Set<string>();
+    accounts.forEach(a => {
+        if ((a instanceof PropertyAccount || a instanceof DebtAccount) && a.linkedAccountId) {
+            linkedExpenseIds.add(a.linkedAccountId);
+        }
+    });
+
+    // Also include mortgage and loan balances from standalone expenses
+    // (skip those linked to an account, already counted above).
+    expenses.forEach(expense => {
+        if (expense instanceof MortgageExpense) {
+            if (!linkedExpenseIds.has(expense.id)) debt += expense.loan_balance;
+        } else if (expense instanceof LoanExpense) {
+            if (!linkedExpenseIds.has(expense.id)) debt += expense.amount;
+        }
+    });
+
+    return debt;
+}
+
+/**
+ * Calculate total annual expenses
+ * Used for expense multiple calculations (e.g., 25x expenses for FI)
+ */
+export function calculateAnnualExpenses(expenses: AnyExpense[], year: number): number {
+    let total = 0;
+
+    expenses.forEach(expense => {
+        // Check if expense is active in this year
+        const startYear = expense.startDate ? expense.startDate.getUTCFullYear() : 0;
+        const endYear = expense.endDate ? expense.endDate.getUTCFullYear() : 9999;
+
+        if (year >= startYear && year <= endYear) {
+            if (expense instanceof MortgageExpense) {
+                total += expense.calculateAnnualAmortization(year).totalPayment;
+            } else if (expense instanceof LoanExpense) {
+                total += expense.calculateAnnualAmortization(year).totalPayment;
+            } else {
+                total += expense.getAnnualAmount(year);
+            }
+        }
+    });
+
+    return total;
+}
+
+/**
+ * Fallback filing status for the expense gross-up, used only when the
+ * MilestoneContext doesn't carry one. 'Single' is the same conservative default
+ * the app ships with (TaxContext.defaultTaxState) and yields the least-favorable
+ * brackets, so the grossed-up target is never optimistic.
+ */
+const GROSS_UP_DEFAULT_FILING_STATUS: FilingStatus = 'Single';
+
+/**
+ * Gross up after-tax living expenses into the pre-tax withdrawal needed to fund
+ * them, using the real federal bracket schedule for the given year instead of a
+ * flat assumed rate.
+ *
+ * A retiree who needs `netExpenses` to spend must withdraw enough pre-tax
+ * dollars `gross` such that `gross - tax(gross) === netExpenses`, i.e.
+ * `gross === netExpenses + tax(gross)`. Because `tax(gross)` depends on `gross`,
+ * we solve it with a short fixed-point iteration (gross starts at the raw
+ * expenses and is bumped by the tax owed each pass). This converges quickly
+ * because the federal schedule is piecewise-linear; a handful of iterations is
+ * more than enough.
+ *
+ * The withdrawal is modeled as ordinary income (the typical case for funding
+ * retirement from Traditional 401k/IRA balances), so it correctly benefits from
+ * the standard deduction and the lower brackets — making the effective rate far
+ * more accurate than the previous flat 15%, especially at modest spend levels.
+ *
+ * Falls back to a flat 15% gross-up if tax parameters can't be resolved for the
+ * year (mirrors the previous behavior so the milestone never silently breaks).
+ */
+function grossUpExpenses(netExpenses: number, year: number, filingStatus: FilingStatus): number {
+    const FALLBACK_TAX_RATE = 0.15;
+
+    const fedParams = getTaxParameters(year, filingStatus, "federal");
+    if (!fedParams) {
+        return netExpenses / (1 - FALLBACK_TAX_RATE);
+    }
+
+    // Fixed-point solve for gross such that gross - tax(gross) === netExpenses.
+    let gross = netExpenses;
+    for (let i = 0; i < 8; i++) {
+        const tax = calculateTotalFederalTax(
+            gross,  // ordinary income (Traditional-account withdrawal)
+            0,      // socialSecurityBenefits
+            0,      // shortTermCapitalGains
+            0,      // longTermCapitalGains
+            0,      // preTaxDeductions (already retired; none assumed)
+            filingStatus,
+            fedParams,
+        ).totalTax;
+        const next = netExpenses + tax;
+        if (Math.abs(next - gross) < 1) {
+            gross = next;
+            break;
+        }
+        gross = next;
+    }
+
+    return gross;
+}
+
+/**
+ * Calculate the target value for comparison based on valueType
+ */
+function calculateTargetValue(condition: MilestoneCondition, context: MilestoneContext): number | null {
+    const valueType = condition.valueType || 'FIXED';
+
+    switch (valueType) {
+        case 'FIXED':
+            return condition.value;
+
+        case 'EXPENSES': {
+            // value × annual expenses (e.g., 25x expenses for 4% rule)
+            // Living expenses only - does NOT include taxes
+            const annualExpenses = calculateAnnualExpenses(context.expenses, context.year);
+            if (annualExpenses <= 0) return null; // Can't multiply by zero expenses
+            return condition.value * annualExpenses;
+        }
+
+        case 'EXPENSES_GROSSED_UP': {
+            // value × (pre-tax dollars needed to net the annual expenses).
+            //
+            // Previously this used a flat 15% rate (expenses / (1 - 0.15)),
+            // ignoring filing status, state, and the actual bracket schedule.
+            // We now derive the gross-up from the real federal tax brackets for
+            // the milestone's year via grossUpExpenses() (solving
+            // gross - tax(gross) === expenses), which is materially more
+            // accurate — at low spend the standard deduction makes the effective
+            // rate well under 15%, and at high spend the upper brackets push it
+            // above 15%.
+            //
+            // The user's real filingStatus is threaded through MilestoneContext
+            // (set by SimulationEngine). Still federal-only: MilestoneContext does
+            // not carry stateResidency, so STATE tax is not included in the
+            // gross-up — a fuller fix would thread stateResidency through too.
+            const annualExpenses = calculateAnnualExpenses(context.expenses, context.year);
+            if (annualExpenses <= 0) return null;
+            const grossedUpExpenses = grossUpExpenses(
+                annualExpenses,
+                context.year,
+                context.filingStatus ?? GROSS_UP_DEFAULT_FILING_STATUS,
+            );
+            return condition.value * grossedUpExpenses;
+        }
+
+        case 'MILESTONE_PLUS': {
+            // milestone year/age + value offset
+            if (!condition.referenceMilestoneId || !context.milestoneReachYears) {
+                return null; // Missing reference
+            }
+            const reachedYear = context.milestoneReachYears.get(condition.referenceMilestoneId);
+            if (reachedYear === undefined) {
+                return null; // Referenced milestone hasn't been reached yet
+            }
+            // For YEAR conditions, return the year + offset
+            // For AGE conditions, convert to age equivalent
+            if (condition.type === 'AGE') {
+                // Convert the milestone's reach-year to the age the user was when it
+                // was reached, then add the offset. (No '_age' key is ever stored in
+                // milestoneReachYears, so this derivation is the sole path.)
+                return (reachedYear - context.year + context.age) + condition.value;
+            }
+            return reachedYear + condition.value;
+        }
+
+        default:
+            return condition.value;
+    }
+}
+
+/**
+ * Evaluate a single condition against the context
+ */
+function evaluateCondition(condition: MilestoneCondition, context: MilestoneContext): boolean {
+    // Get the measured value (left side of comparison)
+    let measuredValue: number;
+
+    switch (condition.type) {
+        case 'NET_WORTH':
+            measuredValue = calculateNetWorth(context.accounts, context.expenses);
+            break;
+        case 'LIQUID_NET_WORTH':
+            measuredValue = calculateLiquidNetWorth(context.accounts);
+            break;
+        case 'TOTAL_DEBT':
+            measuredValue = calculateTotalDebt(context.accounts, context.expenses);
+            break;
+        case 'YEAR':
+            measuredValue = context.year;
+            break;
+        case 'AGE':
+            measuredValue = context.age;
+            break;
+        default:
+            return false;
+    }
+
+    // Get the target value (right side of comparison)
+    const targetValue = calculateTargetValue(condition, context);
+    if (targetValue === null) {
+        return false; // Couldn't calculate target (e.g., milestone not reached yet)
+    }
+
+    switch (condition.operator) {
+        case '>=':
+            return measuredValue >= targetValue;
+        case '<=':
+            return measuredValue <= targetValue;
+        case '>':
+            return measuredValue > targetValue;
+        case '<':
+            return measuredValue < targetValue;
+        case '=':
+            return measuredValue === targetValue;
+        default:
+            return false;
+    }
+}
+
+/**
+ * Evaluate if a milestone has been reached (all conditions must be met)
+ */
+export function evaluateMilestone(milestone: CustomMilestone, context: MilestoneContext): boolean {
+    // All conditions must be met (AND logic)
+    return milestone.conditions.every(condition => evaluateCondition(condition, context));
+}
+
+/**
+ * Evaluate all milestones and return newly reached ones
+ * @param milestones - All defined milestones
+ * @param previouslyReached - IDs of milestones already reached in prior years
+ * @param context - Current simulation context
+ * @returns Object with newly reached milestones and updated active set
+ */
+export function evaluateAllMilestones(
+    milestones: CustomMilestone[],
+    previouslyReached: Set<string>,
+    context: MilestoneContext
+): {
+    newlyReached: MilestoneReachEvent[];
+    activeMilestones: string[];
+} {
+    const newlyReached: MilestoneReachEvent[] = [];
+    const activeMilestones = new Set(previouslyReached);
+
+    milestones.forEach(milestone => {
+        // Skip if already reached
+        if (previouslyReached.has(milestone.id)) {
+            return;
+        }
+
+        // Check if conditions are now met
+        if (evaluateMilestone(milestone, context)) {
+            newlyReached.push({
+                milestoneId: milestone.id,
+                yearReached: context.year,
+                ageReached: context.age,
+            });
+            activeMilestones.add(milestone.id);
+        }
+    });
+
+    return {
+        newlyReached,
+        activeMilestones: Array.from(activeMilestones),
+    };
+}
+
+/**
+ * Check if an income/expense should be active based on milestone state
+ * @param startMilestoneId - Milestone that triggers start (optional)
+ * @param endMilestoneId - Milestone that triggers end (optional)
+ * @param currentMilestones - Set of milestone IDs reached as of current year
+ * @param previousMilestones - Set of milestone IDs reached as of previous year (optional, defaults to currentMilestones)
+ * @returns true if the item should be active
+ */
+export function isActiveByMilestone(
+    startMilestoneId: string | undefined,
+    endMilestoneId: string | undefined,
+    currentMilestones: Set<string>,
+    previousMilestones?: Set<string>
+): boolean {
+    // START: use current state (begin immediately when milestone is reached)
+    if (startMilestoneId && !currentMilestones.has(startMilestoneId)) {
+        return false;
+    }
+
+    // END: use previous state (continue through the year milestone is reached)
+    // If no previous state provided, fall back to current (for backwards compatibility)
+    const endCheckSet = previousMilestones ?? currentMilestones;
+    if (endMilestoneId && endCheckSet.has(endMilestoneId)) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/services/simulation/RMDService.ts
+++ b/src/services/simulation/RMDService.ts
@@ -1,0 +1,138 @@
+import { AnyAccount, InvestedAccount } from "../../components/Objects/Accounts/models";
+import { PassiveIncome } from "../../components/Objects/Income/models";
+import { AssumptionsState, getBirthYear } from "../../components/Objects/Assumptions/AssumptionsContext";
+import { calculateRMD, isAccountSubjectToRMD, isRMDRequired, RMDCalculation } from "../../data/RMDData";
+import { SimulationYear, WithdrawalState } from "./types";
+
+export interface RMDResult {
+    rmdDetails: SimulationYear['rmdDetails'];
+    rmdIncomes: PassiveIncome[];
+    logs: string[];
+}
+
+/**
+ * Process Required Minimum Distributions for Traditional accounts.
+ * RMDs must be taken starting at age 72-75 depending on birth year.
+ * Amount is based on prior year's ending balance divided by life expectancy factor.
+ */
+export function processRMDs(
+    year: number,
+    accounts: AnyAccount[],
+    assumptions: AssumptionsState,
+    previousSimulation: SimulationYear[],
+    currentAge: number,
+    totalGrossIncome: number,
+    withdrawalState: WithdrawalState,
+    logs: string[]
+): RMDResult {
+    const birthYearForRMD = getBirthYear(assumptions.milestones);
+    const rmdRequired = isRMDRequired(currentAge, birthYearForRMD);
+
+    if (!rmdRequired) {
+        return {
+            rmdDetails: undefined,
+            rmdIncomes: [],
+            logs
+        };
+    }
+
+    const rmdCalculations: RMDCalculation[] = [];
+    let totalRMDRequired = 0;
+    let totalRMDWithdrawn = 0;
+    const rmdIncomes: PassiveIncome[] = [];
+
+    for (const account of accounts) {
+        if (!(account instanceof InvestedAccount)) continue;
+        if (!isAccountSubjectToRMD(account.taxType)) continue;
+
+        // Get prior year's ending balance for RMD calculation.
+        // Bug #12: base the RMD requirement on the VESTED prior-year balance so
+        // the requirement and the withdrawal cap (availableBalance below) share
+        // the same basis. Using full balance here while capping withdrawals at
+        // vested fabricates a phantom shortfall + 25% penalty for unvested
+        // employer money the owner cannot legally distribute. The IRS bases RMDs
+        // on the account balance, but unvested employer funds are not yet the
+        // owner's assets, so vested balance is the conservative, consistent basis.
+        const priorYearSim = previousSimulation[previousSimulation.length - 1];
+        let priorYearBalance = account.vestedAmount;
+
+        if (priorYearSim) {
+            const priorAccount = priorYearSim.accounts.find(a => a.id === account.id);
+            if (priorAccount instanceof InvestedAccount) {
+                priorYearBalance = priorAccount.vestedAmount;
+            }
+        }
+
+        const rmdAmount = calculateRMD(priorYearBalance, currentAge);
+        if (rmdAmount <= 0) continue;
+
+        rmdCalculations.push({
+            accountName: account.name,
+            accountId: account.id,
+            priorYearBalance: priorYearBalance,
+            distributionPeriod: priorYearBalance / rmdAmount,
+            rmdAmount: rmdAmount
+        });
+
+        totalRMDRequired += rmdAmount;
+
+        const availableBalance = account.vestedAmount;
+        const actualWithdrawal = Math.min(rmdAmount, availableBalance);
+
+        if (actualWithdrawal > 0) {
+            // Create RMD income object - makes RMD visible to Roth conversion
+            const rmdIncome = new PassiveIncome(
+                `rmd-${account.id}-${year}`,
+                `RMD from ${account.name}`,
+                actualWithdrawal,
+                'Annually',
+                'No',
+                'RMD',
+                new Date(year, 0, 1),
+                new Date(year, 11, 31),
+                false
+            );
+            rmdIncomes.push(rmdIncome);
+
+            // Update totalGrossIncome so it includes RMD for cash flow calculations
+            totalGrossIncome += actualWithdrawal;
+            withdrawalState.totalGrossIncome = totalGrossIncome;
+
+            // Drain the account. This is the ONLY money movement — growAccounts applies
+            // userInflows to the balance (AccountGrowth.ts), so the Traditional account
+            // drops by exactly the RMD regardless of how it's later reported.
+            withdrawalState.userInflows[account.id] = (withdrawalState.userInflows[account.id] || 0) - actualWithdrawal;
+            totalRMDWithdrawn += actualWithdrawal;
+
+            // NOTE: the RMD is intentionally NOT added to withdrawalState.totalWithdrawals
+            // or withdrawalDetail. It is surfaced as spendable INCOME (a PassiveIncome with
+            // sourceType 'RMD', classified into `spendable` by IncomeClassifier), so adding
+            // it to the withdrawal tallies too would double-count the same dollars in the
+            // Sankey cash accounting (inflated `investedUser`/`totalInvested`). RMD = income
+            // that funds expenses, with any surplus reinvested.
+            logs.push(`📋 RMD from ${account.name}: $${actualWithdrawal.toLocaleString(undefined, { maximumFractionDigits: 0 })}`);
+        }
+    }
+
+    // Calculate shortfall and penalty
+    const shortfall = Math.max(0, totalRMDRequired - totalRMDWithdrawn);
+    const penalty = shortfall * 0.25;
+
+    if (shortfall > 0) {
+        logs.push(`[WARN] RMD shortfall: $${shortfall.toLocaleString(undefined, { maximumFractionDigits: 0 })} - Penalty: $${penalty.toLocaleString(undefined, { maximumFractionDigits: 0 })}`);
+    }
+
+    const rmdDetails: SimulationYear['rmdDetails'] = {
+        totalRMD: totalRMDRequired,
+        totalWithdrawn: totalRMDWithdrawn,
+        accountBreakdown: rmdCalculations,
+        shortfall: shortfall,
+        penalty: penalty
+    };
+
+    return {
+        rmdDetails,
+        rmdIncomes,
+        logs
+    };
+}

--- a/src/services/simulation/RothConversionDP.ts
+++ b/src/services/simulation/RothConversionDP.ts
@@ -1,0 +1,1358 @@
+/**
+ * RothConversionDP.ts
+ *
+ * Backward-induction dynamic-programming Roth conversion planner.
+ *
+ * Solved once over the full retirement horizon, this module produces a
+ * year-by-year conversion plan that minimizes lifetime tax under the
+ * deterministic baseline, with a small back-load preference (δ) layered
+ * on top. The result is a `Map<year, conversionAmount>` consumed by the
+ * DP-precomputed conversion strategy in YearSolver.
+ *
+ * State (3D): `(year, traditional_balance, roth_balance)`. Decision:
+ * this year's total Traditional → Roth conversion amount (including any
+ * std-ded-headroom portion that the baseline would do for free — the
+ * DP picks total).
+ *
+ * Cell evaluation: the year's spending need + this year's tax minus
+ * cash supplied by ordinary income forms a `gap`, which flows through
+ * the real-sim withdrawal order brokerage → roth → trad. Trad-spending
+ * is endogenous (depends on roth state and conversion size) and feeds
+ * back into ordinary income; we resolve via a small fixed-point
+ * iteration. `yearTax` is the year's actual tax; the V-table sums
+ * (yearTax + infeasibility-penalty × unmetNeed) across the horizon.
+ *
+ * V-table: `V[t]` is a flat `Float64Array` of size
+ * `(TRAD_BUCKETS+1) × (ROTH_BUCKETS+1)`. Backward sweep is a triple
+ * loop over `(t, tradIdx, rothIdx)` with an inner conversion loop;
+ * future cost is looked up via bilinear interpolation in (trad, roth).
+ * Forward extract walks `(trad, roth)` jointly from
+ * `(currentTradBalance, currentRothBalance)`.
+ *
+ * Approximations:
+ * - Brokerage is exogenous (per-year baseline cap, not state). Plans
+ *   that drain brokerage harder than baseline see an inflated cap in
+ *   later years — accepted to keep state at 3D.
+ * - LTCG income comes from baseline; plans diverging materially in
+ *   brokerage usage under-count LTCG tax. Same trade-off.
+ * - 5-year Roth-conversion withdrawal rule: not modeled.
+ * - IRMAA: not in the codebase yet; will flow through automatically
+ *   once `calculateEffectiveConversionTax` learns about it.
+ * - Monte-Carlo path divergence: handled at the call site by re-running
+ *   the DP per path.
+ */
+
+import { TaxParameters, FilingStatus } from "../../data/TaxData";
+import { TaxState } from "../../components/Objects/Taxes/TaxContext";
+import { AssumptionsState, getBirthYear } from "../../components/Objects/Assumptions/AssumptionsContext";
+import { SimulationYear, DPYearTrace } from "./types";
+import * as TaxService from "../../components/Objects/Taxes/TaxService";
+import { ACAOptions } from "./helpers";
+import { getDistributionPeriod, getRMDStartAge } from "../../data/RMDData";
+import { getAcaCliffThreshold } from "./TaxOptimizedWithdrawal";
+import { InvestedAccount } from "../../components/Objects/Accounts/models";
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/**
+ * Per-year back-load preference. Defined as:
+ *   V(t, b) = min over c of [tax(c) + (1 / (1 + δ)) × V(t+1, b')]
+ * δ > 0 makes future tax look slightly cheaper than present tax, biasing the
+ * optimal plan toward later conversions at the cost of some lifetime-tax
+ * efficiency. δ = 0 gives the lifetime-optimal (mildly front-loaded) plan.
+ *
+ * 0.015 = 1.5%/year — see project memory for rationale.
+ */
+export const DP_BACKLOAD_DELTA = 0.015;
+
+const TRAD_BUCKETS = 100;
+/**
+ * Roth-balance grid resolution for the 3D state extension. With
+ * `determineMaxRoth`'s upper bound of `(roth + trad) × growth^horizon × 1.3`,
+ * a typical 30-year retirement spans ~10× initial wealth, so 50 buckets
+ * gives ~$320k resolution on a $16M maxRoth — coarse but adequate for
+ * distinguishing "Roth depleted" from "Roth has cushion" (the dominant
+ * decision the roth dim drives). Halving from 100 to 50 also halves the
+ * 2D backward-sweep work, which dominates planConversionsViaDP runtime.
+ * Bump if optimization decisions look noisy in late-horizon years.
+ * Memory: (TRAD+1)*(ROTH+1)*horizon*8 = ~150 KB/year × 60yr ≈ 9 MB worst-case.
+ */
+const ROTH_BUCKETS = 50;
+const CONVERSION_BUCKETS = 200;
+const BALANCE_HEADROOM_FACTOR = 1.3;
+const MIN_BALANCE_RANGE = 100_000;
+const MIN_CONVERSION_RANGE = 10_000;
+/**
+ * Caps the per-year conversion grid. Without a cap, dC = currentTradBalance / 50,
+ * so a $1.5M trad portfolio gets $30k buckets — too coarse to pick std-deduction
+ * headroom (~$29k) precisely, and the DP rounds many years to $0. $500k easily
+ * spans the top federal bracket from $0 income, so any optimum will land below it.
+ */
+const MAX_CONVERSION_CAP = 500_000;
+const ACA_SUBSIDY_LOSS_DEFAULT = 12_000;
+/**
+ * Per-dollar penalty added to yearCost when a (year, trad, roth, conversion)
+ * cell can't fund the year's totalNeed (= spendingNeed + yearTax) from the
+ * waterfall. Without this, the DP would happily pick "drain trad to zero
+ * early so RMDs are 0 forever" because no future tax dominates a real
+ * lifetime — but that plan is bankrupt at age 70. Penalty makes infeasible
+ * plans strictly dominated. Tunable: $10/$1 unmet is heavy enough that the
+ * solver will choose any feasible alternative.
+ */
+const INFEASIBILITY_PENALTY_PER_DOLLAR = 10;
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Per-year exogenous context the DP needs: everything that does not change
+ * with the conversion decision. Built once from the baseline simulation.
+ */
+export interface DPYearContext {
+    year: number;
+    age: number;
+
+    /**
+     * Ordinary income on this year's tax return EXCLUDING SS, EXCLUDING the
+     * RMD (DP re-derives RMD from its own trad-balance state), and EXCLUDING
+     * any Roth conversion (DP's `c` decision variable IS the total conversion
+     * for the year — see evaluateCell, where it's added to ordIncomeBase).
+     * Including baseline conversion here would force the DP to think only of
+     * "extra above baseline," and the final sim — which executes whatever
+     * amount the DP returns — would then never replay the baseline std-ded
+     * portion.
+     */
+    nonSSOrdinaryIncomeExclRMD: number;
+    /** Gross SS benefits (taxable portion is computed inside calculateTotalFederalTax). */
+    ssBenefits: number;
+    /** Realized LTCG + qualified dividends. */
+    ltcgIncome: number;
+
+    filingStatus: FilingStatus;
+    fedParams: TaxParameters;
+    stateParams: TaxParameters | null;
+    acaOptions?: ACAOptions;
+
+    /** Trad withdrawal for spending in baseline (excludes RMD; approximated as constant across DP plans). Phase 2: still consumed by the (in-flight 2D) solver. Phase 3 replaces this with endogenous trad-spending in evaluateCell. */
+    baselineTradWithdrawal: number;
+
+    /**
+     * Pre-tax spending need for the year — `cashflow.totalExpense − (fed + state + fica)`.
+     * Used by the 3D solver (Phase 3) as the cash demand the waterfall must cover.
+     * Tax is excluded because the DP recomputes its own per-plan year-tax; including
+     * baseline tax here would double-count.
+     */
+    spendingNeed: number;
+    /**
+     * Brokerage balance ENTERING the year (= end of prior year), used by
+     * evaluateCell as the cap on `fromBrokerage` in the spending waterfall.
+     * For the first context year (= retirementYear), this is
+     * end-of-(retirementYear − 1) — pulled from baseline if available, else
+     * from the `startingBrokerageBalance` passed into `buildDPYearContexts`.
+     *
+     * Approximation note: brokerage is exogenous in pure-3D state, so each
+     * year's cap reflects baseline's brokerage trajectory, not the chosen
+     * plan's. A DP plan that drains brokerage harder than baseline will
+     * under-state the constraint in later years (cap = baseline's larger
+     * entering balance, not plan's depleted reality). Accepted to keep
+     * state at 3D; revisit if plans diverge materially from baseline
+     * brokerage usage.
+     */
+    baselineBrokerageAvailable: number;
+    /** Net growth rate for Roth accounts (mirrors `growthRate` for trad). */
+    rothGrowthRate: number;
+
+    /** Diagnostic only: baseline (std-ded-only sub-sim) Roth/brokerage/trad for this year. Not consumed by the solver — printed in per-year debug to make DP-vs-reality divergence visible. */
+    baselineRothBalance?: number;
+    baselineBrokerageBalance?: number;
+    baselineTradBalance?: number;
+    /** Diagnostic only: baseline sub-sim's actual conversion amount this year. */
+    baselineConversionAmount?: number;
+    /** Diagnostic only — set on the FIRST context: baseline trad at (retirementYear − 1). Used to detect off-by-one between DP starting balance and where real-sim's trad actually is at retirement-year start. */
+    diagnosticPreRetirementBaselineTrad?: number;
+
+    /** Net (RoR − weighted ER) growth rate for trad accounts. */
+    growthRate: number;
+    /** Distribution-period divisor for RMD (0 if age < RMD start age). */
+    rmdDivisor: number;
+}
+
+/** Inputs to the DP solver. */
+export interface DPInputs {
+    contexts: DPYearContext[];
+    /** Current Traditional balance — the DP's starting trad-balance state. */
+    currentTradBalance: number;
+    /**
+     * Current Roth balance — the DP's starting roth-balance state for the
+     * 3D extension. Phase 1 plumbs this through but the solver does not yet
+     * branch on it (V-table is still 1D in trad). Phase 4 wires it in.
+     */
+    currentRothBalance: number;
+    /**
+     * Per-year back-load preference. Defaults to DP_BACKLOAD_DELTA.
+     * Exposed as a parameter so tests can pin δ = 0 for deterministic checks.
+     */
+    backloadDelta?: number;
+}
+
+/** Diagnostic info surfaced to the debug page. */
+export interface DPDiagnostics {
+    backloadDelta: number;
+    tradBuckets: number;
+    rothBuckets: number;
+    conversionBuckets: number;
+    /**
+     * Legacy max-of-horizon scalars (kept for backward compatibility with
+     * existing diagnostic consumers and tests). The 3D solver actually
+     * uses per-year scales `dBByYear` / `dRothByYear` below.
+     */
+    maxBalance: number;
+    maxRoth: number;
+    dB: number;
+    dRoth: number;
+    /**
+     * Per-year V-table grid scales. Index `t` is the bucket width at the
+     * START of year `t`; length is `horizonYears + 1`. Each year's grid
+     * adapts to that year's reachable (trad, roth) range so early years
+     * (where conversion decisions matter) get fine resolution and late
+     * years (where roth has compounded) get coarser buckets.
+     */
+    dBByYear: number[];
+    dRothByYear: number[];
+    /**
+     * Per-year conversion-grid bucket width. Index `t` is the conversion
+     * bucket size for year `t`; the largest candidate that year is
+     * `CONVERSION_BUCKETS × dCByYear[t]`. Sized to year `t`'s reachable
+     * trad balance so late-year conversions above the year-0 ceiling are
+     * still evaluated.
+     */
+    dCByYear: number[];
+    dC: number;
+    maxConversion: number;
+    horizonYears: number;
+    elapsedMs: number;
+    /** Per-year (year → recommended conversion amount). Same data as conversionsByYear, kept for chart rendering. */
+    perYearAmounts: Array<{ year: number; age: number; amount: number; estimatedTradBalance: number }>;
+    /** Debug log lines summarizing solver setup, grid, and per-year forward-walk decisions. */
+    summaryLogs: string[];
+    /** Per-year debug strings keyed by simulation year. Consumed by planConversionDP and pushed into the year's decisions/logs. */
+    perYearDebug: Map<number, string[]>;
+    /**
+     * Structured per-year traces (numeric form of [DEBUG DP …] logs). Consumed
+     * by the Roth debug screen to render the cost curve, waterfall, and
+     * balance-flow visualizations.
+     */
+    perYearTraces: Map<number, DPYearTrace>;
+}
+
+export interface DPPlan {
+    conversionsByYear: Map<number, number>;
+    diagnostics: DPDiagnostics;
+}
+
+// =============================================================================
+// CONTEXT EXTRACTION
+// =============================================================================
+
+/**
+ * Sum brokerage balances for a SimulationYear. Diagnostic only.
+ */
+function sumBrokerageBalanceDiag(simYear: SimulationYear): number {
+    return simYear.accounts
+        .filter((acc): acc is InvestedAccount =>
+            acc instanceof InvestedAccount && acc.taxType === 'Brokerage'
+        )
+        .reduce((sum, acc) => sum + acc.vestedAmount, 0);
+}
+
+/**
+ * Sum Roth balances for a SimulationYear. Diagnostic only.
+ */
+function sumRothBalanceDiag(simYear: SimulationYear): number {
+    return simYear.accounts
+        .filter((acc): acc is InvestedAccount =>
+            acc instanceof InvestedAccount && acc.taxType === 'Roth IRA'
+        )
+        .reduce((sum, acc) => sum + acc.vestedAmount, 0);
+}
+
+/**
+ * Sum traditional balances for a SimulationYear. Diagnostic only.
+ */
+function sumTradBalanceDiag(simYear: SimulationYear): number {
+    return simYear.accounts
+        .filter((acc): acc is InvestedAccount =>
+            acc instanceof InvestedAccount &&
+            (acc.taxType === 'Traditional 401k' || acc.taxType === 'Traditional IRA')
+        )
+        .reduce((sum, acc) => sum + acc.vestedAmount, 0);
+}
+
+/**
+ * Sum trad withdrawals from this year's withdrawalDetail. RMDs are no longer in
+ * withdrawalDetail (they're surfaced as income), so this is already RMD-free.
+ */
+function sumTraditionalWithdrawals(simYear: SimulationYear): number {
+    const traditionalNames = new Set(
+        simYear.accounts
+            .filter((acc): acc is InvestedAccount =>
+                acc instanceof InvestedAccount &&
+                (acc.taxType === 'Traditional 401k' || acc.taxType === 'Traditional IRA')
+            )
+            .map(acc => acc.name)
+    );
+    let total = 0;
+    for (const [name, amount] of Object.entries(simYear.cashflow.withdrawalDetail || {})) {
+        if (traditionalNames.has(name)) total += amount;
+    }
+    return total;
+}
+
+/**
+ * Compute the balance-weighted net growth rate for trad accounts in this
+ * baseline year. Mirrors InvestedAccount.increment (models.tsx:199-201) so
+ * DP's forward sweep tracks real-sim's actual trad evolution. Per-account
+ * formula: (customROR ?? globalROR) + inflationAdjustment − expenseRatio.
+ * Inflation is added when assumptions.macro.inflationAdjusted is true (the
+ * sim runs in nominal dollars). Weighted by vested balance across trad
+ * accounts.
+ */
+function getNetGrowthRate(simYear: SimulationYear, assumptions: AssumptionsState): number {
+    const tradAccounts = simYear.accounts.filter((acc): acc is InvestedAccount =>
+        acc instanceof InvestedAccount &&
+        (acc.taxType === 'Traditional 401k' || acc.taxType === 'Traditional IRA')
+    );
+    const globalRoR = assumptions.investments.returnRates.ror ?? 7;
+    const inflationAdjustment = assumptions.macro.inflationAdjusted
+        ? assumptions.macro.inflationRate
+        : 0;
+    const totalBalance = tradAccounts.reduce((s, a) => s + a.vestedAmount, 0);
+    if (totalBalance <= 0) {
+        return (globalRoR + inflationAdjustment) / 100;
+    }
+    const weightedRatePct = tradAccounts.reduce((sum, a) => {
+        const ror = a.customROR ?? globalRoR;
+        const accountRatePct = ror + inflationAdjustment - a.expenseRatio;
+        return sum + accountRatePct * a.vestedAmount;
+    }, 0) / totalBalance;
+    return weightedRatePct / 100;
+}
+
+/**
+ * Same formula as `getNetGrowthRate` but filtering for Roth accounts. Used
+ * by the 3D solver to project Roth-balance evolution year-over-year. When
+ * a baseline year has no Roth balance, falls back to the global RoR (DP
+ * may project a Roth balance even where baseline has none, e.g. via
+ * conversions earlier in the plan).
+ */
+function getRothGrowthRate(simYear: SimulationYear, assumptions: AssumptionsState): number {
+    const rothAccounts = simYear.accounts.filter((acc): acc is InvestedAccount =>
+        acc instanceof InvestedAccount && acc.taxType === 'Roth IRA'
+    );
+    const globalRoR = assumptions.investments.returnRates.ror ?? 7;
+    const inflationAdjustment = assumptions.macro.inflationAdjusted
+        ? assumptions.macro.inflationRate
+        : 0;
+    const totalBalance = rothAccounts.reduce((s, a) => s + a.vestedAmount, 0);
+    if (totalBalance <= 0) {
+        return (globalRoR + inflationAdjustment) / 100;
+    }
+    const weightedRatePct = rothAccounts.reduce((sum, a) => {
+        const ror = a.customROR ?? globalRoR;
+        const accountRatePct = ror + inflationAdjustment - a.expenseRatio;
+        return sum + accountRatePct * a.vestedAmount;
+    }, 0) / totalBalance;
+    return weightedRatePct / 100;
+}
+
+/**
+ * Build per-year contexts from a baseline simulation timeline.
+ *
+ * The baseline should be a std-ded-only, no-extra-conversion full-horizon sim
+ * (so its `nonSSOrdinaryIncome` does not include the conversion the DP is
+ * deciding). Out-of-retirement years (before retirementAge) are skipped.
+ */
+export function buildDPYearContexts(
+    baseline: SimulationYear[],
+    assumptions: AssumptionsState,
+    taxState: TaxState,
+    retirementYear: number,
+    /**
+     * Brokerage balance entering the FIRST context year (= retirementYear).
+     * Falls back to baseline lookup at (retirementYear − 1) when that year
+     * is in the baseline; this param covers the already-retired-today case
+     * where no prior baseline year exists. Subsequent contexts always use
+     * baseline's prior-year ending balance.
+     */
+    startingBrokerageBalance: number,
+): DPYearContext[] {
+    const contexts: DPYearContext[] = [];
+    const birthYear = getBirthYear(assumptions.milestones);
+    const rmdStartAge = getRMDStartAge(birthYear);
+
+    // Diagnostic: capture the baseline sub-sim's trad balance at the year
+    // BEFORE retirement. If `currentTradBalance` (used by DP's forward sweep)
+    // matches this value, it means the lookup is grabbing the end-of-(year
+    // before retirement) record — which is the correct start-of-retirement
+    // state. If `currentTradBalance` matches baselineTrad@retirementYear
+    // (which is what the existing setup log compares), there's a one-year
+    // off-by-one (DP is starting from end-of-retirement-year-1 baseline).
+    const preRetirementSimYear = baseline.find(y => y.year === retirementYear - 1);
+    const preRetirementBaselineTrad = preRetirementSimYear
+        ? sumTradBalanceDiag(preRetirementSimYear)
+        : undefined;
+
+    // Track the previous sim year so each context can record the brokerage
+    // balance ENTERING that year (= prior year's end). For the first context
+    // (= retirementYear), prev = preRetirementSimYear; if that doesn't
+    // exist (retiring in year 0 of the sim), fall back to startingBrokerageBalance.
+    let prevSimYear: SimulationYear | undefined = preRetirementSimYear;
+
+    for (const simYear of baseline) {
+        if (simYear.year < retirementYear) {
+            prevSimYear = simYear;
+            continue;
+        }
+        const age = simYear.year - birthYear;
+
+        const ssBenefits = TaxService.getSocialSecurityBenefits(simYear.incomes, simYear.year);
+        const grossIncome = TaxService.getGrossIncome(simYear.incomes, simYear.year);
+
+        // Traditional non-RMD withdrawals are taxed as ordinary income but aren't
+        // tracked as Income objects. Phase 2: trad-spending becomes endogenous in
+        // the 3D solver (Phase 3's evaluateCell rewrite); we no longer add
+        // baseline trad-spending into nonSSOrdinaryIncomeExclRMD. Still computed
+        // to populate `baselineTradWithdrawal`, which the in-flight 2D solver
+        // uses until Phase 3 lands.
+        // withdrawalDetail no longer includes RMD (RMD is surfaced as income), so the
+        // trad withdrawal sum is already RMD-free — no subtraction needed.
+        const tradNonRMDWithdrawals = sumTraditionalWithdrawals(simYear);
+        const baselineRMDAmount = simYear.rmdDetails?.totalRMD ?? 0;
+
+        // getGrossIncome includes RMD (PassiveIncome with sourceType='RMD') but
+        // excludes conversions and non-RMD trad withdrawals. We want
+        // plan-INDEPENDENT ordinary-on-return — wages/pension/passive — EXCLUDING
+        // RMD, SS, conversion, AND baseline trad withdrawals. RMD, conversion,
+        // and trad-spending are added back inside evaluateCell using state-derived
+        // amounts (Phase 3 makes trad-spending endogenous; Phase 2 leaves a
+        // brief inconsistency where the 2D solver under-counts ordinary income
+        // in trad-spending years).
+        const nonSSOrdinaryIncomeExclRMD = Math.max(
+            0,
+            grossIncome - ssBenefits - baselineRMDAmount,
+        );
+        const ltcgIncome = simYear.taxDetails.longTermCapitalGains ?? 0;
+
+        const fedParams = TaxService.getTaxParameters(
+            simYear.year, taxState.filingStatus, 'federal', undefined, assumptions
+        );
+        if (!fedParams) continue;
+        const stateParams = TaxService.getTaxParameters(
+            simYear.year, taxState.filingStatus, 'state', taxState.stateResidency, assumptions
+        );
+
+        // ACA cliff applies pre-65 only (Medicare eligibility starts at 65).
+        let acaOptions: ACAOptions | undefined;
+        if (assumptions.investments.acaAware !== false && age < 65) {
+            const acaFiling: 'single' | 'married_filing_jointly' =
+                taxState.filingStatus === 'Married Filing Jointly' ? 'married_filing_jointly' : 'single';
+            acaOptions = {
+                currentAge: age,
+                acaSubsidyAware: true,
+                acaCliffThreshold: getAcaCliffThreshold(acaFiling, simYear.year),
+                estimatedSubsidyLoss: ACA_SUBSIDY_LOSS_DEFAULT,
+            };
+        }
+
+        const growthRate = getNetGrowthRate(simYear, assumptions);
+        const rothGrowthRate = getRothGrowthRate(simYear, assumptions);
+        const rmdDivisor = age >= rmdStartAge ? getDistributionPeriod(age) : 0;
+
+        // Pre-tax spending need: cashflow.totalExpense includes baseline taxes,
+        // which the DP recomputes per-plan. Strip them so we don't double-count.
+        // Early-withdrawal penalty is rolled into `fed` already.
+        const baselineTaxes =
+            (simYear.taxDetails.fed ?? 0)
+            + (simYear.taxDetails.state ?? 0)
+            + (simYear.taxDetails.fica ?? 0);
+        const spendingNeed = Math.max(
+            0,
+            (simYear.cashflow.totalExpense ?? 0) - baselineTaxes,
+        );
+
+        // Brokerage entering this year. For the first context (= retirementYear),
+        // prevSimYear is preRetirementSimYear (year retirementYear − 1) when
+        // available; otherwise fall back to the caller-supplied
+        // startingBrokerageBalance. For subsequent retirement years, prevSimYear
+        // is always populated from the prior loop iteration.
+        const baselineBrokerageAvailable = prevSimYear
+            ? sumBrokerageBalanceDiag(prevSimYear)
+            : startingBrokerageBalance;
+
+        contexts.push({
+            year: simYear.year,
+            age,
+            nonSSOrdinaryIncomeExclRMD,
+            ssBenefits,
+            ltcgIncome,
+            filingStatus: taxState.filingStatus,
+            fedParams,
+            stateParams: stateParams ?? null,
+            acaOptions,
+            baselineTradWithdrawal: tradNonRMDWithdrawals,
+            spendingNeed,
+            baselineBrokerageAvailable,
+            rothGrowthRate,
+            baselineRothBalance: sumRothBalanceDiag(simYear),
+            baselineBrokerageBalance: sumBrokerageBalanceDiag(simYear),
+            baselineTradBalance: sumTradBalanceDiag(simYear),
+            baselineConversionAmount: simYear.rothConversion?.amount ?? 0,
+            // Attach the pre-retirement diagnostic only to the FIRST context
+            // (i.e., when this is the first push for retirementYear).
+            diagnosticPreRetirementBaselineTrad:
+                contexts.length === 0 ? preRetirementBaselineTrad : undefined,
+            growthRate,
+            rmdDivisor,
+        });
+
+        prevSimYear = simYear;
+    }
+
+    return contexts;
+}
+
+// =============================================================================
+// CELL EVALUATION
+// =============================================================================
+
+/**
+ * Compute this year's absolute total tax (federal + state + ACA penalty) for
+ * a given total ordinary-income figure. The DP's V-table accumulates these
+ * absolute taxes across the horizon, which lets it see future-RMD savings
+ * from a today-conversion (lower future trad → lower future RMD → lower
+ * future ordinary income → lower future absolute tax). A conversion's
+ * marginal tax cost is just `yearTax(with conv) − yearTax(without conv)`.
+ */
+function computeYearTax(
+    ordinaryIncome: number,
+    ctx: DPYearContext,
+): number {
+    const fed = TaxService.calculateTotalFederalTax(
+        ordinaryIncome,
+        ctx.ssBenefits,
+        0,                       // STCG
+        ctx.ltcgIncome,
+        0,                       // preTaxDeductions (already in nonSSOrdinaryIncomeExclRMD)
+        ctx.filingStatus,
+        ctx.fedParams,
+    ).totalTax;
+
+    let state = 0;
+    if (ctx.stateParams) {
+        // Most states tax LTCG as ordinary. SS treatment mirrors the real sim's
+        // calculateUnifiedStateTax (stateTax.ts): `ordinaryIncome` here already
+        // EXCLUDES SS, so the state base is non-SS ordinary + LTCG, plus — only
+        // for states that tax SS — the IRS-taxable portion of SS. SS-taxing
+        // states (e.g. via the SS torpedo) make a conversion that raises
+        // provisional income create real state tax the DP must price in.
+        let stateBase = ordinaryIncome + ctx.ltcgIncome;
+        if (ctx.ssBenefits > 0 && ctx.stateParams.socialSecurityTreatment === 'taxable') {
+            // agiExcludingSS = non-SS ordinary + LTCG (preTaxDeductions already
+            // folded into nonSSOrdinaryIncomeExclRMD upstream).
+            const taxableSS = TaxService.getTaxableSocialSecurityBenefits(
+                ctx.ssBenefits,
+                ordinaryIncome + ctx.ltcgIncome,
+                0,
+                ctx.filingStatus,
+            );
+            stateBase += taxableSS;
+        }
+        state = TaxService.calculateTax(stateBase, 0, ctx.stateParams);
+    }
+
+    let acaPenalty = 0;
+    if (ctx.acaOptions) {
+        // ACA MAGI ≈ ordinaryIncome + full SS + LTCG. Cliff is binary at threshold.
+        const magi = ordinaryIncome + ctx.ssBenefits + ctx.ltcgIncome;
+        if (magi >= ctx.acaOptions.acaCliffThreshold) {
+            acaPenalty = ctx.acaOptions.estimatedSubsidyLoss;
+        }
+    }
+
+    return fed + state + acaPenalty;
+}
+
+/**
+ * Single-cell evaluation (3D-ready): given (tradBalance, rothBalance,
+ * conversion, ctx), simulate the year's spending waterfall and tax in
+ * one shot.
+ *
+ * Tax routing mirrors the real sim's WITHHOLD path: the year's gap
+ * (spending need + this-year tax − cash from ordinary income) flows
+ * through the withdrawal order brokerage → roth → trad. The portion that
+ * ends up coming from trad (`tradSpending`) becomes ordinary income and
+ * feeds back into the tax calc. yearTax and tradSpending are coupled, so
+ * we resolve via a small fixed-point iteration. Most years converge in 0
+ * iterations because there's enough brokerage + Roth (or enough ordinary
+ * income from SS/RMD/pension) to keep tradSpending = 0 — the
+ * initial-guess yearTax is already exact.
+ *
+ * Returns:
+ * - `yearTax`: actual federal + state + ACA tax (no infeasibility penalty;
+ *   the solver applies that separately via `unmetNeed`).
+ * - `conversionMarginal`: yearTax − taxBaseline (diagnostic only).
+ * - `tradNext`, `rothNext`: end-of-year balances after flows + growth.
+ * - `tradSpending`, `fromRoth`, `fromBrokerage`: waterfall breakdown for
+ *   diagnostics.
+ * - `unmetNeed`: dollars of `totalNeed` the waterfall couldn't source
+ *   (means the plan ran out of money this year). Solver penalizes via
+ *   INFEASIBILITY_PENALTY_PER_DOLLAR.
+ *
+ * `taxBaseline` is `computeYearTax(ordinaryIncomeBase, ctx)` — i.e. tax
+ * with conversion = 0 and no trad-spending. Used only for the marginal
+ * diagnostic. Cached by the caller so the inner conversion-loop doesn't
+ * recompute it 200× per (year, trad, roth).
+ *
+ * Brokerage is exogenous (per-year baseline cap, not state) — see module
+ * header. LTCG is taken from baseline as well; if a DP plan draws much
+ * more from brokerage than baseline, this under-counts LTCG tax. Known
+ * limitation, accepted to keep state at 3D.
+ */
+function evaluateCell(
+    tradBalance: number,
+    rothBalance: number,
+    conversion: number,
+    ctx: DPYearContext,
+    taxBaseline: number,
+    /**
+     * Pre-computed initial-guess tax = `computeYearTax(ordIncomeExclTradSpend,
+     * ctx)`, i.e. the year's tax assuming zero trad-spending. This quantity
+     * depends only on (conversion, tradBalance via RMD) and NOT on
+     * rothBalance, so the backward sweep hoists it out of the rothIdx loop and
+     * passes it in to avoid recomputing the full fed+state+SS tax once per
+     * rothIdx. When omitted (forward extract / debug-curve paths), it's
+     * computed inline as before. The fixed-point still recomputes tax inside
+     * the loop whenever trad-spending > 0 (the roth-dependent path), so
+     * results are numerically identical.
+     */
+    precomputedInitialTax?: number,
+): {
+    yearTax: number;
+    conversionMarginal: number;
+    tradNext: number;
+    rothNext: number;
+    tradSpending: number;
+    fromRoth: number;
+    fromBrokerage: number;
+    unmetNeed: number;
+} {
+    const rmd = ctx.rmdDivisor > 0 ? tradBalance / ctx.rmdDivisor : 0;
+    const ordIncomeExclTradSpend = ctx.nonSSOrdinaryIncomeExclRMD + rmd + conversion;
+    const tradAvailableForSpending = Math.max(0, tradBalance - conversion - rmd);
+
+    // Cash that ordinary income provides this year — wages/pension/passive
+    // (nonSSOrdExclRMD), full SS benefits, and RMD all land in the user's
+    // pocket and offset the spending+tax demand. Without this offset the
+    // waterfall would over-source by the full ordinary-income amount, which
+    // in late retirement years (SS+RMD) can be tens of thousands of dollars.
+    // Conversion is intentionally NOT in here: a conversion creates ordinary
+    // income for tax purposes but is a Trad→Roth transfer, not cash.
+    const cashFromOrdinary =
+        ctx.nonSSOrdinaryIncomeExclRMD + ctx.ssBenefits + rmd;
+
+    // Initial guess: tax assuming no trad-spending. This is exact when the
+    // waterfall can cover totalNeed from brokerage + roth alone (the common
+    // case in early retirement years). Depends only on (conversion,
+    // tradBalance) — the backward sweep precomputes it once per (tradIdx,
+    // convIdx) and passes it in (see precomputedInitialTax docs).
+    let yearTax = precomputedInitialTax !== undefined
+        ? precomputedInitialTax
+        : computeYearTax(ordIncomeExclTradSpend, ctx);
+    let fromBrokerage = 0;
+    let fromRoth = 0;
+    let tradSpending = 0;
+
+    // Fixed-point: yearTax → totalNeed → waterfall → tradSpending →
+    // ordIncome → yearTax. Up to 5 iterations; in practice 1-2.
+    for (let iter = 0; iter < 5; iter++) {
+        // totalNeed is the cash gap the waterfall must source: spending
+        // demand (livingPlusPayroll + this year's tax) minus cash supplied
+        // by ordinary income. Clamped to ≥ 0 — surplus years have no gap.
+        const totalNeed = Math.max(
+            0,
+            ctx.spendingNeed + yearTax - cashFromOrdinary,
+        );
+        fromBrokerage = Math.min(totalNeed, ctx.baselineBrokerageAvailable);
+        const remainingAfterBrokerage = totalNeed - fromBrokerage;
+        fromRoth = Math.min(remainingAfterBrokerage, rothBalance);
+        const tradSpendingNeeded = Math.max(0, remainingAfterBrokerage - fromRoth);
+        tradSpending = Math.min(tradSpendingNeeded, tradAvailableForSpending);
+
+        // No trad-spending ⇒ initial yearTax guess was exact, done.
+        if (tradSpending === 0) break;
+
+        const ordIncome = ordIncomeExclTradSpend + tradSpending;
+        const newYearTax = computeYearTax(ordIncome, ctx);
+        if (Math.abs(newYearTax - yearTax) < 1) {
+            yearTax = newYearTax;
+            break;
+        }
+        yearTax = newYearTax;
+    }
+
+    const totalNeedFinal = Math.max(
+        0,
+        ctx.spendingNeed + yearTax - cashFromOrdinary,
+    );
+    const sourced = fromBrokerage + fromRoth + tradSpending;
+    const unmetNeed = Math.max(0, totalNeedFinal - sourced);
+
+    const conversionMarginal = Math.max(0, yearTax - taxBaseline);
+    const tradNext = Math.max(0, tradBalance - conversion - rmd - tradSpending) * (1 + ctx.growthRate);
+    const rothNext = Math.max(0, rothBalance + conversion - fromRoth) * (1 + ctx.rothGrowthRate);
+
+    return {
+        yearTax,
+        conversionMarginal,
+        tradNext,
+        rothNext,
+        tradSpending,
+        fromRoth,
+        fromBrokerage,
+        unmetNeed,
+    };
+}
+
+/**
+ * Bilinear interpolation lookup into a 2D value-function table indexed by
+ * (tradIdx, rothIdx). The table is stored as a flat Float64Array with stride
+ * (ROTH_BUCKETS + 1) in the roth dimension — element at (tradIdx, rothIdx)
+ * lives at `V[tradIdx * (rothBuckets + 1) + rothIdx]`.
+ *
+ * Out-of-grid values clamp to the table boundary in each dimension. Returns
+ * the bilinear blend of the four enclosing corner samples weighted by the
+ * fractional position within the (trad, roth) cell.
+ */
+function interpV2D(
+    V: Float64Array,
+    tradBalance: number,
+    rothBalance: number,
+    dB: number,
+    dRoth: number,
+    tradBuckets: number,
+    rothBuckets: number,
+): number {
+    const trad = tradBalance < 0 ? 0 : tradBalance;
+    const roth = rothBalance < 0 ? 0 : rothBalance;
+
+    let tIdx = trad / dB;
+    let rIdx = roth / dRoth;
+    if (tIdx > tradBuckets) tIdx = tradBuckets;
+    if (rIdx > rothBuckets) rIdx = rothBuckets;
+
+    const t0 = tIdx | 0;
+    const r0 = rIdx | 0;
+    const t1 = t0 < tradBuckets ? t0 + 1 : tradBuckets;
+    const r1 = r0 < rothBuckets ? r0 + 1 : rothBuckets;
+
+    const tFrac = tIdx - t0;
+    const rFrac = rIdx - r0;
+
+    const stride = rothBuckets + 1;
+    const v00 = V[t0 * stride + r0];
+    const v01 = V[t0 * stride + r1];
+    const v10 = V[t1 * stride + r0];
+    const v11 = V[t1 * stride + r1];
+
+    const v0 = v00 * (1 - rFrac) + v01 * rFrac;
+    const v1 = v10 * (1 - rFrac) + v11 * rFrac;
+    return v0 * (1 - tFrac) + v1 * tFrac;
+}
+
+// =============================================================================
+// SOLVER
+// =============================================================================
+
+/**
+ * Compute per-year grid scales (`dBByYear`, `dRothByYear`) for the V-table.
+ *
+ * A single uniform grid is the wrong shape for a long-horizon DP: realistic
+ * roth/trad values span ~$200k–$2M in year 1 but compound to tens of
+ * millions over a 40+ year horizon. With one `dRoth`, either early-year
+ * values fall inside a single bucket (interp manufactures fake costs from
+ * unreachable corners) or late-year values exceed the grid (clipped at
+ * boundary). Per-year scales adapt to each year's reachable range.
+ *
+ * Bounds are derived from two independent forward simulations:
+ * - **Trad-max trajectory** (no conversions, no spending): RMD + growth
+ *   only. Maximizes the trad balance reachable at year `t`.
+ * - **Roth-max trajectory** (convert MAX_CONVERSION_CAP/yr, no spending,
+ *   no withdrawals): drains trad into roth as fast as the inner-loop
+ *   conversion cap allows, then lets the roth pile compound. Maximizes
+ *   the roth balance reachable at year `t`.
+ *
+ * Both bounds get a 30% headroom factor and a `MIN_BALANCE_RANGE` floor
+ * so the grid stays usable for small portfolios. Returned arrays have
+ * length `horizonYears + 1` (index `t` covers V[t]'s start-of-year-`t`
+ * state space; index `horizonYears` is the terminal V-table).
+ */
+function determineGridScales(
+    contexts: DPYearContext[],
+    currentTradBalance: number,
+    currentRothBalance: number,
+): { dBByYear: number[]; dRothByYear: number[]; dCByYear: number[] } {
+    const horizonYears = contexts.length;
+    const tradMaxByYear: number[] = new Array(horizonYears + 1);
+    const rothMaxByYear: number[] = new Array(horizonYears + 1);
+    tradMaxByYear[0] = currentTradBalance;
+    rothMaxByYear[0] = currentRothBalance;
+
+    // Trad-max trajectory: no conversions, no spending.
+    {
+        let trad = currentTradBalance;
+        for (let t = 0; t < horizonYears; t++) {
+            const ctx = contexts[t];
+            const rmd = ctx.rmdDivisor > 0 ? trad / ctx.rmdDivisor : 0;
+            trad = Math.max(0, trad - rmd) * (1 + ctx.growthRate);
+            tradMaxByYear[t + 1] = trad;
+        }
+    }
+
+    // Roth-max trajectory: convert as fast as the per-year cap allows.
+    {
+        let trad = currentTradBalance;
+        let roth = currentRothBalance;
+        for (let t = 0; t < horizonYears; t++) {
+            const ctx = contexts[t];
+            const rmd = ctx.rmdDivisor > 0 ? trad / ctx.rmdDivisor : 0;
+            const conv = Math.min(MAX_CONVERSION_CAP, Math.max(0, trad - rmd));
+            trad = Math.max(0, trad - conv - rmd) * (1 + ctx.growthRate);
+            roth = (roth + conv) * (1 + ctx.rothGrowthRate);
+            rothMaxByYear[t + 1] = roth;
+        }
+    }
+
+    const dBByYear = tradMaxByYear.map(v =>
+        Math.max(MIN_BALANCE_RANGE, v * BALANCE_HEADROOM_FACTOR) / TRAD_BUCKETS
+    );
+    const dRothByYear = rothMaxByYear.map(v =>
+        Math.max(MIN_BALANCE_RANGE, v * BALANCE_HEADROOM_FACTOR) / ROTH_BUCKETS
+    );
+
+    // Per-year conversion grid: each year's dC scales to that year's
+    // reachable trad balance (the no-conversion/no-spending trad-max
+    // trajectory), applying the MAX_CONVERSION_CAP ceiling and
+    // MIN_CONVERSION_RANGE floor off the projected balance rather than the
+    // year-0 balance.
+    // This preserves fine early-year resolution AND full late-year reach,
+    // so conversions between the old year-0 ceiling and a later cell's true
+    // cMax are no longer silently truncated.
+    const dCByYear = tradMaxByYear.map(v =>
+        Math.min(MAX_CONVERSION_CAP, Math.max(MIN_CONVERSION_RANGE, v)) / CONVERSION_BUCKETS
+    );
+
+    return { dBByYear, dRothByYear, dCByYear };
+}
+
+/**
+ * Run the DP backward sweep + forward extract, producing a per-year plan.
+ */
+export function planConversionsViaDP(inputs: DPInputs): DPPlan {
+    const startedAt = performance.now();
+    const { contexts, currentTradBalance, currentRothBalance } = inputs;
+    const delta = inputs.backloadDelta ?? DP_BACKLOAD_DELTA;
+    const discountFactor = 1 / (1 + delta);
+
+    const horizonYears = contexts.length;
+
+    // Empty-horizon edge case.
+    if (horizonYears === 0) {
+        return {
+            conversionsByYear: new Map(),
+            diagnostics: {
+                backloadDelta: delta,
+                tradBuckets: TRAD_BUCKETS,
+                rothBuckets: ROTH_BUCKETS,
+                conversionBuckets: CONVERSION_BUCKETS,
+                maxBalance: 0,
+                maxRoth: 0,
+                dB: 0,
+                dRoth: 0,
+                dBByYear: [],
+                dRothByYear: [],
+                dCByYear: [],
+                dC: 0,
+                maxConversion: 0,
+                horizonYears: 0,
+                elapsedMs: 0,
+                perYearAmounts: [],
+                summaryLogs: ['[DEBUG DP] Empty horizon — no contexts to solve.'],
+                perYearDebug: new Map(),
+                perYearTraces: new Map(),
+            },
+        };
+    }
+
+    const { dBByYear, dRothByYear, dCByYear } = determineGridScales(
+        contexts, currentTradBalance, currentRothBalance,
+    );
+    // Legacy/representative scalars: max-of-horizon. Some diagnostics
+    // consumers (and tests) reference `dB`, `dRoth`, `maxBalance`,
+    // `maxRoth` as scalars; we surface the worst-case bucket width across
+    // the horizon for backward compatibility.
+    const dB = Math.max(...dBByYear);
+    const dRoth = Math.max(...dRothByYear);
+    const maxBalance = dB * TRAD_BUCKETS;
+    const maxRoth = dRoth * ROTH_BUCKETS;
+    // Representative scalars for diagnostics: the conversion grid is now
+    // per-year (dCByYear), so surface the widest bucket across the horizon
+    // (and its implied ceiling) for the DPDiagnostics fields and any
+    // consumer (e.g. RothConversionDebug.tsx) that reads scalar dC /
+    // maxConversion. The solver itself uses dCByYear[t] per cell.
+    const dC = Math.max(...dCByYear);
+    const maxConversion = dC * CONVERSION_BUCKETS;
+    const summaryLogs: string[] = [];
+    const perYearDebug = new Map<number, string[]>();
+    const perYearTraces = new Map<number, DPYearTrace>();
+    const fmt$ = (n: number) => '$' + Math.round(n).toLocaleString();
+    const vTableMB =
+        ((TRAD_BUCKETS + 1) * (ROTH_BUCKETS + 1) * (horizonYears + 1) * 8) / (1024 * 1024);
+    summaryLogs.push(
+        `[DEBUG DP] solver: δ=${(delta * 100).toFixed(2)}%, df=${discountFactor.toFixed(4)}, ` +
+        `tradBuckets=${TRAD_BUCKETS}, rothBuckets=${ROTH_BUCKETS}, convBuckets=${CONVERSION_BUCKETS}, ` +
+        `maxConversion=${fmt$(maxConversion)} (dC=${fmt$(dC)}), horizon=${horizonYears} years, ` +
+        `V-table 2D ≈ ${vTableMB.toFixed(2)} MB`,
+    );
+    // Per-year grid scales. Each year `t` has its own dB[t]/dRoth[t]
+    // sized to that year's reachable (trad, roth) range. Early years
+    // get fine resolution where conversion decisions matter; late years
+    // get looser buckets where roth has compounded but decisions are
+    // already locked in. Sample the first few years and a midpoint plus
+    // the last to see the shape — printing all 46+ years would be noise.
+    const sampleYears = Array.from(new Set([
+        0, 1, 5,
+        Math.floor(horizonYears / 2),
+        horizonYears - 1, horizonYears,
+    ].filter(t => t >= 0 && t <= horizonYears)));
+    const dBSamples = sampleYears
+        .map(t => `t=${t}:${fmt$(dBByYear[t])}`).join(', ');
+    const dRothSamples = sampleYears
+        .map(t => `t=${t}:${fmt$(dRothByYear[t])}`).join(', ');
+    summaryLogs.push(
+        `[DEBUG DP] per-year dB (trad bucket width): ${dBSamples}`,
+    );
+    summaryLogs.push(
+        `[DEBUG DP] per-year dRoth (roth bucket width): ${dRothSamples}`,
+    );
+    let baselineTradPeak = 0;
+    let baselineRothPeak = 0;
+    for (const c of contexts) {
+        if ((c.baselineTradBalance ?? 0) > baselineTradPeak) baselineTradPeak = c.baselineTradBalance ?? 0;
+        if ((c.baselineRothBalance ?? 0) > baselineRothPeak) baselineRothPeak = c.baselineRothBalance ?? 0;
+    }
+    summaryLogs.push(
+        `[DEBUG DP] grid-sizing rationale: ` +
+        `baselineTradPeak=${fmt$(baselineTradPeak)}, ` +
+        `baselineRothPeak=${fmt$(baselineRothPeak)}. ` +
+        `Per-year scales above adapt to each year's reachable range; ` +
+        `legacy max scalars: maxBalance=${fmt$(maxBalance)} (dB=${fmt$(dB)}), ` +
+        `maxRoth=${fmt$(maxRoth)} (dRoth=${fmt$(dRoth)}).`,
+    );
+    summaryLogs.push(
+        `[DEBUG DP] start: currentTradBalance=${fmt$(currentTradBalance)}, ` +
+        `currentRothBalance=${fmt$(currentRothBalance)} ` +
+        `(both at start of FIRST context year — should be retirement-year balances, not today's), ` +
+        `firstYear=${contexts[0].year} (age ${contexts[0].age}), ` +
+        `lastYear=${contexts[horizonYears - 1].year} (age ${contexts[horizonYears - 1].age})`,
+    );
+    // Sample first 3 contexts so the user can see what the DP is seeing.
+    for (let i = 0; i < Math.min(3, horizonYears); i++) {
+        const c = contexts[i];
+        summaryLogs.push(
+            `[DEBUG DP] ctx[${i}] year=${c.year} age=${c.age}: ` +
+            `nonSSOrdExclRMD=${fmt$(c.nonSSOrdinaryIncomeExclRMD)}, ss=${fmt$(c.ssBenefits)}, ` +
+            `ltcg=${fmt$(c.ltcgIncome)}, ` +
+            `baselineTradWithdrawal=${fmt$(c.baselineTradWithdrawal)}, ` +
+            `rmdDivisor=${c.rmdDivisor.toFixed(2)}, growth=${(c.growthRate * 100).toFixed(2)}%`,
+        );
+    }
+
+    // V[t] is a flat Float64Array indexed by `tradIdx * (ROTH_BUCKETS+1) + rothIdx`,
+    // total size (TRAD_BUCKETS+1) × (ROTH_BUCKETS+1). V[horizonYears] is the terminal
+    // value (all zeros — no future tax).
+    const V_STRIDE = ROTH_BUCKETS + 1;
+    const V_SIZE = (TRAD_BUCKETS + 1) * V_STRIDE;
+    const V: Float64Array[] = new Array(horizonYears + 1);
+    for (let t = 0; t <= horizonYears; t++) {
+        V[t] = new Float64Array(V_SIZE);
+    }
+
+    // -----------------------------------------------------------------
+    // Backward sweep — 3D state (year, tradIdx, rothIdx).
+    //
+    // For each (t, tradIdx, rothIdx) cell, iterate over conversion buckets,
+    // evaluate the cell to get (yearTax, tradNext, rothNext, unmetNeed),
+    // then look up V[t+1] at (tradNext, rothNext) via bilinear interpolation
+    // in trad and roth. The minimum total-cost conversion wins.
+    //
+    // Phase 4 caveat: the inner conversion loop and `taxBaseline` only
+    // depend on (t, tradIdx) — recomputing them per rothIdx wastes work.
+    // We hoist them outside the rothIdx loop.
+    // -----------------------------------------------------------------
+    for (let t = horizonYears - 1; t >= 0; t--) {
+        const ctx = contexts[t];
+        const Vnext = V[t + 1];
+        const Vt = V[t];
+        const dB_t = dBByYear[t];
+        const dRoth_t = dRothByYear[t];
+        const dB_next = dBByYear[t + 1];
+        const dRoth_next = dRothByYear[t + 1];
+
+        for (let bi = 0; bi <= TRAD_BUCKETS; bi++) {
+            const b = bi * dB_t;
+
+            const rmdAtB = ctx.rmdDivisor > 0 ? b / ctx.rmdDivisor : 0;
+            const cMax = Math.max(0, b - rmdAtB);
+            // Baseline (no-conversion, no-trad-spending) tax — only used for
+            // the marginal diagnostic. Doesn't depend on rothIdx.
+            const taxBaseline = computeYearTax(ctx.nonSSOrdinaryIncomeExclRMD + rmdAtB, ctx);
+
+            // Hoist the roth-INDEPENDENT initial-guess tax out of the rothIdx
+            // loop. For a fixed (bi, ci), the conversion `c` and RMD are fixed
+            // (cMax depends only on b), so `ordIncomeExclTradSpend =
+            // nonSSOrdinaryIncomeExclRMD + rmdAtB + c` — and thus its full
+            // fed+state+SS tax — is identical across all rothIdx values. We
+            // compute it once per (bi, ci) here and reuse it for every ri.
+            // The fixed-point inside evaluateCell still recomputes tax when
+            // trad-spending > 0 (the genuinely roth-dependent path), so
+            // results are numerically identical.
+            const initialTaxByCi: number[] = new Array(CONVERSION_BUCKETS + 1);
+            {
+                let ci = 0;
+                for (; ci <= CONVERSION_BUCKETS; ci++) {
+                    const c = Math.min(ci * dCByYear[t], cMax);
+                    initialTaxByCi[ci] =
+                        computeYearTax(ctx.nonSSOrdinaryIncomeExclRMD + rmdAtB + c, ctx);
+                    if (c >= cMax) break;
+                }
+            }
+
+            for (let ri = 0; ri <= ROTH_BUCKETS; ri++) {
+                const r = ri * dRoth_t;
+
+                let bestCost = Infinity;
+
+                for (let ci = 0; ci <= CONVERSION_BUCKETS; ci++) {
+                    const c = Math.min(ci * dCByYear[t], cMax);
+                    const { yearTax, tradNext, rothNext, unmetNeed } =
+                        evaluateCell(b, r, c, ctx, taxBaseline, initialTaxByCi[ci]);
+
+                    const futureCost = interpV2D(
+                        Vnext, tradNext, rothNext,
+                        dB_next, dRoth_next, TRAD_BUCKETS, ROTH_BUCKETS,
+                    );
+                    const yearCost = yearTax + unmetNeed * INFEASIBILITY_PENALTY_PER_DOLLAR;
+                    const totalCost = yearCost + discountFactor * futureCost;
+
+                    if (totalCost < bestCost) bestCost = totalCost;
+
+                    if (c >= cMax) break;
+                }
+
+                Vt[bi * V_STRIDE + ri] = bestCost === Infinity ? taxBaseline : bestCost;
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Forward extract: walk the policy from current state.
+    // -----------------------------------------------------------------
+    const conversionsByYear = new Map<number, number>();
+    const perYearAmounts: DPDiagnostics['perYearAmounts'] = [];
+
+    let trad = currentTradBalance;
+    let roth = currentRothBalance;
+    // Snapshot for first-year debug: lets us see in the inspector whether the
+    // starting balances DP was handed match the baseline sub-sim's
+    // retirement-year balances (they should, per the a7eca53 fix).
+    const firstCtx = contexts[0];
+    const preRetirementBaselineTradVal = firstCtx.diagnosticPreRetirementBaselineTrad;
+    const startingDebug =
+        `[DEBUG DP setup] year=${firstCtx.year} (first context): ` +
+        `startingTrad=${fmt$(currentTradBalance)}, startingRoth=${fmt$(currentRothBalance)} ` +
+        `(both passed into planConversionsViaDP), ` +
+        `baselineTrad@firstYear=${fmt$(firstCtx.baselineTradBalance ?? 0)} (END of retirement year in baseline), ` +
+        `baselineTrad@(firstYear-1)=${preRetirementBaselineTradVal !== undefined ? fmt$(preRetirementBaselineTradVal) : 'n/a'} ` +
+        `(END of year BEFORE retirement = START of retirement year). ` +
+        `If startingTrad matches baselineTrad@(firstYear-1) ⇒ correct (start-of-retirement). ` +
+        `If startingTrad matches baselineTrad@firstYear ⇒ off-by-one (DP is starting from end-of-retirement-year baseline).`;
+
+    for (let t = 0; t < horizonYears; t++) {
+        const ctx = contexts[t];
+        const Vnext = V[t + 1];
+        const dB_next = dBByYear[t + 1];
+        const dRoth_next = dRothByYear[t + 1];
+
+        const rmdAtB = ctx.rmdDivisor > 0 ? trad / ctx.rmdDivisor : 0;
+        const cMax = Math.max(0, trad - rmdAtB);
+        const taxBaseline = computeYearTax(ctx.nonSSOrdinaryIncomeExclRMD + rmdAtB, ctx);
+
+        let bestC = 0;
+        let bestCost = Infinity;
+        let bestTradNext = trad;
+        let bestRothNext = roth;
+        let bestYearTax = 0;
+        let bestMarginal = 0;
+        let bestTradSpending = 0;
+        let bestFromRoth = 0;
+        let bestFromBrokerage = 0;
+        let bestUnmetNeed = 0;
+        // For the diagnostic table: cost @ c=0 vs cost @ a non-zero candidate.
+        let costAtZero = Infinity;
+        let yearTaxAtZero = 0;
+        let futureAtZero = 0;
+        let bestFuture = 0;
+
+        for (let ci = 0; ci <= CONVERSION_BUCKETS; ci++) {
+            const c = Math.min(ci * dCByYear[t], cMax);
+            const { yearTax, conversionMarginal, tradNext, rothNext, tradSpending, fromRoth, fromBrokerage, unmetNeed } =
+                evaluateCell(trad, roth, c, ctx, taxBaseline);
+
+            const futureCost = interpV2D(
+                Vnext, tradNext, rothNext,
+                dB_next, dRoth_next, TRAD_BUCKETS, ROTH_BUCKETS,
+            );
+            const yearCost = yearTax + unmetNeed * INFEASIBILITY_PENALTY_PER_DOLLAR;
+            const totalCost = yearCost + discountFactor * futureCost;
+
+            if (ci === 0) {
+                costAtZero = totalCost;
+                yearTaxAtZero = yearTax;
+                futureAtZero = futureCost;
+            }
+
+            if (totalCost < bestCost) {
+                bestCost = totalCost;
+                bestC = c;
+                bestTradNext = tradNext;
+                bestRothNext = rothNext;
+                bestYearTax = yearTax;
+                bestMarginal = conversionMarginal;
+                bestFuture = futureCost;
+                bestTradSpending = tradSpending;
+                bestFromRoth = fromRoth;
+                bestFromBrokerage = fromBrokerage;
+                bestUnmetNeed = unmetNeed;
+            }
+
+            if (c >= cMax) break;
+        }
+
+        conversionsByYear.set(ctx.year, bestC);
+        perYearAmounts.push({
+            year: ctx.year,
+            age: ctx.age,
+            amount: bestC,
+            estimatedTradBalance: trad,
+        });
+
+        // Per-year debug emitted to the year inspector via planConversionDP.
+        const debugLines: string[] = [];
+        if (t === 0) {
+            // Surface the setup info on the first conversion year so the user
+            // can spot starting-balance issues right in the inspector.
+            debugLines.push(startingDebug);
+        }
+        debugLines.push(
+            `[DEBUG DP solver] year=${ctx.year} age=${ctx.age}: ` +
+            `tradEntering=${fmt$(trad)}, rmdAtB=${fmt$(rmdAtB)}, cMax=${fmt$(cMax)}, ` +
+            `taxBaseline=${fmt$(taxBaseline)}`,
+        );
+        debugLines.push(
+            `[DEBUG DP solver] year=${ctx.year}: chose c=${fmt$(bestC)} ` +
+            `(yearTax=${fmt$(bestYearTax)}, marginal=${fmt$(bestMarginal)}, ` +
+            `discountedFuture=${fmt$(discountFactor * bestFuture)}, totalCost=${fmt$(bestCost)}, ` +
+            `tradNext=${fmt$(bestTradNext)}, rothNext=${fmt$(bestRothNext)})`,
+        );
+        debugLines.push(
+            `[DEBUG DP solver] year=${ctx.year}: c=0 totalCost=${fmt$(costAtZero)} ` +
+            `(yearTax=${fmt$(yearTaxAtZero)}, discountedFuture=${fmt$(discountFactor * futureAtZero)})`,
+        );
+        // Cost-curve sample at FEDERAL BRACKET BOUNDARIES so each segment in
+        // the rate-analysis table represents a single bracket — marginals
+        // read 10% → 12% → 22% → 24% → 32% → 35% as expected, instead of
+        // averages across multi-bracket ranges. Always include 0, the std-ded
+        // boundary, the chosen c, and cMax.
+        //
+        // Conversion needed to land taxable ordinary income at federal bracket
+        // threshold T:  c = (stdDed + T) − existingOrdinaryAtCellEntry
+        // where existingOrdinary = nonSSOrdinaryIncomeExclRMD + rmd (excludes
+        // the conversion itself, which we're varying).
+        const stdDed = ctx.fedParams.standardDeduction;
+        const existingOrdinary = ctx.nonSSOrdinaryIncomeExclRMD + rmdAtB;
+        const stdDedBoundaryC = Math.max(0, stdDed - existingOrdinary);
+        const bracketSampleCs = ctx.fedParams.brackets.map(
+            b => Math.max(0, stdDed + b.threshold - existingOrdinary),
+        );
+        const sampleCs = [
+            0,
+            stdDedBoundaryC,
+            ...bracketSampleCs,
+            bestC,
+            cMax,
+        ]
+            .filter(c => c >= 0 && c <= cMax)
+            .sort((a, b) => a - b)
+            .filter((c, i, arr) => i === 0 || Math.abs(c - arr[i - 1]) > 0.5);
+        const curveParts: string[] = [];
+        const costCurve: DPYearTrace['costCurve'] = [];
+        for (const sampleC of sampleCs) {
+            const r = evaluateCell(trad, roth, sampleC, ctx, taxBaseline);
+            const fc = interpV2D(
+                Vnext, r.tradNext, r.rothNext,
+                dB_next, dRoth_next, TRAD_BUCKETS, ROTH_BUCKETS,
+            );
+            const yc = r.yearTax + r.unmetNeed * INFEASIBILITY_PENALTY_PER_DOLLAR;
+            const dFut = discountFactor * fc;
+            const total = yc + dFut;
+            curveParts.push(
+                `c=${fmt$(sampleC)}→total=${fmt$(total)}` +
+                ` (yearTax=${fmt$(r.yearTax)}, dFut=${fmt$(dFut)}, ` +
+                `tradNext=${fmt$(r.tradNext)}, rothNext=${fmt$(r.rothNext)})`,
+            );
+            costCurve.push({
+                c: sampleC,
+                yearTax: r.yearTax,
+                discountedFuture: dFut,
+                totalCost: total,
+                tradNext: r.tradNext,
+                rothNext: r.rothNext,
+            });
+        }
+        debugLines.push(
+            `[DEBUG DP curve] year=${ctx.year}: ${curveParts.join(' | ')}`,
+        );
+        // Waterfall breakdown for the chosen conversion. The 3D solver
+        // tracks the running roth balance forward, so `cap` reflects what
+        // DP's own plan has left in Roth this year — not a baseline proxy.
+        // gap = max(0, spendingNeed + yearTax − cashFromOrdinary); sourced
+        // brokerage → roth → trad in the real-sim withdrawal order.
+        const cashFromOrd =
+            ctx.nonSSOrdinaryIncomeExclRMD + ctx.ssBenefits + rmdAtB;
+        const gap = Math.max(0, ctx.spendingNeed + bestYearTax - cashFromOrd);
+        debugLines.push(
+            `[DEBUG DP waterfall] year=${ctx.year}: ` +
+            `spendingNeed=${fmt$(ctx.spendingNeed)} + yearTax=${fmt$(bestYearTax)} − ` +
+            `cashFromOrdinary=${fmt$(cashFromOrd)} = gap=${fmt$(gap)} → ` +
+            `fromBrokerage=${fmt$(bestFromBrokerage)} (cap=${fmt$(ctx.baselineBrokerageAvailable)}), ` +
+            `fromRoth=${fmt$(bestFromRoth)} (cap=${fmt$(roth)}), ` +
+            `tradSpending=${fmt$(bestTradSpending)}, unmetNeed=${fmt$(bestUnmetNeed)}`,
+        );
+        // Forward-sweep decomposition: shows exactly how DP is propagating
+        // trad and roth jointly under the chosen plan.
+        // tradAfterFlows = tradEntering − conversion − rmd − tradSpending
+        // tradNext = tradAfterFlows × (1 + growthRate)
+        // rothAfterFlows = rothEntering + conversion − fromRoth
+        // rothNext = max(0, rothAfterFlows) × (1 + rothGrowthRate)
+        const tradAfterFlows = trad - bestC - rmdAtB - bestTradSpending;
+        const rothAfterFlows = roth + bestC - bestFromRoth;
+        debugLines.push(
+            `[DEBUG DP forward] year=${ctx.year}: ` +
+            `tradEntering=${fmt$(trad)} − c=${fmt$(bestC)} − rmd=${fmt$(rmdAtB)} − ` +
+            `tradSpending=${fmt$(bestTradSpending)} ` +
+            `= ${fmt$(tradAfterFlows)} × (1 + ${(ctx.growthRate * 100).toFixed(2)}%) = tradNext=${fmt$(bestTradNext)}`,
+        );
+        debugLines.push(
+            `[DEBUG DP forward roth] year=${ctx.year}: ` +
+            `rothEntering=${fmt$(roth)} + c=${fmt$(bestC)} − fromRoth=${fmt$(bestFromRoth)} ` +
+            `= ${fmt$(rothAfterFlows)} × (1 + ${(ctx.rothGrowthRate * 100).toFixed(2)}%) = rothNext=${fmt$(bestRothNext)}`,
+        );
+        // Baseline trajectory snapshot (std-ded-only sub-sim). The 3D solver
+        // tracks both trad and roth jointly under DP's own plan, so divergence
+        // from baseline here is expected and informative — compare DP's
+        // tradEntering / rothEntering above with these baseline values to see
+        // how the chosen plan differs.
+        debugLines.push(
+            `[DEBUG DP baseline] year=${ctx.year}: ` +
+            `baselineTrad=${fmt$(ctx.baselineTradBalance ?? 0)}, ` +
+            `baselineRoth=${fmt$(ctx.baselineRothBalance ?? 0)}, ` +
+            `baselineBrokerage=${fmt$(ctx.baselineBrokerageBalance ?? 0)}, ` +
+            `baselineConversion=${fmt$(ctx.baselineConversionAmount ?? 0)}, ` +
+            `baselineTradWithdrawal=${fmt$(ctx.baselineTradWithdrawal)}`,
+        );
+        perYearDebug.set(ctx.year, debugLines);
+
+        // Structured trace for the Roth debug screen.
+        const trace: DPYearTrace = {
+            year: ctx.year,
+            age: ctx.age,
+            chosenC: bestC,
+            yearTax: bestYearTax,
+            conversionMarginal: bestMarginal,
+            discountedFuture: discountFactor * bestFuture,
+            totalCost: bestCost,
+            tradEntering: trad,
+            rothEntering: roth,
+            rmdAtEntering: rmdAtB,
+            cMax,
+            taxBaselineNoConv: taxBaseline,
+            tradNext: bestTradNext,
+            rothNext: bestRothNext,
+            spendingNeed: ctx.spendingNeed,
+            cashFromOrdinary: cashFromOrd,
+            gap,
+            fromBrokerage: bestFromBrokerage,
+            fromRoth: bestFromRoth,
+            tradSpending: bestTradSpending,
+            unmetNeed: bestUnmetNeed,
+            baselineBrokerageCap: ctx.baselineBrokerageAvailable,
+            costCurve,
+            baselineTrad: ctx.baselineTradBalance,
+            baselineRoth: ctx.baselineRothBalance,
+            baselineBrokerage: ctx.baselineBrokerageBalance,
+            baselineConversion: ctx.baselineConversionAmount,
+            dB: dBByYear[t],
+            dRoth: dRothByYear[t],
+        };
+        perYearTraces.set(ctx.year, trace);
+
+        trad = bestTradNext;
+        roth = bestRothNext;
+    }
+
+    const elapsedMs = performance.now() - startedAt;
+    const totalConverted = Array.from(conversionsByYear.values()).reduce((s, a) => s + a, 0);
+    const yearsConverting = Array.from(conversionsByYear.values()).filter(a => a > 0).length;
+    summaryLogs.push(
+        `[DEBUG DP] result: totalConverted=${fmt$(totalConverted)} across ${yearsConverting}/${horizonYears} years, ` +
+        `elapsed=${elapsedMs.toFixed(1)}ms`,
+    );
+
+    return {
+        conversionsByYear,
+        diagnostics: {
+            backloadDelta: delta,
+            tradBuckets: TRAD_BUCKETS,
+            rothBuckets: ROTH_BUCKETS,
+            conversionBuckets: CONVERSION_BUCKETS,
+            maxBalance,
+            maxRoth,
+            dB,
+            dRoth,
+            dBByYear,
+            dRothByYear,
+            dCByYear,
+            dC,
+            maxConversion,
+            horizonYears,
+            elapsedMs,
+            perYearAmounts,
+            summaryLogs,
+            perYearDebug,
+            perYearTraces,
+        },
+    };
+}

--- a/src/services/simulation/SpendingStrategy.ts
+++ b/src/services/simulation/SpendingStrategy.ts
@@ -1,0 +1,203 @@
+import { AnyExpense, MortgageExpense, LoanExpense } from "../../components/Objects/Expense/models";
+import { AnyIncome, WorkIncome } from "../../components/Objects/Income/models";
+import { AnyAccount, InvestedAccount, SavedAccount, ESPPAccount } from "../../components/Objects/Accounts/models";
+import { AssumptionsState, getRetirementAge, getLifeExpectancy, getBirthYear } from "../../components/Objects/Assumptions/AssumptionsContext";
+import { calculateStrategyWithdrawal, WithdrawalResult } from "../WithdrawalStrategies";
+import { SimulationYear } from "./types";
+
+export interface SpendingStrategyResult {
+    nextExpenses: AnyExpense[];
+    strategyWithdrawalResult: WithdrawalResult | undefined;
+    strategyAdjustmentResult: SimulationYear['strategyAdjustment'];
+    totalLivingExpenses: number;
+    discretionaryCash: number;
+    logs: string[];
+}
+
+/**
+ * Calculate total discretionary expenses.
+ */
+export function calculateTotalDiscretionary(expenses: AnyExpense[], year: number): number {
+    return expenses.reduce((sum, exp) => {
+        if (!exp.isDiscretionary) return sum;
+        if (exp instanceof MortgageExpense) {
+            return sum + exp.calculateAnnualAmortization(year).totalPayment;
+        }
+        if (exp instanceof LoanExpense) {
+            return sum + exp.calculateAnnualAmortization(year).totalPayment;
+        }
+        return sum + exp.getAnnualAmount(year);
+    }, 0);
+}
+
+/**
+ * Apply lifestyle creep to discretionary expenses during working years.
+ */
+export function applyLifestyleCreep(
+    expenses: AnyExpense[],
+    incomes: AnyIncome[],
+    assumptions: AssumptionsState,
+    year: number,
+    isRetired: boolean,
+    logs: string[]
+): AnyExpense[] {
+    if (isRetired || assumptions.expenses.lifestyleCreep <= 0) {
+        return expenses;
+    }
+
+    const salaryGrowthRate = assumptions.income.salaryGrowth / 100;
+    let totalRaise = 0;
+    for (const prevInc of incomes) {
+        if (prevInc instanceof WorkIncome) {
+            const realRaise = prevInc.getAnnualAmount() * salaryGrowthRate;
+            if (realRaise > 0) {
+                totalRaise += realRaise;
+            }
+        }
+    }
+
+    if (totalRaise <= 0) return expenses;
+
+    const lifestyleCreepAmount = totalRaise * (assumptions.expenses.lifestyleCreep / 100);
+    const discretionaryExpenses = expenses.filter(exp => exp.isDiscretionary);
+    const totalDiscretionary = discretionaryExpenses.reduce((sum, exp) => {
+        return sum + exp.getAnnualAmount(year);
+    }, 0);
+
+    if (totalDiscretionary <= 0 || lifestyleCreepAmount <= 0) return expenses;
+
+    const increaseRatio = 1 + (lifestyleCreepAmount / totalDiscretionary);
+    const result = expenses.map(exp => {
+        if (exp.isDiscretionary) {
+            return exp.adjustAmount(increaseRatio);
+        }
+        return exp;
+    });
+
+    logs.push(`[FLOW] Lifestyle creep: Salary raise of $${totalRaise.toLocaleString(undefined, { maximumFractionDigits: 0 })}/yr → Discretionary expenses increased by $${lifestyleCreepAmount.toLocaleString(undefined, { maximumFractionDigits: 0 })}/yr (${assumptions.expenses.lifestyleCreep}%)`);
+
+    return result;
+}
+
+/**
+ * Calculate withdrawal strategy target for all strategies (GK, Fixed Real, Percentage).
+ * Returns undefined for 'None' and 'Needs Based' strategies.
+ */
+export function calculateStrategyTarget(
+    accounts: AnyAccount[],
+    assumptions: AssumptionsState,
+    previousSimulation: SimulationYear[],
+    year: number,
+    currentAge: number,
+    logs: string[]
+): WithdrawalResult | undefined {
+    const strategy = assumptions.investments.withdrawalStrategy;
+
+    // No target for these strategies
+    if (strategy === 'None' || strategy === 'Needs Based') {
+        return undefined;
+    }
+
+    const totalInvestedAssets = accounts.reduce((sum, acc) => {
+        if (acc instanceof InvestedAccount || acc instanceof SavedAccount || acc instanceof ESPPAccount) {
+            return sum + acc.amount;
+        }
+        return sum;
+    }, 0);
+
+    const previousStrategyResult = previousSimulation.length > 0
+        ? previousSimulation[previousSimulation.length - 1].strategyWithdrawal
+        : undefined;
+
+    const retirementStartYear = getBirthYear(assumptions.milestones) + getRetirementAge(assumptions.milestones);
+    const yearsInRetirement = year - retirementStartYear;
+
+    // yearsRemaining only needed for GK 15-year rule
+    const yearsRemaining = strategy === 'Guyton Klinger'
+        ? getLifeExpectancy(assumptions.milestones) - currentAge
+        : undefined;
+
+    const result = calculateStrategyWithdrawal({
+        strategy,
+        withdrawalRate: assumptions.investments.withdrawalRate,
+        currentPortfolio: totalInvestedAssets,
+        inflationRate: assumptions.macro.inflationRate,
+        yearsInRetirement,
+        previousWithdrawal: previousStrategyResult,
+        // GK-specific params (ignored by other strategies)
+        gkUpperGuardrail: assumptions.investments.gkUpperGuardrail,
+        gkLowerGuardrail: assumptions.investments.gkLowerGuardrail,
+        gkAdjustmentPercent: assumptions.investments.gkAdjustmentPercent,
+        yearsRemaining,
+    });
+
+    logs.push(`[INFO] Retirement withdrawal strategy: ${strategy}`);
+    logs.push(`  Target withdrawal: $${result.amount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`);
+    logs.push(`  Portfolio value: $${totalInvestedAssets.toLocaleString(undefined, { maximumFractionDigits: 0 })}`);
+
+    const effectiveRate = totalInvestedAssets > 0 ? (result.amount / totalInvestedAssets) * 100 : 0;
+    logs.push(`  Effective rate: ${effectiveRate.toFixed(2)}%`);
+
+    if (result.guardrailTriggered !== 'none') {
+        if (result.guardrailTriggered === 'capital-preservation') {
+            logs.push(`[CUT] GK Capital Preservation triggered: withdrawal target reduced by ${assumptions.investments.gkAdjustmentPercent}%`);
+        } else if (result.guardrailTriggered === 'prosperity') {
+            logs.push(`[FLOW] GK Prosperity triggered: withdrawal target increased by ${assumptions.investments.gkAdjustmentPercent}%`);
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Increase discretionary expenses to match budget when budget > current expenses.
+ * Any surplus beyond discretionary goes to brokerage.
+ *
+ * This implements "prosperity spending" - when the withdrawal strategy budget
+ * exceeds current expenses, we increase discretionary spending up to the budget,
+ * and any remaining surplus is invested.
+ */
+export function applyProsperitySpending(
+    expenses: AnyExpense[],
+    currentTotalExpenses: number,
+    budgetTarget: number,
+    year: number,
+    logs: string[]
+): { adjustedExpenses: AnyExpense[]; surplusToInvest: number; prosperityApplied: boolean } {
+    // If budget doesn't exceed expenses, no prosperity to apply
+    if (budgetTarget <= currentTotalExpenses) {
+        return { adjustedExpenses: expenses, surplusToInvest: 0, prosperityApplied: false };
+    }
+
+    const surplus = budgetTarget - currentTotalExpenses;
+    const totalDiscretionary = calculateTotalDiscretionary(expenses, year);
+
+    // If no discretionary expenses, invest the entire surplus
+    if (totalDiscretionary <= 0) {
+        logs.push(`[FLOW] Prosperity: Budget $${budgetTarget.toLocaleString(undefined, { maximumFractionDigits: 0 })} exceeds expenses $${currentTotalExpenses.toLocaleString(undefined, { maximumFractionDigits: 0 })} by $${surplus.toLocaleString(undefined, { maximumFractionDigits: 0 })}, but no discretionary expenses to increase. Surplus will be invested.`);
+        return { adjustedExpenses: expenses, surplusToInvest: surplus, prosperityApplied: false };
+    }
+
+    // Calculate how much we can increase discretionary expenses
+    // Cap increase at 100% of current discretionary (doubling max)
+    const maxIncrease = totalDiscretionary; // Can double discretionary spending
+    const actualIncrease = Math.min(surplus, maxIncrease);
+    const surplusAfterIncrease = surplus - actualIncrease;
+
+    // Apply proportional increase to all discretionary expenses
+    const increaseRatio = 1 + (actualIncrease / totalDiscretionary);
+    const adjustedExpenses = expenses.map(exp => {
+        if (exp.isDiscretionary) {
+            return exp.adjustAmount(increaseRatio);
+        }
+        return exp;
+    });
+
+    logs.push(`[FLOW] Prosperity: Budget $${budgetTarget.toLocaleString(undefined, { maximumFractionDigits: 0 })} exceeds expenses $${currentTotalExpenses.toLocaleString(undefined, { maximumFractionDigits: 0 })} → discretionary increased by $${actualIncrease.toLocaleString(undefined, { maximumFractionDigits: 0 })} (${((increaseRatio - 1) * 100).toFixed(0)}%)`);
+
+    if (surplusAfterIncrease > 0) {
+        logs.push(`[FLOW] Remaining surplus of $${surplusAfterIncrease.toLocaleString(undefined, { maximumFractionDigits: 0 })} will be invested`);
+    }
+
+    return { adjustedExpenses, surplusToInvest: surplusAfterIncrease, prosperityApplied: true };
+}

--- a/src/services/simulation/SurplusAllocator.ts
+++ b/src/services/simulation/SurplusAllocator.ts
@@ -1,0 +1,374 @@
+/**
+ * SurplusAllocator.ts
+ *
+ * Handles surplus allocation after all expenses and taxes are covered.
+ *
+ * Surplus occurs when:
+ * - RMDs exceed spending needs
+ * - Pension + SS fully covers expenses
+ * - Working year with excess income
+ *
+ * Allocation Priority (reuses paycheck allocator logic):
+ * 1. Pay down DeficitDebt first (if any exists)
+ * 2. Follow user's priority bucket order
+ * 3. Any remaining: Brokerage (default catch-all)
+ */
+
+import { AnyAccount, SavedAccount, InvestedAccount, DeficitDebtAccount } from "../../components/Objects/Accounts/models";
+import { PlannedSurplusAllocation, DecisionLogEntry } from "./types";
+import { CapType } from "../../components/Objects/Assumptions/AssumptionsContext";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface SurplusAllocationResult {
+    allocations: PlannedSurplusAllocation[];
+    decisions: DecisionLogEntry[];
+    /** Amount allocated to pay down deficit debt */
+    deficitDebtPayment: number;
+    /** Amount that couldn't be allocated (shouldn't happen) */
+    unallocated: number;
+}
+
+export interface SurplusAllocationSettings {
+    /** Target emergency fund balance */
+    emergencyFundTarget: number;
+    /** Whether Roth IRA contributions are enabled in priority buckets */
+    rothIRAContributionEnabled: boolean;
+    /** Annual Roth IRA contribution limit */
+    rothIRALimit: number;
+    /** Amount already contributed to Roth IRA this year */
+    rothIRAContributedThisYear: number;
+    /** Monthly expenses (used for MULTIPLE_OF_EXPENSES cap type) */
+    monthlyExpenses?: number;
+}
+
+// =============================================================================
+// MAIN FUNCTION
+// =============================================================================
+
+/**
+ * Allocate surplus cash according to priority rules.
+ *
+ * @param surplus - Amount of surplus cash to allocate
+ * @param accounts - All accounts (for finding targets)
+ * @param priorityBuckets - User's priority bucket order with cap settings
+ * @param earnedIncome - Earned income this year (for Roth IRA eligibility)
+ * @param settings - Allocation settings
+ * @returns Allocation plan
+ */
+export function allocateSurplus(
+    surplus: number,
+    accounts: AnyAccount[],
+    priorityBuckets: { accountId: string; priority: number; capType?: CapType; capValue?: number }[],
+    earnedIncome: number,
+    settings: SurplusAllocationSettings
+): SurplusAllocationResult {
+    const allocations: PlannedSurplusAllocation[] = [];
+    const decisions: DecisionLogEntry[] = [];
+    let remaining = surplus;
+    let deficitDebtPayment = 0;
+
+    if (surplus <= 0) {
+        return { allocations, decisions, deficitDebtPayment: 0, unallocated: 0 };
+    }
+
+    // 1. Pay down DeficitDebt first
+    const deficitDebt = accounts.find(a => a instanceof DeficitDebtAccount) as DeficitDebtAccount | undefined;
+    if (deficitDebt && deficitDebt.amount > 0) {
+        const payment = Math.min(remaining, deficitDebt.amount);
+        deficitDebtPayment = payment;
+        remaining -= payment;
+
+        allocations.push({
+            accountId: deficitDebt.id,
+            amount: payment,
+            reason: `Paying down deficit debt balance of $${deficitDebt.amount.toLocaleString()}`,
+        });
+
+        decisions.push({
+            category: 'surplus',
+            account: 'DeficitDebt',
+            amount: payment,
+            description: `Paid down $${payment.toLocaleString()} of deficit debt.`,
+        });
+
+        if (remaining <= 0) {
+            return { allocations, decisions, deficitDebtPayment, unallocated: 0 };
+        }
+    }
+
+    // 2. Follow priority bucket order (or use smart defaults if no priorities configured)
+    const sortedBuckets = [...priorityBuckets].sort((a, b) => a.priority - b.priority);
+
+    // If no explicit priorities, use smart defaults: Emergency → Roth IRA → Brokerage
+    if (sortedBuckets.length === 0) {
+        // 2a. Find and fill emergency fund (SavedAccount) to target
+        const emergencyFund = accounts.find(a => a instanceof SavedAccount) as SavedAccount | undefined;
+        if (emergencyFund && emergencyFund.amount < settings.emergencyFundTarget) {
+            const gap = settings.emergencyFundTarget - emergencyFund.amount;
+            const toAdd = Math.min(remaining, gap);
+
+            if (toAdd > 0) {
+                allocations.push({
+                    accountId: emergencyFund.id,
+                    amount: toAdd,
+                    reason: `Emergency fund contribution (target: $${settings.emergencyFundTarget.toLocaleString()}, current: $${emergencyFund.amount.toLocaleString()})`,
+                });
+
+                decisions.push({
+                    category: 'surplus',
+                    account: emergencyFund.name,
+                    amount: toAdd,
+                    description: `Allocated $${toAdd.toLocaleString()} to emergency fund (${emergencyFund.name}).`,
+                });
+
+                remaining -= toAdd;
+            }
+        }
+
+        // 2b. Find and contribute to Roth IRA (if eligible)
+        if (remaining > 0 && settings.rothIRAContributionEnabled && earnedIncome > 0) {
+            const rothIRA = accounts.find(a =>
+                a instanceof InvestedAccount && a.taxType === 'Roth IRA'
+            ) as InvestedAccount | undefined;
+
+            if (rothIRA) {
+                const contributionRoom = Math.max(0, settings.rothIRALimit - settings.rothIRAContributedThisYear);
+                const maxContribution = Math.min(remaining, earnedIncome, contributionRoom);
+
+                if (maxContribution > 0) {
+                    allocations.push({
+                        accountId: rothIRA.id,
+                        amount: maxContribution,
+                        reason: `Roth IRA contribution (earned income: $${earnedIncome.toLocaleString()}, room: $${contributionRoom.toLocaleString()})`,
+                    });
+
+                    decisions.push({
+                        category: 'surplus',
+                        account: rothIRA.name,
+                        amount: maxContribution,
+                        description: `Contributed $${maxContribution.toLocaleString()} to Roth IRA.`,
+                    });
+
+                    remaining -= maxContribution;
+                }
+            }
+        }
+
+        // 2c. Put remainder in brokerage (handled by step 3 below)
+    }
+
+    // Running total of Roth IRA contributions across ALL buckets in this pass.
+    // settings.rothIRAContributedThisYear is a fixed snapshot (caller passes 0)
+    // and is never mutated, so without this accumulator each Roth IRA bucket
+    // would independently see the full annual limit as available room.
+    let rothIRAContributedSoFar = settings.rothIRAContributedThisYear ?? 0;
+
+    for (const bucket of sortedBuckets) {
+        if (remaining <= 0) break;
+
+        const account = accounts.find(a => a.id === bucket.accountId);
+        if (!account) continue;
+
+        // Determine cap for this bucket
+        const capType = bucket.capType ?? 'REMAINDER';
+        const capValue = bucket.capValue ?? 0;
+        let bucketCap: number;
+
+        switch (capType) {
+            case 'FIXED':
+                // capValue is monthly amount → annual
+                bucketCap = capValue * 12;
+                break;
+            case 'MAX':
+                // capValue is max annual allocation
+                bucketCap = capValue;
+                break;
+            case 'MULTIPLE_OF_EXPENSES': {
+                // capValue is number of months of expenses → desired END balance.
+                // Subtract not just the start-of-year balance but also surplus
+                // already routed to this account earlier in this pass, so we
+                // don't overshoot the target balance.
+                // NOTE: payroll/other same-year contributions applied elsewhere
+                // are NOT visible here; fully closing that gap would require the
+                // caller to pass a projected-contributions figure per account.
+                const alreadyAllocatedThisAccount = allocations
+                    .filter(a => a.accountId === account.id)
+                    .reduce((sum, a) => sum + a.amount, 0);
+                bucketCap = Math.max(0,
+                    (settings.monthlyExpenses ?? 0) * capValue
+                    - account.amount
+                    - alreadyAllocatedThisAccount
+                );
+                break;
+            }
+            case 'REMAINDER':
+            default:
+                bucketCap = Infinity;
+                break;
+        }
+
+        // Apply cap to what we can allocate from remaining surplus
+        const maxForBucket = Math.min(remaining, bucketCap);
+        if (maxForBucket <= 0) continue;
+
+        // Handle different account types
+        if (account instanceof SavedAccount) {
+            const toAdd = maxForBucket;
+
+            allocations.push({
+                accountId: account.id,
+                amount: toAdd,
+                reason: capType === 'REMAINDER'
+                    ? `Savings contribution (remainder)`
+                    : `Savings contribution (${capType} cap: $${bucketCap.toLocaleString()})`,
+            });
+
+            decisions.push({
+                category: 'surplus',
+                account: account.name,
+                amount: toAdd,
+                description: `Allocated $${toAdd.toLocaleString()} to savings (${account.name}).`,
+            });
+
+            remaining -= toAdd;
+        } else if (account instanceof InvestedAccount) {
+            // Check if it's a Roth IRA
+            if (account.taxType === 'Roth IRA') {
+                // Can only contribute if there's earned income
+                if (!settings.rothIRAContributionEnabled) {
+                    decisions.push({
+                        category: 'surplus',
+                        account: account.name,
+                        description: `Skipped Roth IRA contribution: contributions not enabled in settings.`,
+                    });
+                    continue;
+                }
+
+                if (earnedIncome <= 0) {
+                    decisions.push({
+                        category: 'surplus',
+                        account: account.name,
+                        description: `Skipped Roth IRA contribution: no earned income this year.`,
+                    });
+                    continue;
+                }
+
+                // Calculate available contribution room against the running
+                // total so multiple Roth IRA buckets share the per-person limit.
+                const contributionRoom = Math.max(0, settings.rothIRALimit - rothIRAContributedSoFar);
+                const maxContribution = Math.min(maxForBucket, earnedIncome, contributionRoom);
+
+                if (maxContribution > 0) {
+                    allocations.push({
+                        accountId: account.id,
+                        amount: maxContribution,
+                        reason: `Roth IRA contribution (earned income: $${earnedIncome.toLocaleString()}, room: $${contributionRoom.toLocaleString()})`,
+                    });
+
+                    decisions.push({
+                        category: 'surplus',
+                        account: account.name,
+                        amount: maxContribution,
+                        description: `Contributed $${maxContribution.toLocaleString()} to Roth IRA.`,
+                    });
+
+                    remaining -= maxContribution;
+                    rothIRAContributedSoFar += maxContribution;
+                } else if (contributionRoom <= 0) {
+                    decisions.push({
+                        category: 'surplus',
+                        account: account.name,
+                        description: `Skipped Roth IRA contribution: annual limit reached.`,
+                    });
+                }
+            } else if (account.taxType === 'Brokerage') {
+                // Brokerage - allocate up to cap (or all remaining for REMAINDER)
+                const toAdd = maxForBucket;
+
+                allocations.push({
+                    accountId: account.id,
+                    amount: toAdd,
+                    reason: capType === 'REMAINDER'
+                        ? `Brokerage investment (surplus remainder)`
+                        : `Brokerage investment (${capType} cap: $${bucketCap.toLocaleString()})`,
+                });
+
+                decisions.push({
+                    category: 'surplus',
+                    account: account.name,
+                    amount: toAdd,
+                    description: `Invested $${toAdd.toLocaleString()} surplus in brokerage.`,
+                });
+
+                remaining -= toAdd;
+            }
+            // Skip other account types (Traditional, etc.) for surplus allocation
+        }
+    }
+
+    // Collect account IDs already allocated via priority buckets so catch-all
+    // doesn't deposit additional surplus into a capped account.
+    const bucketAccountIds = new Set(sortedBuckets.map(b => b.accountId));
+
+    // 3. If there's still remaining surplus, find any brokerage account
+    //    (skip accounts already in a priority bucket)
+    if (remaining > 0) {
+        const brokerage = accounts.find(a =>
+            a instanceof InvestedAccount && a.taxType === 'Brokerage'
+            && !bucketAccountIds.has(a.id)
+        );
+
+        if (brokerage) {
+            allocations.push({
+                accountId: brokerage.id,
+                amount: remaining,
+                reason: `Brokerage investment (default catch-all)`,
+            });
+
+            decisions.push({
+                category: 'surplus',
+                account: brokerage.name,
+                amount: remaining,
+                description: `Invested remaining $${remaining.toLocaleString()} surplus in brokerage (default).`,
+            });
+
+            remaining = 0;
+        }
+    }
+
+    // 4. If STILL remaining (no brokerage account), find any savings account
+    //    (skip accounts already in a priority bucket)
+    if (remaining > 0) {
+        const savings = accounts.find(a => a instanceof SavedAccount
+            && !bucketAccountIds.has(a.id));
+
+        if (savings) {
+            allocations.push({
+                accountId: savings.id,
+                amount: remaining,
+                reason: `Savings (no brokerage available)`,
+            });
+
+            decisions.push({
+                category: 'surplus',
+                account: savings.name,
+                amount: remaining,
+                description: `Deposited remaining $${remaining.toLocaleString()} surplus in savings (no brokerage available).`,
+            });
+
+            remaining = 0;
+        }
+    }
+
+    const result = {
+        allocations,
+        decisions,
+        deficitDebtPayment,
+        unallocated: remaining,
+    };
+    return result;
+}
+

--- a/src/services/simulation/TaxOptimizedWithdrawal.ts
+++ b/src/services/simulation/TaxOptimizedWithdrawal.ts
@@ -1,0 +1,1058 @@
+/**
+ * Tax-Optimized Withdrawal and Roth Conversion Service
+ *
+ * Implements the tax optimization strategy described in TAX_OPTIMIZATION_IMPLEMENTATION.md.
+ * Key features:
+ * - Dynamic conversion ceiling based on projected RMD bracket
+ * - Target Traditional balance to keep RMDs in low brackets
+ * - SS torpedo and LTCG bump zone awareness
+ * - Four-phase withdrawal logic with survival spending priority
+ */
+
+import { TaxParameters, FilingStatus } from '../../data/TaxData';
+import * as TaxService from '../../components/Objects/Taxes/TaxService';
+import { TaxState } from '../../components/Objects/Taxes/TaxContext';
+import { AssumptionsState, getBirthYear } from '../../components/Objects/Assumptions/AssumptionsContext';
+import { calculateEffectiveConversionTax, ACAOptions } from './helpers';
+import { getDistributionPeriod } from '../../data/RMDData';
+import { BaselineProjections, RateMatchWalkRow } from './types';
+
+// Re-export for convenience
+export type { TaxParameters, FilingStatus, TaxState };
+
+// =============================================================================
+// TYPE DEFINITIONS
+// =============================================================================
+
+/**
+ * Which phase of retirement we're in
+ */
+export type Phase =
+    | 'BROKERAGE_AVAILABLE'    // Brokerage covers spending; conversions get full bracket space
+    | 'BROKERAGE_TRANSITION'   // Brokerage running low (0.5-2 years); reduce conversion aggressiveness
+    | 'BROKERAGE_DEPLETED'     // No brokerage; survival spending has first claim on bracket space
+    | 'ROTH_DEPLETED';         // No Roth either; Traditional is primary source, no conversions
+
+/**
+ * How conversion taxes will be funded
+ */
+export type TaxPaymentSource = 'BROKERAGE' | 'SAVINGS' | 'WITHHOLD' | 'NONE';
+
+/**
+ * What caused the effective rate limit to be reached
+ */
+export type EdgeType =
+    | 'SS_TORPEDO'        // Social Security taxation caused >25% rate jump
+    | 'LTCG_BUMP'         // Long-term capital gains pushed from 0% to 15%
+    | 'BRACKET_EDGE'      // Normal tax bracket boundary
+    | 'ALREADY_AT_CEILING'; // Already at or above target rate at zero conversion
+
+/**
+ * Result of calculating how much can be converted before exceeding target effective rate
+ */
+export interface EffectiveRateLimitResult {
+    /** Maximum conversion amount before exceeding target rate */
+    maxConversion: number;
+
+    /** The effective marginal rate at the max conversion amount */
+    effectiveRateAtMax: number;
+
+    /** The nominal tax bracket at the max conversion amount */
+    bracketAtMax: number;
+
+    /** What caused the limit (SS torpedo, LTCG bump, or bracket edge) */
+    edgeType: EdgeType | null;
+}
+
+/**
+ * Result of dynamic conversion ceiling calculation
+ */
+export interface ConversionCeilingResult {
+    /** The tax bracket rate to convert up to (e.g., 0.22 for 22%) */
+    conversionCeiling: number;
+
+    /** Bracket space available per year up to the ceiling */
+    bracketSpacePerYear: number;
+
+    /** What Traditional balance will realistically be at RMD age */
+    projectedBalanceAtRMD: number;
+
+    /** What bracket RMDs will land in given projected balance */
+    projectedRMDBracket: number;
+
+    /** Peak mid-retirement RMD amount (balance / 15) used to select ceiling */
+    peakRMD: number;
+
+    /** Tax bracket the peak RMD lands in — this is what drives ceiling selection */
+    peakRMDBracket: number;
+
+    /** Bracket-by-bracket trace of the rate-match walk (for the Roth Debug page) */
+    rateMatchWalk?: RateMatchWalkRow[];
+}
+
+/**
+ * Result of coarse-to-fine search for max conversion amount
+ */
+export interface CoarseToFineSearchResult {
+    /** Maximum conversion amount before exceeding target rate */
+    amount: number;
+
+    /** Whether the search converged within tolerance */
+    converged: boolean;
+
+    /** Type of edge that caused the limit (null if no limit reached) */
+    edgeType: EdgeType | null;
+}
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/**
+ * Configuration for coarse-to-fine search algorithm
+ */
+export const SEARCH_CONFIG = {
+    /** Coarse scan increment for initial sweep */
+    coarseStep: 5_000,
+
+    /** Minimum step size for fine binary search */
+    fineMinStep: 100,
+
+    /** Maximum iterations for binary search */
+    maxIterations: 50,
+
+    /** Tolerance for rate matching (±0.25%) */
+    epsilon: 0.0025,
+
+    /** Maximum conversion amount to consider (practical limit) */
+    maxConversionCap: 500_000,
+} as const;
+
+/**
+ * Maximum bracket for Roth conversions.
+ * We cap at 32% because prepaying 35%+ tax on conversions is rarely beneficial.
+ */
+export const MAX_CONVERSION_BRACKET = 0.32;
+
+/**
+ * Get bracket progression from tax parameters, capped at MAX_CONVERSION_BRACKET.
+ * We cap at 32% because prepaying 35%+ tax on conversions is rarely beneficial.
+ */
+export function getBracketProgression(taxParams: TaxParameters): number[] {
+    return taxParams.brackets
+        .map(b => b.rate)
+        .filter(rate => rate <= MAX_CONVERSION_BRACKET);
+}
+
+/**
+ * Get the RMD divisor for a given age.
+ *
+ * Delegates to the canonical IRS Uniform Lifetime Table in RMDData
+ * (getDistributionPeriod), which covers ages 72-120 accurately, instead of
+ * keeping a duplicate truncated table with an inaccurate >95 extrapolation.
+ * The "no RMD before 72 -> 0" sentinel is preserved here because RMDData's
+ * getDistributionPeriod returns the age-72 factor for ages < 72.
+ *
+ * @param age - Age at end of year
+ * @returns RMD divisor (distribution period), or 0 if no RMD applies
+ */
+export function getRMDDivisor(age: number): number {
+    if (age < 72) return 0; // No RMD before 72
+    return getDistributionPeriod(age);
+}
+
+// =============================================================================
+// HELPER FUNCTIONS
+// =============================================================================
+
+/**
+ * Get the damping factor for conversion calculations based on years until RMD.
+ * More aggressive (higher %) when time is short, conservative when time is long.
+ *
+ * @param yearsUntilRMD - Years remaining until Required Minimum Distributions start
+ * @returns Damping factor between 0.15 and 0.50
+ */
+export function getDampingFactor(yearsUntilRMD: number): number {
+    if (yearsUntilRMD >= 15) return 0.15;  // Very conservative when lots of time
+    if (yearsUntilRMD >= 10) return 0.20;
+    if (yearsUntilRMD >= 7) return 0.25;
+    if (yearsUntilRMD >= 5) return 0.30;
+    if (yearsUntilRMD >= 3) return 0.40;
+    return 0.50;  // Aggressive when time is very short
+}
+
+/**
+ * Get the ACA subsidy cliff threshold (400% FPL) for a given year and filing status.
+ * Values should be updated annually when FPL is published (typically January).
+ *
+ * @param filingStatus - 'single' or 'married_filing_jointly'
+ * @param year - The tax year
+ * @returns The income threshold where ACA subsidies phase out completely
+ */
+export function getAcaCliffThreshold(
+    filingStatus: 'single' | 'married_filing_jointly',
+    year: number
+): number {
+    // Base FPL values by year (update annually when published)
+    // 400% FPL = threshold where ACA subsidies phase out completely
+    const FPL_BASE: Record<number, { single: number; couple: number }> = {
+        2024: { single: 15_060, couple: 20_440 },
+        2025: { single: 15_650, couple: 21_150 },  // Estimated
+        2026: { single: 16_100, couple: 21_750 },  // Estimated ~3% inflation
+    };
+
+    // Use most recent known year if future year requested
+    const knownYears = Object.keys(FPL_BASE).map(Number).sort((a, b) => b - a);
+    const useYear = knownYears.find(y => y <= year) ?? knownYears[knownYears.length - 1];
+    const fpl = FPL_BASE[useYear];
+
+    const baseFPL = filingStatus === 'single' ? fpl.single : fpl.couple;
+
+    // 400% FPL is the cliff
+    return baseFPL * 4;
+}
+
+/**
+ * Get the effective MARGINAL tax rate for a conversion at a given amount.
+ * Calculates (total cost at amount+1 - total cost at amount) to get the marginal rate.
+ *
+ * This properly handles SS torpedo, LTCG bump, NIIT, state tax, and ACA cliff.
+ * Uses taxIncrease (which includes federal + state + ACA) not just taxAfter (federal only).
+ *
+ * Production reaches this through coarseToFineSearch; the export exists so unit
+ * tests can probe marginal-rate math directly (SS torpedo, ACA cliff, state
+ * stacking) without going through the opaque search wrapper.
+ *
+ * @public
+ */
+export function getEffectiveConversionRate(
+    conversionAmount: number,
+    ordinaryIncome: number,
+    ltcgIncome: number,
+    socialSecurity: number,
+    taxParams: TaxParameters,
+    taxState: TaxState,
+    _year: number,
+    stateParams: TaxParameters | null,
+    acaOptions?: ACAOptions
+): number {
+    // Calculate total cost of converting conversionAmount
+    // taxIncrease includes federal tax increase + state tax + ACA subsidy loss
+    const resultAtAmount = calculateEffectiveConversionTax(
+        ordinaryIncome,
+        socialSecurity,
+        ltcgIncome,
+        Math.max(0, conversionAmount),
+        taxState.filingStatus,
+        taxParams,
+        stateParams,
+        acaOptions
+    );
+
+    // Calculate total cost of converting conversionAmount + $1
+    const resultAtAmountPlus1 = calculateEffectiveConversionTax(
+        ordinaryIncome,
+        socialSecurity,
+        ltcgIncome,
+        Math.max(0, conversionAmount) + 1,
+        taxState.filingStatus,
+        taxParams,
+        stateParams,
+        acaOptions
+    );
+
+    // Marginal rate = difference in total cost for $1 more conversion
+    // taxIncrease is the cost of converting that amount vs not converting at all
+    // So the difference gives us the marginal cost of the last $1
+    return resultAtAmountPlus1.taxIncrease - resultAtAmount.taxIncrease;
+}
+
+/**
+ * Coarse-to-fine search for maximum conversion amount before exceeding target effective rate.
+ *
+ * Pure binary search fails on plateaus and discontinuities (SS torpedo, LTCG bump zones).
+ * This algorithm:
+ * 1. Coarse scan in $5k increments to find the edge
+ * 2. Identify edge type based on rate jump magnitude
+ * 3. Fine binary search within the identified window
+ * 4. Return conservative lower bound
+ *
+ * @param targetRate - Target effective tax rate to stay under (e.g., 0.22 for 22%)
+ * @param traditionalBalance - Available Traditional IRA/401k balance
+ * @param currentAGI - Current AGI before conversion (gross income)
+ * @param socialSecurity - Annual Social Security benefits
+ * @param ltcgIncome - Long-term capital gains income
+ * @param taxParams - Federal tax parameters
+ * @param taxState - Tax state (filing status, etc.)
+ * @param year - Tax year
+ * @param stateParams - State tax parameters (null if no state tax)
+ * @param acaOptions - ACA subsidy awareness options (undefined if not applicable)
+ * @param assumptions - Optional assumptions for inflation adjustments
+ * @returns Search result with amount, convergence status, and edge type
+ */
+export function coarseToFineSearch(
+    targetRate: number,
+    traditionalBalance: number,
+    currentAGI: number,
+    socialSecurity: number,
+    ltcgIncome: number,
+    taxParams: TaxParameters,
+    taxState: TaxState,
+    year: number,
+    stateParams: TaxParameters | null,
+    acaOptions: ACAOptions | undefined,
+    _assumptions?: AssumptionsState,  // Reserved for future inflation adjustments
+    _debugLabel?: string  // For debug logging
+): CoarseToFineSearchResult {
+    const maxAmount = Math.min(traditionalBalance, SEARCH_CONFIG.maxConversionCap);
+
+    // EDGE CASE: Check if we're already above target rate at zero conversion
+    const rateAtZero = getEffectiveConversionRate(
+        0,
+        currentAGI,
+        ltcgIncome,
+        socialSecurity,
+        taxParams,
+        taxState,
+        year,
+        stateParams,
+        acaOptions
+    );
+
+
+    if (rateAtZero > targetRate + SEARCH_CONFIG.epsilon) {
+        // Already ABOVE target rate from other income - cannot convert anything
+        // Note: if rateAtZero ≈ targetRate (within epsilon), we're IN the target bracket
+        // and can still convert up to the top of that bracket
+        return { amount: 0, converged: true, edgeType: 'ALREADY_AT_CEILING' };
+    }
+
+    // PHASE 1: Coarse scan to find the bracket edge
+    let edgeFound = false;
+    let edgeLow = 0;
+    let edgeHigh = 0;
+    let edgeType: EdgeType | null = null;
+
+    // Special case: Check ACA cliff threshold specifically since coarse step might jump over it
+    // The cliff creates a rate spike at exactly the crossing point
+    if (acaOptions && acaOptions.acaSubsidyAware && acaOptions.currentAge < 65) {
+        const cliffConversion = Math.max(0, acaOptions.acaCliffThreshold - currentAGI);
+        if (cliffConversion > 0 && cliffConversion <= maxAmount) {
+            // Check rate just before and at the cliff
+            const rateBeforeCliff = getEffectiveConversionRate(
+                cliffConversion - 1,
+                currentAGI,
+                ltcgIncome,
+                socialSecurity,
+                taxParams,
+                taxState,
+                year,
+                stateParams,
+                acaOptions
+            );
+            if (rateBeforeCliff > targetRate) {
+                // Already over target before cliff
+                edgeFound = true;
+                edgeLow = 0;
+                edgeHigh = cliffConversion - 1;
+                edgeType = 'BRACKET_EDGE';
+            } else {
+                // Check if the cliff crossing exceeds target
+                const rateAtCliff = getEffectiveConversionRate(
+                    cliffConversion,
+                    currentAGI,
+                    ltcgIncome,
+                    socialSecurity,
+                    taxParams,
+                    taxState,
+                    year,
+                    stateParams,
+                    acaOptions
+                );
+                // The cliff causes a massive spike at exactly cliffConversion - 1
+                // (because converting $1 more would cross the cliff)
+                if (rateAtCliff > targetRate || rateAtCliff >= 1.0) {
+                    // Cliff crossing would exceed target - cap at cliff - 1
+                    return {
+                        amount: Math.max(0, cliffConversion - 1),
+                        converged: true,
+                        edgeType: 'BRACKET_EDGE'
+                    };
+                }
+            }
+        }
+    }
+
+    for (let amount = 0; amount <= maxAmount; amount += SEARCH_CONFIG.coarseStep) {
+        const rate = getEffectiveConversionRate(
+            amount,
+            currentAGI,
+            ltcgIncome,
+            socialSecurity,
+            taxParams,
+            taxState,
+            year,
+            stateParams,
+            acaOptions
+        );
+
+        // Use epsilon tolerance to avoid numerical precision issues
+        // We want to find where rate CLEARLY exceeds target, not just barely
+        if (rate > targetRate + SEARCH_CONFIG.epsilon) {
+            // Found the edge - it's somewhere in the previous $5k window
+            edgeFound = true;
+            edgeLow = Math.max(0, amount - SEARCH_CONFIG.coarseStep);
+            edgeHigh = amount;
+
+            // Identify edge type for logging based on rate jump magnitude
+            const rateBefore = getEffectiveConversionRate(
+                edgeLow,
+                currentAGI,
+                ltcgIncome,
+                socialSecurity,
+                taxParams,
+                taxState,
+                year,
+                stateParams,
+                acaOptions
+            );
+            const rateJump = rate - rateBefore;
+
+            // Thresholds based on actual discontinuity magnitudes:
+            // - SS torpedo: Can cause 40%+ effective rates (jump of 25%+)
+            // - LTCG bump: 0% to 15% LTCG rate (jump of ~12-15%)
+            // - Bracket edge: Normal bracket transitions (10-12% jumps max)
+            if (rateJump > 0.25) {
+                edgeType = 'SS_TORPEDO';
+            } else if (rateJump > 0.12) {
+                edgeType = 'LTCG_BUMP';
+            } else {
+                edgeType = 'BRACKET_EDGE';
+            }
+            break;
+        }
+    }
+
+    if (!edgeFound) {
+        // Never exceeded target rate - can convert everything
+        return { amount: maxAmount, converged: true, edgeType: null };
+    }
+
+    // PHASE 2: Fine binary search within the identified window
+    let low = edgeLow;
+    let high = edgeHigh;
+    let iterations = 0;
+
+    while (high - low > SEARCH_CONFIG.fineMinStep &&
+           iterations < SEARCH_CONFIG.maxIterations) {
+        const mid = Math.floor((low + high) / 2);
+        const rate = getEffectiveConversionRate(
+            mid,
+            currentAGI,
+            ltcgIncome,
+            socialSecurity,
+            taxParams,
+            taxState,
+            year,
+            stateParams,
+            acaOptions
+        );
+
+        // We want to find the MAXIMUM conversion where rate <= target
+        // When rate ≈ target (within epsilon), it's still valid, so search higher
+        // Only search lower when rate clearly exceeds target
+        if (rate <= targetRate + SEARCH_CONFIG.epsilon) {
+            low = mid;  // Valid amount, search higher for max
+        } else {
+            high = mid;  // Too high, search lower
+        }
+        iterations++;
+    }
+
+    // Return conservative lower bound
+    return {
+        amount: low,
+        converged: iterations < SEARCH_CONFIG.maxIterations,
+        edgeType
+    };
+}
+
+/**
+ * Calculate how much can be converted before effective marginal rate exceeds a target rate.
+ *
+ * Uses coarse-to-fine search to handle the complexities of the SS tax torpedo
+ * (effective rates can be much higher than nominal brackets) and other
+ * discontinuities like LTCG bump zones.
+ *
+ * Properly handles SS torpedo, LTCG bump, NIIT, state tax, and ACA cliff
+ * via calculateEffectiveConversionTax.
+ *
+ * @param currentAGI - AGI before conversion (gross income)
+ * @param socialSecurityBenefits - Total SS benefits
+ * @param ltcgIncome - Long-term capital gains (for bump zone detection)
+ * @param targetEffectiveRate - Stop when effective rate exceeds this
+ * @param traditionalBalance - Available Traditional IRA/401k balance
+ * @param taxParams - Federal tax parameters
+ * @param taxState - Tax state (filing status, etc.)
+ * @param year - Tax year
+ * @param stateParams - State tax parameters (null if no state tax)
+ * @param acaOptions - ACA subsidy awareness options (undefined if not applicable)
+ * @param assumptions - Optional assumptions for inflation adjustments
+ * @returns Result with maxConversion, effectiveRateAtMax, bracketAtMax, and edgeType
+ *
+ * Test-only entry point. Production calls coarseToFineSearch directly; this
+ * wrapper exists so Bug-C/D regression tests and the refactor-sanity suite
+ * can probe the search at a single point with a target effective rate.
+ *
+ * @public
+ */
+export function calculateEffectiveRateConversionLimit(
+    currentAGI: number,
+    socialSecurityBenefits: number,
+    ltcgIncome: number,
+    targetEffectiveRate: number,
+    traditionalBalance: number,
+    taxParams: TaxParameters,
+    taxState: TaxState,
+    year: number,
+    stateParams: TaxParameters | null,
+    acaOptions: ACAOptions | undefined,
+    assumptions?: AssumptionsState
+): EffectiveRateLimitResult {
+    // Use coarse-to-fine search to find max conversion staying below target effective rate
+    const searchResult = coarseToFineSearch(
+        targetEffectiveRate,
+        traditionalBalance,
+        currentAGI,
+        socialSecurityBenefits,
+        ltcgIncome,
+        taxParams,
+        taxState,
+        year,
+        stateParams,
+        acaOptions,
+        assumptions
+    );
+
+    // Calculate the effective rate at the found amount
+    const effectiveRateAtMax = getEffectiveConversionRate(
+        searchResult.amount,
+        currentAGI,
+        ltcgIncome,
+        socialSecurityBenefits,
+        taxParams,
+        taxState,
+        year,
+        stateParams,
+        acaOptions
+    );
+
+    // Find nominal bracket at the conversion amount
+    // Approximate by looking at total income
+    const totalIncome = currentAGI + searchResult.amount;
+    const taxableAtMax = Math.max(0, totalIncome - taxParams.standardDeduction);
+    let bracketAtMax = 0;
+    for (const bracket of taxParams.brackets) {
+        if (taxableAtMax >= bracket.threshold) {
+            bracketAtMax = bracket.rate;
+        }
+    }
+
+    return {
+        maxConversion: searchResult.amount,
+        effectiveRateAtMax,
+        bracketAtMax,
+        edgeType: searchResult.edgeType
+    };
+}
+
+/**
+ * Result of rate-matched conversion calculation.
+ */
+export interface RateMatchedConversion {
+    /** Total dollars to convert this year */
+    optimalConversion: number;
+    /** Marginal rate of the last bracket converted into (e.g., 0.12 if conversion stopped after filling 12%) */
+    topConversionRate: number;
+    /** Projected future marginal rate after this conversion (used to compute the gap that stopped us) */
+    futureMarginalAtStop: number;
+    /** Why we stopped converting */
+    stopReason: 'gap-closed' | 'no-balance' | 'no-future-tax';
+    /** Bracket-by-bracket walk trace (for the Roth Debug page). */
+    walk: RateMatchWalkRow[];
+}
+
+/**
+ * Compute the optimal Roth conversion for a single year using direct rate-match.
+ *
+ * The principle: a dollar is worth converting today only if today's marginal rate
+ * is meaningfully lower than the rate it'd be taxed at when withdrawn from Trad
+ * later (as RMD). For each chunk of conversion (std-ded headroom, then each
+ * federal bracket), compute:
+ *   - current_marginal_rate: rate of the bracket this chunk would be taxed at
+ *   - future_marginal_rate: rate the LAST RMD dollar would face if we converted
+ *     up through this chunk and stopped (depends on remaining Trad balance)
+ *
+ * Convert the chunk if (future − current) ≥ minimumRateGap. Stop otherwise.
+ *
+ * Compared to bracket-fill ceilings: this naturally adapts to the actual
+ * rate-arbitrage available. Heavy conversions when future is much higher than
+ * current; tapers off automatically as remaining Trad shrinks and future rate
+ * drops with it.
+ *
+ * Limitations (handled downstream by SS-torpedo / ACA / LTCG-bump logic):
+ *   - Doesn't model SS-taxability bumps mid-conversion
+ *   - Doesn't model LTCG bracket stacking
+ *   - Doesn't model ACA cliff
+ * The conversion amount returned here is the rate-arbitrage optimum; downstream
+ * coarseToFineSearch can reduce it further to avoid those discontinuities.
+ */
+export function computeRateMatchedConversion(
+    currentTraditionalBalance: number,
+    yearsUntilRMD: number,
+    pensionIncomeAtRMD: number,
+    ssAtRMD: number,
+    passiveIncomeAtRMD: number,
+    currentAGI: number,
+    growthRate: number,
+    currentTaxParams: TaxParameters,
+    rmdYearTaxParams: TaxParameters,
+    taxState: TaxState,
+    minimumRateGap: number = 0.05,
+    projectedTradAtRMD?: number
+): RateMatchedConversion {
+    const walk: RateMatchWalkRow[] = [];
+
+    if (currentTraditionalBalance <= 0 || yearsUntilRMD <= 0) {
+        return {
+            optimalConversion: 0,
+            topConversionRate: 0,
+            futureMarginalAtStop: 0,
+            stopReason: 'no-balance',
+            walk,
+        };
+    }
+
+    const PEAK_RMD_DIVISOR = 15;
+    const stdDed = currentTaxParams.standardDeduction;
+    const growthFactor = Math.pow(1 + growthRate, yearsUntilRMD);
+    // Baseline projected Traditional balance at RMD age. When the caller supplies a
+    // sub-sim-derived value, use it as a fixed target (independent of how much we
+    // convert this year). Fallback: naive forward-compound of today's balance —
+    // matches the legacy algebra so existing tests stay green.
+    const baselineProjectedTrad = projectedTradAtRMD ?? currentTraditionalBalance * growthFactor;
+
+    // Helper: project future marginal rate given dollars converted in the current year.
+    // balanceAtRMD = baseline projected balance MINUS the conversion compounded forward.
+    const futureMarginalAt = (convertedSoFar: number): number => {
+        const balanceAtRMD = Math.max(0, baselineProjectedTrad - convertedSoFar * growthFactor);
+        if (balanceAtRMD <= 0) return 0;
+        const projectedRMD = balanceAtRMD / PEAK_RMD_DIVISOR;
+        const projectedTaxableSS = TaxService.getTaxableSocialSecurityBenefits(
+            ssAtRMD,
+            projectedRMD + pensionIncomeAtRMD + passiveIncomeAtRMD,
+            0,
+            taxState.filingStatus
+        );
+        const projectedTaxableIncome =
+            projectedRMD + pensionIncomeAtRMD + passiveIncomeAtRMD + projectedTaxableSS - rmdYearTaxParams.standardDeduction;
+        return TaxService.getMarginalTaxRate(Math.max(0, projectedTaxableIncome), rmdYearTaxParams).rate;
+    };
+
+    let totalConverted = 0;
+    let topRate = 0;
+
+    // Chunk 0: std-ded headroom (effectively 0% rate). Conversion that just fills
+    // standard deduction produces no taxable income → no current tax → always
+    // worth doing if there's any future tax to dodge.
+    const stdDedHeadroom = Math.max(0, stdDed - currentAGI);
+    if (stdDedHeadroom > 0) {
+        const chunkSize = Math.min(stdDedHeadroom, currentTraditionalBalance - totalConverted);
+        if (chunkSize > 0) {
+            const futureMarginal = futureMarginalAt(totalConverted + chunkSize);
+            const gap = futureMarginal; // currentRate is 0
+            // For free conversions (current rate = 0), gap is just the future rate. Always convert
+            // if future rate is at least the threshold (otherwise we're paying nothing now to
+            // dodge nothing later).
+            if (futureMarginal >= minimumRateGap) {
+                totalConverted += chunkSize;
+                topRate = 0;
+                walk.push({
+                    currentRate: 0,
+                    chunkStart: -stdDedHeadroom,
+                    chunkEnd: 0,
+                    chunkSize,
+                    futureMarginal,
+                    gap,
+                    decision: 'convert',
+                    cumulative: totalConverted,
+                });
+            } else {
+                walk.push({
+                    currentRate: 0,
+                    chunkStart: -stdDedHeadroom,
+                    chunkEnd: 0,
+                    chunkSize,
+                    futureMarginal,
+                    gap,
+                    decision: 'stop',
+                    cumulative: totalConverted,
+                });
+                return {
+                    optimalConversion: totalConverted,
+                    topConversionRate: topRate,
+                    futureMarginalAtStop: futureMarginal,
+                    stopReason: futureMarginal === 0 ? 'no-future-tax' : 'gap-closed',
+                    walk,
+                };
+            }
+        }
+    }
+
+    // Subsequent chunks: walk through federal brackets from current taxable position
+    // upward. Position in the bracket structure = currentAGI - stdDed + (totalConverted - stdDedHeadroom)
+    // — i.e., the post-stdDed taxable income after our conversions so far.
+    const sortedBrackets = [...currentTaxParams.brackets].sort((a, b) => a.threshold - b.threshold);
+
+    for (let i = 0; i < sortedBrackets.length; i++) {
+        if (currentTraditionalBalance - totalConverted <= 0) {
+            return {
+                optimalConversion: totalConverted,
+                topConversionRate: topRate,
+                futureMarginalAtStop: futureMarginalAt(currentTraditionalBalance),
+                stopReason: 'no-balance',
+                walk,
+            };
+        }
+
+        const bracket = sortedBrackets[i];
+        const nextBracket = sortedBrackets[i + 1];
+        const bracketTop = nextBracket ? nextBracket.threshold : Infinity;
+
+        // Current taxable position (post-stdDed) after conversions so far
+        const currentTaxablePos = Math.max(0, currentAGI + totalConverted - stdDed);
+
+        if (currentTaxablePos >= bracketTop) continue; // already past this bracket
+
+        const chunkStart = Math.max(currentTaxablePos, bracket.threshold);
+        const chunkSizeInBracket = bracketTop - chunkStart;
+        if (chunkSizeInBracket <= 0) continue;
+
+        const chunkSize = Math.min(chunkSizeInBracket, currentTraditionalBalance - totalConverted);
+        if (chunkSize <= 0) continue;
+
+        const currentMarginal = bracket.rate;
+        const futureMarginal = futureMarginalAt(totalConverted + chunkSize);
+
+        const gap = futureMarginal - currentMarginal;
+        if (gap < minimumRateGap) {
+            walk.push({
+                currentRate: currentMarginal,
+                chunkStart,
+                chunkEnd: chunkStart + chunkSize,
+                chunkSize,
+                futureMarginal,
+                gap,
+                decision: 'stop',
+                cumulative: totalConverted,
+            });
+            return {
+                optimalConversion: totalConverted,
+                topConversionRate: topRate,
+                futureMarginalAtStop: futureMarginal,
+                stopReason: 'gap-closed',
+                walk,
+            };
+        }
+
+        totalConverted += chunkSize;
+        topRate = currentMarginal;
+        walk.push({
+            currentRate: currentMarginal,
+            chunkStart,
+            chunkEnd: chunkStart + chunkSize,
+            chunkSize,
+            futureMarginal,
+            gap,
+            decision: 'convert',
+            cumulative: totalConverted,
+        });
+    }
+
+    return {
+        optimalConversion: totalConverted,
+        topConversionRate: topRate,
+        futureMarginalAtStop: futureMarginalAt(totalConverted),
+        stopReason: 'no-balance',
+        walk,
+    };
+}
+
+/**
+ * Project what Traditional balance will be at RMD age given a conversion rate.
+ *
+ * For each year: balance = balance × (1 + growthRate) - annualConversionAmount
+ *
+ * @param currentBalance - Current Traditional balance
+ * @param yearsUntilRMD - Years remaining until RMD age
+ * @param annualConversionAmount - Amount to convert each year
+ * @param growthRate - Expected annual growth rate (e.g., 0.07 for 7%)
+ * @returns Projected balance at RMD age (floored at 0)
+ */
+export function projectBalanceAtRMD(
+    currentBalance: number,
+    yearsUntilRMD: number,
+    annualConversionAmount: number,
+    growthRate: number
+): number {
+    // Handle edge cases
+    if (yearsUntilRMD <= 0) {
+        return currentBalance;
+    }
+
+    // Zero growth is a special case - simple subtraction
+    if (growthRate === 0) {
+        const projectedBalance = currentBalance - (yearsUntilRMD * annualConversionAmount);
+        return Math.max(0, projectedBalance);
+    }
+
+    // Use iterative calculation (clearer than closed-form)
+    // For each year: balance grows, then conversion is removed
+    let balance = currentBalance;
+
+    for (let year = 0; year < yearsUntilRMD; year++) {
+        // Growth first
+        balance = balance * (1 + growthRate);
+
+        // Then conversion
+        balance = balance - annualConversionAmount;
+
+        // Floor at 0 - can't go negative
+        if (balance <= 0) {
+            return 0;
+        }
+    }
+
+    return Math.max(0, balance);
+}
+
+/**
+ * Find the optimal bracket ceiling for conversions using a simple three-tier system.
+ *
+ * Algorithm:
+ * 1. Compute baseline projected balance assuming only 12% bracket conversions each year
+ * 2. Determine peak RMD bracket from baseline using mid-retirement divisor (15)
+ * 3. Set ceiling from three-tier table based on peak RMD bracket
+ * 4. Return bracket space at that ceiling for PMT pacing
+ *
+ * Three-tier ceiling table:
+ * - Peak RMD bracket <= 12%: ceiling = 0% (standard deduction only)
+ * - Peak RMD bracket is 22% or 24%: ceiling = 12%
+ * - Peak RMD bracket >= 32%: ceiling = 24%
+ *
+ * Principle: Only convert at a rate that is at least two bracket tiers below
+ * the projected RMD rate. This ensures real savings after accounting for
+ * sequence-of-returns risk.
+ *
+ * @param currentTraditionalBalance - Current Traditional IRA/401k balance
+ * @param yearsUntilRMD - Years remaining until RMD age
+ * @param pensionIncomeAtRMD - Non-SS fixed income at RMD age (pensions, annuities)
+ * @param ssAtRMD - Social Security benefits at RMD age
+ * @param currentAGI - This year's AGI (excluding SS)
+ * @param socialSecurityThisYear - This year's SS benefits
+ * @param ltcgIncome - Long-term capital gains (for bump zone detection)
+ * @param growthRate - Expected annual growth rate
+ * @param rmdStartAge - Age at which RMDs begin (72, 73, or 75 based on birth year)
+ * @param taxParams - Federal tax parameters
+ * @param taxState - Tax state (filing status, etc.)
+ * @returns ConversionCeilingResult with ceiling, bracket space, projections
+ */
+export function calculateDynamicConversionCeiling(
+    currentTraditionalBalance: number,
+    yearsUntilRMD: number,
+    pensionIncomeAtRMD: number,
+    ssAtRMD: number,
+    passiveIncomeAtRMD: number,
+    currentAGI: number,
+    _socialSecurityThisYear: number,
+    _ltcgIncome: number,
+    growthRate: number,
+    rmdStartAge: number,
+    taxParams: TaxParameters,
+    taxState: TaxState,
+    _stateParams: TaxParameters | null = null,
+    _acaOptions?: ACAOptions,
+    baselineProjections?: BaselineProjections,
+    /**
+     * Simulation assumptions. When provided, the peak-RMD bracket lookup uses
+     * tax parameters projected to the RMD year so that RMD-year nominal income
+     * is compared against RMD-year nominal brackets. Without this, the bracket
+     * comparison mixes units (income in RMD-year dollars vs brackets in
+     * current-year dollars), which inflates the apparent peak-RMD bracket at
+     * younger ages. Optional for backwards compatibility — callers that don't
+     * pass it get the legacy (unit-mismatched) behavior.
+     */
+    assumptions?: AssumptionsState,
+    conversionMode: 'rate-match' | 'std-ded-only' = 'rate-match'
+): ConversionCeilingResult {
+    // If already at RMD age, no conversions
+    if (yearsUntilRMD <= 0) {
+        return {
+            conversionCeiling: 0,
+            bracketSpacePerYear: 0,
+            projectedBalanceAtRMD: currentTraditionalBalance,
+            projectedRMDBracket: 0,
+            peakRMD: 0,
+            peakRMDBracket: 0,
+        };
+    }
+
+    // Std-ded-only mode: fill the 0% federal bracket (standard-deduction headroom)
+    // and stop. Used by `runProjectionSubsim` to project a Traditional-balance
+    // trajectory that does only "free" conversions, which feeds the rate-match
+    // baseline for the main sim. Skip rate-match, peak-bracket lookup, ideal-target
+    // computation entirely — none of it is needed when the conversion is bounded
+    // by the standard deduction.
+    if (conversionMode === 'std-ded-only') {
+        const stdDedHeadroom = Math.max(0, taxParams.standardDeduction - currentAGI);
+        const cappedAmount = Math.min(stdDedHeadroom, currentTraditionalBalance);
+        return {
+            conversionCeiling: 0,
+            bracketSpacePerYear: cappedAmount,
+            projectedBalanceAtRMD: currentTraditionalBalance,
+            projectedRMDBracket: 0,
+            peakRMD: 0,
+            peakRMDBracket: 0,
+        };
+    }
+
+    // Use baseline projections if available for fixed income at RMD.
+    // Pass 1 simulates the trajectory to RMD year so these reflect actual portfolio
+    // dynamics (brokerage growth → dividends, etc.); fall back to direct inputs
+    // (which use COLA-only projection or current-year proxies) when not available.
+    const effectiveSsAtRMD = baselineProjections?.ssAtRMD ?? ssAtRMD;
+    const effectivePensionAtRMD = baselineProjections?.pensionAtRMD ?? pensionIncomeAtRMD;
+    const effectivePassiveIncomeAtRMD = baselineProjections?.passiveAtRMD ?? passiveIncomeAtRMD;
+
+    // =========================================================================
+    // STEP 1: Compute projected Trad balance at RMD age
+    // =========================================================================
+    // Prefer baselineProjections.traditionalBalanceAtRMD when available — this
+    // value comes from the iterative two-pass run and reflects the actual
+    // converging conversion trajectory, so peakRMDBracket reflects where RMDs
+    // really land (not "where they'd land if I never converted from this point").
+    //
+    // Without iteration, fall back to naive growth projection from current
+    // balance. This was the original behavior and produces conservative ceilings.
+
+    const baselineBalance = baselineProjections?.traditionalBalanceAtRMD
+        ?? currentTraditionalBalance * Math.pow(1 + growthRate, yearsUntilRMD);
+
+    // =========================================================================
+    // STEP 2: Determine peak RMD bracket from baseline
+    // =========================================================================
+
+    const PEAK_RMD_DIVISOR = 15;  // Approximates age ~87 (mid-retirement)
+    const peakRMD = baselineBalance / PEAK_RMD_DIVISOR;
+
+    // Look up tax parameters for the RMD year, not the current year. peakRMD,
+    // effectiveSsAtRMD, effectivePensionAtRMD, and passiveIncomeAtRMD are all
+    // expressed in RMD-year nominal dollars — they need to be compared against
+    // RMD-year inflation-projected brackets, otherwise the apparent peak-RMD
+    // bracket is inflated by (1 + inflation)^yearsUntilRMD.
+    //
+    // Use birthYear + rmdStartAge for the RMD year — that's the user's actual
+    // RMD year and is invariant across simulation years. (Avoid taxState.year +
+    // yearsUntilRMD: taxState.year is the user's configured tax year, not the
+    // current simulation year, so as yearsUntilRMD shrinks the apparent rmdYear
+    // would walk backwards toward the present.)
+    let peakBracketTaxParams = taxParams;
+    if (assumptions) {
+        const rmdYear = getBirthYear(assumptions.milestones) + rmdStartAge;
+        const rmdYearParams = TaxService.getTaxParameters(
+            rmdYear, taxState.filingStatus, 'federal', undefined, assumptions
+        );
+        if (rmdYearParams) {
+            peakBracketTaxParams = rmdYearParams;
+        }
+    }
+
+    // Calculate taxable SS at peak RMD
+    const peakTaxableSS = TaxService.getTaxableSocialSecurityBenefits(
+        effectiveSsAtRMD,
+        effectivePensionAtRMD + peakRMD + effectivePassiveIncomeAtRMD,
+        0,
+        taxState.filingStatus
+    );
+    const peakTaxableIncome = peakRMD + effectivePensionAtRMD + effectivePassiveIncomeAtRMD + peakTaxableSS - peakBracketTaxParams.standardDeduction;
+    const peakRMDBracket = TaxService.getMarginalTaxRate(Math.max(0, peakTaxableIncome), peakBracketTaxParams).rate;
+
+    // =========================================================================
+    // STEP 3 + 4: Rate-matched conversion via direct bracket walk
+    // =========================================================================
+    //
+    // Rather than computing a single "ceiling" rate and then filling brackets up
+    // to it, walk through the brackets dollar-chunk by dollar-chunk. For each
+    // chunk: compute current marginal (the bracket's rate) and project future
+    // marginal at the remaining Trad balance after the chunk. Convert if the gap
+    // is at least minimumRateGap (default 5pp). Stop otherwise.
+    //
+    // This naturally adapts: in early low-income years with lots of Trad, walk
+    // up through 22%/24% brackets because future is even higher. As Trad shrinks
+    // year by year, future marginal drops, gaps close, and the walk stops sooner.
+    // No discrete ceiling cliff, no iteration needed — convergence is per-year.
+    const minRateGap = assumptions?.investments?.rothConversionMinRateGap ?? 0.05;
+    const rateMatchResult = computeRateMatchedConversion(
+        currentTraditionalBalance,
+        yearsUntilRMD,
+        effectivePensionAtRMD,
+        effectiveSsAtRMD,
+        effectivePassiveIncomeAtRMD,
+        currentAGI,
+        growthRate,
+        taxParams,            // current-year params for the brackets we walk
+        peakBracketTaxParams, // RMD-year params for projecting future marginal
+        taxState,
+        minRateGap,
+        baselineBalance       // sub-sim-derived projection (decoupled from live trad balance)
+    );
+
+    const ceiling = rateMatchResult.topConversionRate;
+    let bracketSpacePerYear = rateMatchResult.optimalConversion;
+
+    // Subsequent SS-torpedo / ACA / LTCG-bump logic (downstream in YearSolver) may
+    // further reduce this; rate-match output is the rate-arbitrage optimum.
+
+    // =========================================================================
+    // Compute projected balance for return
+    // =========================================================================
+
+    // Use baseline projection for projectedBalanceAtRMD if available
+    const effectiveProjectedBalance = baselineProjections?.traditionalBalanceAtRMD
+        ?? projectBalanceAtRMD(currentTraditionalBalance, yearsUntilRMD, 0, growthRate);
+
+    // Compute projected RMD bracket (first-year RMD using standard divisor)
+    const rmdDivisor = getRMDDivisor(rmdStartAge);
+    const projectedRMD = rmdDivisor > 0 ? effectiveProjectedBalance / rmdDivisor : 0;
+    const projectedTaxableSS = TaxService.getTaxableSocialSecurityBenefits(
+        effectiveSsAtRMD,
+        effectivePensionAtRMD + projectedRMD,
+        0,
+        taxState.filingStatus
+    );
+    // Same units fix as peakRMDBracket: projectedRMD/SS/pension are in RMD-year
+    // nominal dollars, so look up brackets in RMD-year params when available.
+    const projectedTaxableIncome = projectedRMD + effectivePensionAtRMD + projectedTaxableSS - peakBracketTaxParams.standardDeduction;
+    const projectedRMDBracket = TaxService.getMarginalTaxRate(Math.max(0, projectedTaxableIncome), peakBracketTaxParams).rate;
+
+    return {
+        conversionCeiling: ceiling,
+        bracketSpacePerYear,
+        projectedBalanceAtRMD: effectiveProjectedBalance,
+        projectedRMDBracket,
+        peakRMD,
+        peakRMDBracket,
+        rateMatchWalk: rateMatchResult.walk,
+    };
+}
+

--- a/src/services/simulation/WithdrawalPlanner.ts
+++ b/src/services/simulation/WithdrawalPlanner.ts
@@ -1,0 +1,1135 @@
+/**
+ * WithdrawalPlanner.ts
+ *
+ * Unified withdrawal planning for the SimulationEngine rewrite.
+ *
+ * Design Principles:
+ * 1. Single code path - both basic and tax-optimized modes use this
+ * 2. Algebraic gross-up - solves single-source withdrawals in 1 pass
+ * 3. Account drain - withdraws entire balance when insufficient
+ * 4. Savings preservation - savings moved to end of non-penalized accounts
+ *
+ * CRITICAL: Uses BASE deficit (expenses + ordinaryTax + FICA - income - RMD).
+ * LTCG tax is NOT included in the deficit before grossing up - that causes double-counting.
+ */
+
+import { AnyAccount, InvestedAccount, SavedAccount, ESPPAccount } from "../../components/Objects/Accounts/models";
+import { TaxState } from "../../components/Objects/Taxes/TaxContext";
+import { AssumptionsState } from "../../components/Objects/Assumptions/AssumptionsContext";
+import {
+    PlannedWithdrawal,
+    AccountBalanceSnapshot,
+    WithdrawalAccountType,
+    DecisionLogEntry,
+} from "./types";
+import * as TaxService from "../../components/Objects/Taxes/TaxService";
+import { getLTCGRate as getLTCGRateForIncome } from "../../components/Objects/Taxes/taxService/capitalGainsTax";
+import { TaxBracket } from "../../data/TaxData";
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const EARLY_WITHDRAWAL_AGE = 59.5;
+const EARLY_WITHDRAWAL_PENALTY_RATE = 0.10;
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface WithdrawalPlanResult {
+    withdrawals: PlannedWithdrawal[];
+    totalGross: number;
+    totalNet: number;
+    totalTax: number;
+    totalPenalties: number;
+    totalLTCG: number;
+    totalSTCG: number;
+    remainingDeficit: number;
+    decisions: DecisionLogEntry[];
+}
+
+// AccountWithdrawalContext interface removed - was unused
+
+// =============================================================================
+// ACCOUNT CLASSIFICATION
+// =============================================================================
+
+/**
+ * Classify an account's tax type for withdrawal ordering.
+ */
+function classifyAccount(account: AnyAccount): WithdrawalAccountType {
+    if (account instanceof SavedAccount) return 'savings';
+    if (account instanceof ESPPAccount) return 'espp';
+    if (account instanceof InvestedAccount) {
+        switch (account.taxType) {
+            case 'Traditional 401k': return 'traditional_401k';
+            case 'Traditional IRA': return 'traditional_ira';
+            case 'Roth 401k': return 'roth_401k';
+            case 'Roth IRA': return 'roth_ira';
+            case 'HSA': return 'hsa';
+            case 'Brokerage':
+            default:
+                return 'brokerage';
+        }
+    }
+    return 'savings';
+}
+
+/**
+ * Check if account type incurs early withdrawal penalty.
+ */
+function hasEarlyWithdrawalPenalty(
+    accountType: WithdrawalAccountType,
+    age: number,
+    isEarnings: boolean = false
+): boolean {
+    // HSA non-medical withdrawals are penalized (20%) until age 65, not 59.5.
+    if (accountType === 'hsa') return age < 65;
+
+    if (age >= EARLY_WITHDRAWAL_AGE) return false;
+
+    switch (accountType) {
+        case 'traditional_401k':
+        case 'traditional_ira':
+            return true;
+        case 'roth_401k':
+        case 'roth_ira':
+            // Only earnings have penalty; contributions are penalty-free
+            return isEarnings;
+        // 'hsa' is handled above (penalized until 65, not 59.5).
+        default:
+            return false;
+    }
+}
+
+// =============================================================================
+// ACCOUNT SNAPSHOTTING
+// =============================================================================
+
+/**
+ * Create a balance snapshot from an account.
+ */
+export function createAccountSnapshot(account: AnyAccount, snapshotDate?: Date): AccountBalanceSnapshot {
+    const accountType = classifyAccount(account);
+
+    let vestedBalance = account.amount;
+    let gainRatio = 0;
+    let rothContributions: number | undefined;
+    let conversionHistory: { year: number; amount: number }[] | undefined;
+    let esppLots: AccountBalanceSnapshot['esppLots'];
+
+    if (account instanceof ESPPAccount) {
+        // ESPP: pre-compute per-lot disposition data using existing functions
+        const saleDate = snapshotDate ?? new Date();
+        const sharePrice = account.currentSharePrice ?? (account.amount / Math.max(1, account.totalShares));
+
+        esppLots = account.lots.map(lot => {
+            const dispositionType = account.calculateDispositionType(lot, saleDate);
+
+            // Use calculateSaleTax to get proper tax breakdown for this lot
+            const taxResult = account.calculateSaleTax(
+                lot.shares,
+                sharePrice,
+                saleDate,
+                'fifo',
+                [lot] // Just this lot
+            );
+
+            const ordinaryIncomePerShare = lot.shares > 0 ? taxResult.ordinaryIncome / lot.shares : 0;
+            const ltcgPerShare = lot.shares > 0 ? taxResult.longTermGains / lot.shares : 0;
+            const totalValue = lot.shares * sharePrice;
+
+            return {
+                lotId: lot.id,
+                shares: lot.shares,
+                currentValuePerShare: sharePrice,
+                purchasePricePerShare: lot.purchasePrice,
+                dispositionType,
+                ordinaryIncomePerShare,
+                ltcgPerShare,
+                totalValue,
+            };
+        });
+
+        // Calculate gain ratio for ESPP using lot data (totalCost may not be set)
+        const totalCostBasis = account.lots.reduce((sum, lot) => {
+            // Use totalCost if available, otherwise compute from purchasePrice × shares
+            const lotCost = lot.totalCost ?? (lot.purchasePrice * lot.shares);
+            return sum + lotCost;
+        }, 0);
+        const unrealizedGains = Math.max(0, account.amount - totalCostBasis);
+        gainRatio = account.amount > 0 ? unrealizedGains / account.amount : 0;
+    } else if (account instanceof InvestedAccount) {
+        vestedBalance = account.vestedAmount;
+
+        // Calculate gain ratio for brokerage accounts
+        if (accountType === 'brokerage') {
+            const unrealizedGains = account.amount - account.costBasis;
+            gainRatio = account.amount > 0 ? Math.max(0, unrealizedGains / account.amount) : 0;
+        }
+
+        // Track Roth contribution basis
+        if (accountType === 'roth_ira' || accountType === 'roth_401k') {
+            rothContributions = account.regularContributions ?? 0;
+            conversionHistory = account.conversionHistory ?? [];
+        }
+    }
+
+    return {
+        accountId: account.id,
+        accountName: account.name,
+        accountType,
+        balance: account.amount,
+        vestedBalance,
+        gainRatio,
+        rothContributions,
+        conversionHistory,
+        esppLots,
+    };
+}
+
+/**
+ * Create snapshots for all accounts in withdrawal order.
+ * Savings is moved to end of non-penalized accounts.
+ */
+export function createOrderedSnapshots(
+    accounts: AnyAccount[],
+    withdrawalOrder: { accountId: string }[],
+    currentAge: number,
+    year?: number
+): AccountBalanceSnapshot[] {
+    const snapshots: AccountBalanceSnapshot[] = [];
+    const savingsSnapshots: AccountBalanceSnapshot[] = [];
+    const penalizedSnapshots: AccountBalanceSnapshot[] = [];
+
+    // Use mid-year date for ESPP disposition calculations
+    const snapshotDate = year ? new Date(year, 5, 15) : undefined;
+
+    // Process in user's configured order
+    for (const bucket of withdrawalOrder) {
+        const account = accounts.find(a => a.id === bucket.accountId);
+        if (!account) continue;
+
+        const snapshot = createAccountSnapshot(account, snapshotDate);
+
+        // Separate into categories
+        if (snapshot.accountType === 'savings') {
+            savingsSnapshots.push(snapshot);
+        } else if (hasEarlyWithdrawalPenalty(snapshot.accountType, currentAge)) {
+            penalizedSnapshots.push(snapshot);
+        } else {
+            snapshots.push(snapshot);
+        }
+    }
+
+    // Final order: non-penalized → savings → penalized
+    return [...snapshots, ...savingsSnapshots, ...penalizedSnapshots];
+}
+
+// =============================================================================
+// GROSS-UP FORMULAS
+// =============================================================================
+
+/**
+ * Calculate gross withdrawal needed for a given net from savings.
+ * No tax, no penalty.
+ */
+function grossUpSavings(netNeeded: number): { gross: number; tax: number; penalty: number } {
+    return { gross: netNeeded, tax: 0, penalty: 0 };
+}
+
+/**
+ * Calculate gross withdrawal needed for a given net from brokerage.
+ * Uses algebraic formula: gross = net / (1 - gainRatio × ltcgRate)
+ */
+function grossUpBrokerage(
+    netNeeded: number,
+    gainRatio: number,
+    ltcgRate: number
+): { gross: number; tax: number; ltcg: number } {
+    if (gainRatio <= 0) {
+        // No gains - no tax
+        return { gross: netNeeded, tax: 0, ltcg: 0 };
+    }
+
+    const effectiveRate = gainRatio * ltcgRate;
+    const gross = netNeeded / (1 - effectiveRate);
+    const ltcg = gross * gainRatio;
+    const tax = ltcg * ltcgRate;
+
+    return { gross, tax, ltcg };
+}
+
+/**
+ * Compute piecewise tax on a known gross Traditional withdrawal.
+ * Walks federal and state brackets stacked on current taxable income positions.
+ */
+function computeTaxOnGross(
+    grossAmount: number,
+    fedTaxableIncome: number,
+    stateTaxableIncome: number,
+    fedBrackets: TaxBracket[],
+    stateBrackets: TaxBracket[] | null,
+    remainingFedStdDedSpace: number,
+    remainingStateStdDedSpace: number
+): { fedTax: number; stateTax: number; totalTax: number } {
+    // Federal: tax applies to amount above std deduction space
+    const fedTaxableWithdrawal = Math.max(0, grossAmount - remainingFedStdDedSpace);
+    let fedTax = 0;
+    if (fedTaxableWithdrawal > 0 && fedBrackets.length > 0) {
+        let remaining = fedTaxableWithdrawal;
+        let incomePos = fedTaxableIncome;
+        for (let i = 0; i < fedBrackets.length && remaining > 0; i++) {
+            const bracket = fedBrackets[i];
+            const nextThreshold = fedBrackets[i + 1]?.threshold ?? Infinity;
+            if (incomePos >= nextThreshold) continue;
+            const floor = Math.max(incomePos, bracket.threshold);
+            const room = nextThreshold - floor;
+            const inBracket = Math.min(remaining, room);
+            fedTax += inBracket * bracket.rate;
+            incomePos += inBracket;
+            remaining -= inBracket;
+        }
+    }
+
+    // State: same approach
+    let stateTax = 0;
+    if (stateBrackets && stateBrackets.length > 0) {
+        const stateTaxableWithdrawal = Math.max(0, grossAmount - remainingStateStdDedSpace);
+        if (stateTaxableWithdrawal > 0) {
+            let remaining = stateTaxableWithdrawal;
+            let incomePos = stateTaxableIncome;
+            for (let i = 0; i < stateBrackets.length && remaining > 0; i++) {
+                const bracket = stateBrackets[i];
+                const nextThreshold = stateBrackets[i + 1]?.threshold ?? Infinity;
+                if (incomePos >= nextThreshold) continue;
+                const floor = Math.max(incomePos, bracket.threshold);
+                const room = nextThreshold - floor;
+                const inBracket = Math.min(remaining, room);
+                stateTax += inBracket * bracket.rate;
+                incomePos += inBracket;
+                remaining -= inBracket;
+            }
+        }
+    }
+
+    return { fedTax, stateTax, totalTax: fedTax + stateTax };
+}
+
+
+/**
+ * Calculate gross withdrawal needed for a given net from Traditional accounts.
+ * Uses binary search over computeTaxOnGross to correctly handle separate
+ * federal and state standard deduction spaces and bracket positions.
+ */
+function grossUpTraditional(
+    netNeeded: number,
+    age: number,
+    fedTaxableIncome: number,
+    stateTaxableIncome: number,
+    fedBrackets: TaxBracket[],
+    stateBrackets: TaxBracket[] | null,
+    remainingFedStdDedSpace: number,
+    remainingStateStdDedSpace: number
+): { gross: number; tax: number; penalty: number } {
+    if (netNeeded <= 0) {
+        return { gross: 0, tax: 0, penalty: 0 };
+    }
+
+    const penaltyRate = age < EARLY_WITHDRAWAL_AGE ? EARLY_WITHDRAWAL_PENALTY_RATE : 0;
+
+    // Helper: net delivered by a given gross withdrawal (tax + penalty subtracted).
+    const netAtGross = (gross: number): number => {
+        const t = computeTaxOnGross(
+            gross, fedTaxableIncome, stateTaxableIncome,
+            fedBrackets, stateBrackets,
+            remainingFedStdDedSpace, remainingStateStdDedSpace
+        );
+        return gross - t.totalTax - gross * penaltyRate;
+    };
+
+    // Binary search: find gross such that gross - tax(gross) - penalty(gross) = netNeeded
+    let lo = netNeeded;
+    let hi = netNeeded * 3;
+
+    // When the combined fed+state+penalty rate exceeds ~66.7%, even gross = 3×netNeeded
+    // nets less than netNeeded, so [lo, hi] never brackets the target and the search
+    // silently under-funds the deficit. Grow hi (capped) until net(hi) >= netNeeded.
+    const maxHi = netNeeded * 20;
+    while (hi < maxHi && netAtGross(hi) < netNeeded) {
+        hi = Math.min(hi * 2, maxHi);
+    }
+
+    let bestGross = netNeeded;
+    let bestTax = 0;
+
+    for (let iter = 0; iter < 60; iter++) {
+        const mid = (lo + hi) / 2;
+        const taxResult = computeTaxOnGross(
+            mid, fedTaxableIncome, stateTaxableIncome,
+            fedBrackets, stateBrackets,
+            remainingFedStdDedSpace, remainingStateStdDedSpace
+        );
+        const penalty = mid * penaltyRate;
+        const net = mid - taxResult.totalTax - penalty;
+
+        bestGross = mid;
+        bestTax = taxResult.totalTax;
+
+        if (Math.abs(net - netNeeded) < 0.0001) break;
+
+        if (net < netNeeded) {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+
+    return { gross: bestGross, tax: bestTax, penalty: bestGross * penaltyRate };
+}
+
+/**
+ * Calculate gross withdrawal needed for Roth accounts.
+ * Follows IRS ordering: contributions → conversions → earnings.
+ */
+function grossUpRoth(
+    netNeeded: number,
+    contributionBasis: number,
+    conversionHistory: { year: number; amount: number }[],
+    currentYear: number,
+    age: number,
+    marginalRate: number,
+    maxGross: number = Infinity
+): { gross: number; tax: number; penalty: number; fromContributions: number; fromConversions: number; fromEarnings: number } {
+    let remaining = netNeeded;
+    let fromContributions = 0;
+    let fromConversions = 0;
+    let fromEarnings = 0;
+    let tax = 0;
+    let penalty = 0;
+    let grossUsed = 0;
+
+    // 1. Contributions first - tax-free, penalty-free
+    if (contributionBasis > 0 && remaining > 0 && grossUsed < maxGross) {
+        const fromContrib = Math.min(remaining, contributionBasis, maxGross - grossUsed);
+        fromContributions = fromContrib;
+        grossUsed += fromContrib;
+        remaining -= fromContrib;
+    }
+
+    // 2. Conversions second - FIFO by year, 5-year rule for penalty.
+    // Caller passes a pre-sorted (oldest first) array; we mutate entry amounts
+    // in place so a shared pool can be drained across multiple withdrawals
+    // within the same year.
+    if (remaining > 0 && grossUsed < maxGross && conversionHistory.length > 0) {
+        for (const conv of conversionHistory) {
+            if (remaining <= 0 || grossUsed >= maxGross) break;
+            if (conv.amount <= 0) continue;
+
+            const yearsHeld = currentYear - conv.year;
+            const penaltyApplies = age < EARLY_WITHDRAWAL_AGE && yearsHeld < 5;
+
+            const fromThisConv = Math.min(remaining, conv.amount, maxGross - grossUsed);
+            fromConversions += fromThisConv;
+            grossUsed += fromThisConv;
+            conv.amount -= fromThisConv;
+
+            if (penaltyApplies) {
+                const penaltyOnConv = fromThisConv * EARLY_WITHDRAWAL_PENALTY_RATE;
+                penalty += penaltyOnConv;
+            }
+
+            remaining -= fromThisConv;
+        }
+    }
+
+    // 3. Earnings last - tax + penalty if under 59.5
+    if (remaining > 0 && grossUsed < maxGross) {
+        const grossRoom = maxGross - grossUsed;
+        if (age < EARLY_WITHDRAWAL_AGE) {
+            // Earnings are taxed as ordinary income + 10% penalty
+            const penaltyRate = EARLY_WITHDRAWAL_PENALTY_RATE;
+            const effectiveRate = marginalRate + penaltyRate;
+
+            // Gross up the remaining need, capped by available room
+            const grossEarnings = Math.min(remaining / (1 - effectiveRate), grossRoom);
+            fromEarnings = grossEarnings;
+            tax = grossEarnings * marginalRate;
+            penalty += grossEarnings * penaltyRate;
+        } else {
+            // After 59.5, earnings are tax-free too (qualified distribution)
+            fromEarnings = Math.min(remaining, grossRoom);
+        }
+    }
+
+    const gross = fromContributions + fromConversions + fromEarnings;
+
+    return { gross, tax, penalty, fromContributions, fromConversions, fromEarnings };
+}
+
+// =============================================================================
+// MAIN PLANNING FUNCTION
+// =============================================================================
+
+/**
+ * Plan withdrawals to cover a net deficit.
+ *
+ * @param netNeeded - Net amount needed after all taxes
+ * @param accountOrder - Ordered list of accounts to tap
+ * @param currentAge - Current age for penalty calculations
+ * @param year - Current simulation year
+ * @param taxState - Tax state for rate lookups
+ * @param currentOrdinaryIncome - Current ordinary income (for marginal rate)
+ * @param assumptions - Simulation assumptions
+ * @param reason - Reason for withdrawal (for logging)
+ * @returns Withdrawal plan with all details
+ */
+export function planWithdrawals(
+    netNeeded: number,
+    accountOrder: AccountBalanceSnapshot[],
+    currentAge: number,
+    year: number,
+    taxState: TaxState,
+    currentOrdinaryIncome: number,
+    assumptions: AssumptionsState | undefined,
+    reason: PlannedWithdrawal['reason'] = 'Spending deficit',
+    acaWithdrawalOptions?: { acaCliffThreshold: number; currentMAGI: number },
+    /** Income included in currentOrdinaryIncome for federal brackets but exempt from state tax
+     *  (e.g., taxable Social Security for DC and most states that exempt SS). */
+    stateExemptIncome: number = 0
+): WithdrawalPlanResult {
+    const withdrawals: PlannedWithdrawal[] = [];
+    const decisions: DecisionLogEntry[] = [];
+
+    let remainingNetNeeded = netNeeded;
+    let totalGross = 0;
+    let totalNet = 0;
+    let totalTax = 0;
+    let totalPenalties = 0;
+    let totalLTCG = 0;
+    let totalSTCG = 0;
+    let cumulativeLTCG = 0; // Tracks LTCG from brokerage/ESPP for ACA MAGI headroom
+    let runningOrdinaryIncome = currentOrdinaryIncome;
+
+    // ACA cliff: track Roth amounts pre-consumed by look-ahead substitution
+    const acaRothConsumed = new Map<string, number>();
+    const ACA_WITHDRAWAL_BUFFER = 500; // Buffer under cliff for withdrawal LTCG
+
+    // Get tax parameters
+    const fedParams = TaxService.getTaxParameters(year, taxState.filingStatus, 'federal', undefined, assumptions);
+    const stateParams = TaxService.getTaxParameters(year, taxState.filingStatus, 'state', taxState.stateResidency, assumptions);
+
+    // Get LTCG rate based on current ordinary income.
+    // Delegates to the shared getLTCGRate helper (imported as getLTCGRateForIncome),
+    // closing over this year's fedParams.
+    const getLTCGRate = (ordinaryIncome: number): number =>
+        getLTCGRateForIncome(ordinaryIncome, fedParams);
+
+    // Get marginal ordinary rate
+    const getMarginalRate = (ordinaryIncome: number): number => {
+        if (!fedParams) return 0.22; // Default to 22%
+
+        const result = TaxService.getMarginalTaxRate(
+            Math.max(0, ordinaryIncome - fedParams.standardDeduction),
+            fedParams
+        );
+        return result.rate;
+    };
+
+    // Get state marginal rate
+    const getStateRate = (): number => {
+        if (!stateParams) return 0;
+        const result = TaxService.getMarginalTaxRate(
+            Math.max(0, currentOrdinaryIncome - stateParams.standardDeduction),
+            stateParams
+        );
+        return result.rate;
+    };
+
+    const stateRate = getStateRate();
+
+    // IRS Pub 590-B: all Roth IRAs are treated as a single Roth IRA for ordering
+    // rules. Pool contribution basis and conversion history (FIFO across accounts)
+    // across every roth_ira snapshot. The pool is decremented in place as
+    // withdrawals are processed. Roth 401k accounts (pre-retirement only after
+    // the at-retirement rollover) keep per-account treatment.
+    const rothIRASnapshots = accountOrder.filter(s => s.accountType === 'roth_ira');
+    let remainingPoolBasis = rothIRASnapshots.reduce(
+        (sum, s) => sum + Math.max(0, s.rothContributions ?? 0),
+        0,
+    );
+    const pooledRothConversions: { year: number; amount: number }[] = rothIRASnapshots
+        .flatMap(s => s.conversionHistory ?? [])
+        .filter(c => c.amount > 0)
+        .map(c => ({ year: c.year, amount: c.amount }))
+        .sort((a, b) => a.year - b.year);
+
+    // Process each account in order
+    for (const snapshot of accountOrder) {
+        if (remainingNetNeeded <= 0) break;
+
+        // Reduce available balance for Roth accounts already tapped by ACA substitution look-ahead
+        const acaAlreadyConsumed = acaRothConsumed.get(snapshot.accountId) ?? 0;
+        const effectiveVestedBalance = snapshot.vestedBalance - acaAlreadyConsumed;
+        if (effectiveVestedBalance <= 0) continue;
+
+        const ltcgRate = getLTCGRate(runningOrdinaryIncome);
+        const marginalRate = getMarginalRate(runningOrdinaryIncome) + stateRate;
+
+        let withdrawal: PlannedWithdrawal;
+
+        switch (snapshot.accountType) {
+            case 'savings': {
+                const result = grossUpSavings(remainingNetNeeded);
+                const grossToWithdraw = Math.min(result.gross, effectiveVestedBalance);
+                const netReceived = grossToWithdraw;
+
+                withdrawal = {
+                    source: 'savings',
+                    accountId: snapshot.accountId,
+                    accountName: snapshot.accountName,
+                    gross: grossToWithdraw,
+                    net: netReceived,
+                    penalty: 0,
+                    tax: 0,
+                    reason,
+                };
+
+                remainingNetNeeded -= netReceived;
+                totalNet += netReceived;
+                totalGross += grossToWithdraw;
+                break;
+            }
+
+            case 'brokerage': {
+                const result = grossUpBrokerage(remainingNetNeeded, snapshot.gainRatio, ltcgRate);
+                let grossToWithdraw = Math.min(result.gross, effectiveVestedBalance);
+
+                // Recalculate for actual amount if capped
+                const actualGainRatio = snapshot.gainRatio;
+                let actualLTCG = grossToWithdraw * actualGainRatio;
+                let actualTax = actualLTCG * ltcgRate;
+                let netReceived = grossToWithdraw - actualTax;
+
+                // =================================================================
+                // ACA CLIFF CHECK: Cap brokerage withdrawal if LTCG would breach cliff
+                // Substitute tax-free Roth withdrawals for the remainder
+                // =================================================================
+                if (acaWithdrawalOptions && grossToWithdraw > 0) {
+                    const projectedMAGI = acaWithdrawalOptions.currentMAGI + cumulativeLTCG + actualLTCG;
+
+                    if (projectedMAGI > acaWithdrawalOptions.acaCliffThreshold) {
+                        // Calculate how much LTCG headroom we have
+                        const magiHeadroom = Math.max(0,
+                            acaWithdrawalOptions.acaCliffThreshold - ACA_WITHDRAWAL_BUFFER
+                            - acaWithdrawalOptions.currentMAGI - cumulativeLTCG
+                        );
+
+                        // Convert LTCG headroom to max safe gross withdrawal
+                        // LTCG = gross × gainRatio, so gross = LTCG / gainRatio
+                        let maxSafeGross: number;
+                        if (actualGainRatio > 0) {
+                            const maxSafeLTCG = magiHeadroom;
+                            maxSafeGross = maxSafeLTCG / actualGainRatio;
+                        } else {
+                            maxSafeGross = grossToWithdraw; // No gains, no MAGI impact
+                        }
+
+                        const originalGross = grossToWithdraw;
+                        const originalNet = netReceived;
+                        grossToWithdraw = Math.max(0, Math.min(grossToWithdraw, maxSafeGross));
+
+                        // Recalculate with capped amount
+                        actualLTCG = grossToWithdraw * actualGainRatio;
+                        actualTax = actualLTCG * ltcgRate;
+                        netReceived = grossToWithdraw - actualTax;
+
+                        // Calculate deficit still needing coverage from Roth
+                        const netShortfall = originalNet - netReceived;
+
+                        if (netShortfall > 0) {
+                            // Look-ahead: find Roth accounts in the withdrawal order
+                            let rothSubstitutionNet = 0;
+
+                            for (const rothSnapshot of accountOrder) {
+                                if (rothSubstitutionNet >= netShortfall) break;
+                                if (rothSnapshot.accountType !== 'roth_ira' && rothSnapshot.accountType !== 'roth_401k') continue;
+
+                                const alreadyConsumed = acaRothConsumed.get(rothSnapshot.accountId) ?? 0;
+                                const availableRoth = rothSnapshot.vestedBalance - alreadyConsumed;
+                                if (availableRoth <= 0) continue;
+
+                                const stillNeeded = netShortfall - rothSubstitutionNet;
+
+                                // BUG #9 FIX: consume from the SAME conversion/basis source the
+                                // main loop drains, so a conversion spent here is not available
+                                // again to the main pass (which would double-count the dollars and
+                                // mis-assign the 5-year penalty).
+                                //
+                                // For roth_ira (pooled per IRS Pub 590-B) we pass the shared
+                                // `pooledRothConversions` array (grossUpRoth mutates conv.amount in
+                                // place, so the drain is visible to the main loop) and decrement the
+                                // shared `remainingPoolBasis` by whatever contribution basis is used.
+                                // For roth_401k (per-account) the snapshot's conversionHistory is a
+                                // LIVE reference to the account model's array, and snapshots are reused
+                                // across YearSolver's deficit iterations (and the model persists across
+                                // simulation years). grossUpRoth decrements conv.amount in place, so we
+                                // must pass a deep COPY here (mirroring pooledRothConversions) to avoid
+                                // corrupting the account's conversion basis / 5-year-penalty accounting
+                                // on later iterations and years. Combined with the main loop's
+                                // acaRothConsumed/effectiveVestedBalance guard on balance, this prevents
+                                // double-spend without mutating the model.
+                                const isPooledRoth = rothSnapshot.accountType === 'roth_ira';
+                                const acaContribAvailable = isPooledRoth
+                                    ? Math.max(0, Math.min(remainingPoolBasis, rothSnapshot.vestedBalance) - alreadyConsumed)
+                                    : Math.max(0, (rothSnapshot.rothContributions ?? 0) - alreadyConsumed);
+                                const acaConversionsForCall = isPooledRoth
+                                    ? pooledRothConversions
+                                    : (rothSnapshot.conversionHistory ?? [])
+                                        .map(c => ({ year: c.year, amount: c.amount }))
+                                        .sort((a, b) => a.year - b.year);
+
+                                const rothResult = grossUpRoth(
+                                    Math.min(stillNeeded, availableRoth),
+                                    acaContribAvailable,
+                                    acaConversionsForCall,
+                                    year,
+                                    currentAge,
+                                    marginalRate,
+                                    availableRoth
+                                );
+
+                                if (isPooledRoth) {
+                                    remainingPoolBasis = Math.max(0, remainingPoolBasis - rothResult.fromContributions);
+                                }
+
+                                const rothGross = rothResult.gross;
+                                const rothTax = rothResult.tax;
+                                const rothPenalty = rothResult.penalty;
+                                const rothNet = rothGross - rothTax - rothPenalty;
+
+                                if (rothNet <= 0) continue;
+
+                                // Track consumption
+                                acaRothConsumed.set(rothSnapshot.accountId, alreadyConsumed + rothGross);
+                                rothSubstitutionNet += rothNet;
+
+                                // Record the Roth substitution withdrawal
+                                const rothWithdrawal: PlannedWithdrawal = {
+                                    source: rothSnapshot.accountType,
+                                    accountId: rothSnapshot.accountId,
+                                    accountName: rothSnapshot.accountName,
+                                    gross: rothGross,
+                                    net: rothNet,
+                                    penalty: rothPenalty,
+                                    tax: rothTax,
+                                    reason: 'ACA cliff Roth substitution',
+                                };
+
+                                withdrawals.push(rothWithdrawal);
+                                totalNet += rothNet;
+                                totalGross += rothGross;
+                                totalTax += rothTax;
+                                totalPenalties += rothPenalty;
+
+                                // Roth earnings add to ordinary income if under 59.5
+                                if (rothResult.fromEarnings > 0 && currentAge < 59.5) {
+                                    runningOrdinaryIncome += rothResult.fromEarnings;
+                                }
+
+                                decisions.push({
+                                    category: 'withdrawal',
+                                    account: rothSnapshot.accountName,
+                                    amount: rothGross,
+                                    description: `ACA cliff Roth substitution: $${rothGross.toLocaleString()} from ${rothSnapshot.accountName} (tax-free) replaces brokerage to avoid MAGI breach.`,
+                                });
+                            }
+
+                            // Reduce remainingNetNeeded by what Roth covered
+                            remainingNetNeeded -= rothSubstitutionNet;
+
+                            decisions.push({
+                                category: 'withdrawal',
+                                account: snapshot.accountName,
+                                amount: grossToWithdraw,
+                                description: `ACA cliff: Brokerage capped at $${grossToWithdraw.toLocaleString()} (was $${originalGross.toLocaleString()}). LTCG $${actualLTCG.toLocaleString()} keeps MAGI under cliff $${acaWithdrawalOptions.acaCliffThreshold.toLocaleString()}. Roth substituted $${rothSubstitutionNet.toLocaleString()}.`,
+                            });
+
+                            if (rothSubstitutionNet < netShortfall) {
+                                // Not enough Roth to cover the gap — accept cliff breach for remainder
+                                decisions.push({
+                                    category: 'warning',
+                                    amount: netShortfall - rothSubstitutionNet,
+                                    description: `Insufficient Roth balance for full ACA substitution. Remaining $${(netShortfall - rothSubstitutionNet).toLocaleString()} unfunded by substitution.`,
+                                });
+                            }
+                        }
+                    }
+                }
+
+                withdrawal = {
+                    source: 'brokerage',
+                    accountId: snapshot.accountId,
+                    accountName: snapshot.accountName,
+                    gross: grossToWithdraw,
+                    net: netReceived,
+                    capitalGains: { shortTerm: 0, longTerm: actualLTCG },
+                    penalty: 0,
+                    tax: actualTax,
+                    reason,
+                };
+
+                cumulativeLTCG += actualLTCG;
+                remainingNetNeeded -= netReceived;
+                totalNet += netReceived;
+                totalGross += grossToWithdraw;
+                totalTax += actualTax;
+                totalLTCG += actualLTCG;
+                break;
+            }
+
+            case 'traditional_401k':
+            case 'traditional_ira': {
+                // Compute taxable income positions and remaining std ded space
+                // Federal: uses full runningOrdinaryIncome (includes taxable SS)
+                const fedTaxable = Math.max(0, runningOrdinaryIncome - (fedParams?.standardDeduction ?? 0));
+                // State: excludes stateExemptIncome (e.g., taxable SS for DC)
+                const stateIncomeForBrackets = runningOrdinaryIncome - stateExemptIncome;
+                const stateTaxable = stateParams ? Math.max(0, stateIncomeForBrackets - stateParams.standardDeduction) : 0;
+                const fedStdDedSpace = Math.max(0, (fedParams?.standardDeduction ?? 0) - runningOrdinaryIncome);
+                const stateStdDedSpace = stateParams
+                    ? Math.max(0, stateParams.standardDeduction - stateIncomeForBrackets)
+                    : Infinity;
+
+                const result = grossUpTraditional(
+                    remainingNetNeeded, currentAge,
+                    fedTaxable, stateTaxable,
+                    fedParams?.brackets ?? [], stateParams?.brackets ?? null,
+                    fedStdDedSpace, stateStdDedSpace
+                );
+                const grossToWithdraw = Math.min(result.gross, effectiveVestedBalance);
+
+                // Compute tax: if capped by balance, recompute piecewise; otherwise use gross-up result
+                const penaltyRate = currentAge < EARLY_WITHDRAWAL_AGE ? EARLY_WITHDRAWAL_PENALTY_RATE : 0;
+                let actualTax: number;
+                let actualPenalty: number;
+                let netReceived: number;
+
+                if (grossToWithdraw < result.gross) {
+                    // Capped by account balance — recompute tax piecewise for actual gross
+                    const taxResult = computeTaxOnGross(
+                        grossToWithdraw, fedTaxable, stateTaxable,
+                        fedParams?.brackets ?? [], stateParams?.brackets ?? null,
+                        fedStdDedSpace, stateStdDedSpace
+                    );
+                    actualTax = taxResult.totalTax;
+                    actualPenalty = grossToWithdraw * penaltyRate;
+                    netReceived = grossToWithdraw - actualTax - actualPenalty;
+                } else {
+                    actualTax = result.tax;
+                    actualPenalty = result.penalty;
+                    netReceived = grossToWithdraw - actualTax - actualPenalty;
+                }
+
+                withdrawal = {
+                    source: snapshot.accountType,
+                    accountId: snapshot.accountId,
+                    accountName: snapshot.accountName,
+                    gross: grossToWithdraw,
+                    net: netReceived,
+                    penalty: actualPenalty,
+                    tax: actualTax,
+                    reason,
+                };
+
+                // Traditional withdrawal adds to ordinary income
+                runningOrdinaryIncome += grossToWithdraw;
+
+                remainingNetNeeded -= netReceived;
+                totalNet += netReceived;
+                totalGross += grossToWithdraw;
+                totalTax += actualTax;
+                totalPenalties += actualPenalty;
+
+                if (actualPenalty > 0) {
+                    decisions.push({
+                        category: 'withdrawal',
+                        account: snapshot.accountName,
+                        amount: actualPenalty,
+                        description: `Early withdrawal penalty of $${actualPenalty.toFixed(0)} on Traditional withdrawal.`,
+                    });
+                }
+                break;
+            }
+
+            case 'roth_401k':
+            case 'roth_ira': {
+                // Roth IRA: pool contribution basis and conversion history across all
+                // Roth IRAs (IRS Pub 590-B). Roth 401k: keep per-account treatment.
+                const isPooled = snapshot.accountType === 'roth_ira';
+                const contribAvailable = isPooled
+                    ? Math.max(0, Math.min(remainingPoolBasis, snapshot.vestedBalance) - acaAlreadyConsumed)
+                    : Math.max(0, (snapshot.rothContributions ?? 0) - acaAlreadyConsumed);
+                const conversionsForCall = isPooled
+                    ? pooledRothConversions
+                    : (snapshot.conversionHistory ? snapshot.conversionHistory.map(c => ({ year: c.year, amount: c.amount })).sort((a, b) => a.year - b.year) : []);
+
+                const result = grossUpRoth(
+                    remainingNetNeeded,
+                    contribAvailable,
+                    conversionsForCall,
+                    year,
+                    currentAge,
+                    marginalRate,
+                    effectiveVestedBalance
+                );
+
+                if (isPooled) {
+                    remainingPoolBasis = Math.max(0, remainingPoolBasis - result.fromContributions);
+                }
+                const grossToWithdraw = result.gross;
+                const netReceived = grossToWithdraw - result.tax - result.penalty;
+
+                withdrawal = {
+                    source: snapshot.accountType,
+                    accountId: snapshot.accountId,
+                    accountName: snapshot.accountName,
+                    gross: grossToWithdraw,
+                    net: netReceived,
+                    penalty: result.penalty,
+                    tax: result.tax,
+                    reason,
+                };
+
+                // Roth earnings (if any) add to ordinary income
+                if (result.fromEarnings > 0 && currentAge < EARLY_WITHDRAWAL_AGE) {
+                    runningOrdinaryIncome += result.fromEarnings;
+                }
+
+                remainingNetNeeded -= netReceived;
+                totalNet += netReceived;
+                totalGross += grossToWithdraw;
+                totalTax += result.tax;
+                totalPenalties += result.penalty;
+
+                if (result.penalty > 0) {
+                    decisions.push({
+                        category: 'withdrawal',
+                        account: snapshot.accountName,
+                        amount: result.penalty,
+                        description: `Early withdrawal penalty of $${result.penalty.toFixed(0)} on Roth withdrawal (5-year rule).`,
+                    });
+                }
+                break;
+            }
+
+            case 'hsa': {
+                // HSA withdrawals for non-healthcare are taxed as ordinary + 20% penalty before 65
+                const penaltyRate = currentAge < 65 ? 0.20 : 0;
+                const effectiveRate = marginalRate + penaltyRate;
+                const gross = remainingNetNeeded / (1 - effectiveRate);
+                const grossToWithdraw = Math.min(gross, effectiveVestedBalance);
+
+                const actualPenalty = grossToWithdraw * penaltyRate;
+                const actualTax = grossToWithdraw * marginalRate;
+                const netReceived = grossToWithdraw - actualTax - actualPenalty;
+
+                withdrawal = {
+                    source: 'hsa',
+                    accountId: snapshot.accountId,
+                    accountName: snapshot.accountName,
+                    gross: grossToWithdraw,
+                    net: netReceived,
+                    penalty: actualPenalty,
+                    tax: actualTax,
+                    reason,
+                };
+
+                runningOrdinaryIncome += grossToWithdraw;
+                remainingNetNeeded -= netReceived;
+                totalNet += netReceived;
+                totalGross += grossToWithdraw;
+                totalTax += actualTax;
+                totalPenalties += actualPenalty;
+
+                if (actualPenalty > 0) {
+                    decisions.push({
+                        category: 'warning',
+                        account: snapshot.accountName,
+                        amount: actualPenalty,
+                        description: `HSA withdrawal for non-healthcare incurs 20% penalty of $${actualPenalty.toFixed(0)}.`,
+                    });
+                }
+                break;
+            }
+
+            case 'espp': {
+                const esppLots = snapshot.esppLots;
+
+                // Use pre-computed lot data if available
+                if (esppLots && esppLots.length > 0) {
+                    // Blended effective-tax sizing. The bargain element is taxed as
+                    // ordinary income (marginal + state), only the post-bargain
+                    // appreciation is LTCG. Sizing the gross against just
+                    // gainRatio*ltcgRate (as before) ignored the ordinary tax on the
+                    // bargain element AND wrongly applied the lower LTCG rate to the
+                    // ordinary-taxed portion, so the sale under-delivered net cash.
+                    // Derive the pool's tax-per-gross-dollar from the lot data and
+                    // gross up against the blended rate.
+                    const esppMarginalRate = getMarginalRate(runningOrdinaryIncome);
+                    const esppStateRate = getStateRate();
+                    const esppCombinedOrdinaryRate = esppMarginalRate + esppStateRate;
+
+                    let poolValue = 0;
+                    let poolOrdinaryTax = 0;
+                    let poolLtcgTax = 0;
+                    for (const lot of esppLots) {
+                        poolValue += lot.totalValue;
+                        poolOrdinaryTax += lot.shares * lot.ordinaryIncomePerShare * esppCombinedOrdinaryRate;
+                        poolLtcgTax += lot.shares * lot.ltcgPerShare * ltcgRate;
+                    }
+                    const effectiveTaxPerGrossDollar = poolValue > 0
+                        ? (poolOrdinaryTax + poolLtcgTax) / poolValue
+                        : 0;
+
+                    // Estimate gross needed using the blended effective rate.
+                    // Clamp the denominator defensively so a near-100% blended rate
+                    // can't produce a negative/exploding gross.
+                    const esppDenominator = Math.max(0.01, 1 - effectiveTaxPerGrossDollar);
+                    const estimatedGross = Math.min(
+                        remainingNetNeeded / esppDenominator,
+                        effectiveVestedBalance
+                    );
+
+                    // Walk lots in order, consuming shares until we have enough
+                    let grossToWithdraw = 0;
+                    let esppOrdinaryIncome = 0;
+                    let esppLTCG = 0;
+                    let remainingGrossNeeded = estimatedGross;
+
+                    for (const lot of esppLots) {
+                        if (remainingGrossNeeded <= 0) break;
+
+                        const lotValue = lot.totalValue;
+                        const valueToUse = Math.min(lotValue, remainingGrossNeeded);
+                        const shareRatio = lotValue > 0 ? valueToUse / lotValue : 0;
+                        const sharesUsed = lot.shares * shareRatio;
+
+                        grossToWithdraw += valueToUse;
+                        esppOrdinaryIncome += sharesUsed * lot.ordinaryIncomePerShare;
+                        esppLTCG += sharesUsed * lot.ltcgPerShare;
+                        remainingGrossNeeded -= valueToUse;
+                    }
+
+                    if (grossToWithdraw <= 0) {
+                        continue; // Skip to next account if no value to withdraw
+                    }
+
+                    // Calculate taxes: ordinary income at marginal rate, LTCG at cap gains rate.
+                    // Reuse the blended-rate inputs computed above for the gross-up.
+                    const ordinaryTax = esppOrdinaryIncome * esppCombinedOrdinaryRate;
+                    const ltcgTax = esppLTCG * ltcgRate;
+                    const actualTax = ordinaryTax + ltcgTax;
+
+                    const netReceived = grossToWithdraw - actualTax;
+
+                    withdrawal = {
+                        source: 'espp',
+                        accountId: snapshot.accountId,
+                        accountName: snapshot.accountName,
+                        gross: grossToWithdraw,
+                        net: netReceived,
+                        capitalGains: { shortTerm: 0, longTerm: esppLTCG },
+                        penalty: 0,
+                        tax: actualTax,
+                        reason,
+                    };
+
+                    // ESPP ordinary income affects tax bracket
+                    runningOrdinaryIncome += esppOrdinaryIncome;
+
+                    cumulativeLTCG += esppLTCG;
+                    remainingNetNeeded -= netReceived;
+                    totalNet += netReceived;
+                    totalGross += grossToWithdraw;
+                    totalTax += actualTax;
+                    totalLTCG += esppLTCG;
+
+                    // Log ESPP ordinary income decision
+                    if (esppOrdinaryIncome > 0) {
+                        const dispositionTypes = [...new Set(esppLots.map(l => l.dispositionType))].join('/');
+                        decisions.push({
+                            category: 'tax',
+                            account: snapshot.accountName,
+                            amount: esppOrdinaryIncome,
+                            description: `ESPP withdrawal: $${esppOrdinaryIncome.toLocaleString()} ordinary income (${dispositionTypes} disposition), $${esppLTCG.toLocaleString()} LTCG.`,
+                        });
+                    }
+                } else {
+                    // Fallback: treat like brokerage if no ESPP lot data
+                    const result = grossUpBrokerage(remainingNetNeeded, snapshot.gainRatio, ltcgRate);
+                    const grossToWithdraw = Math.min(result.gross, effectiveVestedBalance);
+
+                    const actualLTCG = grossToWithdraw * snapshot.gainRatio;
+                    const actualTax = actualLTCG * ltcgRate;
+                    const netReceived = grossToWithdraw - actualTax;
+
+                    withdrawal = {
+                        source: 'espp',
+                        accountId: snapshot.accountId,
+                        accountName: snapshot.accountName,
+                        gross: grossToWithdraw,
+                        net: netReceived,
+                        capitalGains: { shortTerm: 0, longTerm: actualLTCG },
+                        penalty: 0,
+                        tax: actualTax,
+                        reason,
+                    };
+
+                    cumulativeLTCG += actualLTCG;
+                    remainingNetNeeded -= netReceived;
+                    totalNet += netReceived;
+                    totalGross += grossToWithdraw;
+                    totalTax += actualTax;
+                    totalLTCG += actualLTCG;
+                }
+                break;
+            }
+
+            default:
+                continue;
+        }
+
+        withdrawals.push(withdrawal);
+
+        // Log the withdrawal
+        decisions.push({
+            category: 'withdrawal',
+            account: snapshot.accountName,
+            amount: withdrawal.gross,
+            description: `Withdrew $${withdrawal.gross.toLocaleString()} from ${snapshot.accountName} (net: $${withdrawal.net.toLocaleString()}).`,
+        });
+    }
+
+    // Log if there's remaining deficit
+    if (remainingNetNeeded > 0) {
+        decisions.push({
+            category: 'warning',
+            amount: remainingNetNeeded,
+            description: `Unfunded deficit of $${remainingNetNeeded.toLocaleString()}. All accounts exhausted.`,
+        });
+    }
+
+    return {
+        withdrawals,
+        totalGross,
+        totalNet,
+        totalTax,
+        totalPenalties,
+        totalLTCG,
+        totalSTCG,
+        remainingDeficit: remainingNetNeeded < 0.01 ? 0 : remainingNetNeeded,
+        decisions,
+    };
+}

--- a/src/services/simulation/WithdrawalService.ts
+++ b/src/services/simulation/WithdrawalService.ts
@@ -1,0 +1,51 @@
+import { AnyAccount, DeficitDebtAccount } from "../../components/Objects/Accounts/models";
+
+export interface DeficitDebtResult {
+    existingDeficitDebt: DeficitDebtAccount | undefined;
+    deficitDebtPayment: number;
+    discretionaryCash: number;
+    logs: string[];
+}
+
+/**
+ * Track deficit debt: if there's still an uncovered deficit after all withdrawals.
+ */
+export function processDeficitDebt(
+    discretionaryCash: number,
+    accounts: AnyAccount[],
+    logs: string[]
+): DeficitDebtResult {
+    const DEFICIT_DEBT_ID = 'system-deficit-debt';
+    const DEFICIT_DEBT_NAME = 'Uncovered Deficit';
+    let deficitDebtPayment = 0;
+
+    let existingDeficitDebt = accounts.find(
+        acc => acc instanceof DeficitDebtAccount && acc.id === DEFICIT_DEBT_ID
+    ) as DeficitDebtAccount | undefined;
+
+    // Only create deficit debt for deficits > $0.005 (ignore small rounding errors)
+    if (discretionaryCash < -0.005) {
+        const uncoveredDeficit = Math.abs(discretionaryCash);
+
+        if (existingDeficitDebt) {
+            existingDeficitDebt = new DeficitDebtAccount(
+                DEFICIT_DEBT_ID,
+                DEFICIT_DEBT_NAME,
+                existingDeficitDebt.amount + uncoveredDeficit
+            );
+        } else {
+            existingDeficitDebt = new DeficitDebtAccount(
+                DEFICIT_DEBT_ID,
+                DEFICIT_DEBT_NAME,
+                uncoveredDeficit
+            );
+        }
+
+        logs.push(`[WARN] Uncovered deficit of $${uncoveredDeficit.toLocaleString(undefined, { maximumFractionDigits: 0 })} added to deficit debt`);
+        logs.push(`  Total deficit debt: $${existingDeficitDebt.amount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`);
+
+        discretionaryCash = 0;
+    }
+
+    return { existingDeficitDebt, deficitDebtPayment, discretionaryCash, logs };
+}

--- a/src/services/simulation/YearSolver.ts
+++ b/src/services/simulation/YearSolver.ts
@@ -1,0 +1,1960 @@
+/**
+ * YearSolver.ts
+ *
+ * Phase 2R: Retirement Year Solver
+ *
+ * This is the core convergence solver for retirement years. It handles:
+ * 1. Roth conversion planning (FIRST - determines ordinary income)
+ * 2. Withdrawal planning (SECOND - uses known tax rates)
+ * 3. Convergence loop for bracket crossings
+ *
+ * Design Principles:
+ * - Conversion before withdrawals (conversion affects LTCG rates)
+ * - Algebraic gross-up on BASE deficit (no LTCG in deficit)
+ * - Loop only when bracket crossing occurs (rare)
+ * - Pure functions - no mutations during planning
+ */
+
+import { AnyAccount, InvestedAccount } from "../../components/Objects/Accounts/models";
+import { AnyIncome } from "../../components/Objects/Income/models";
+// AnyExpense is currently unused but kept for future extension
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { AnyExpense } from "../../components/Objects/Expense/models";
+import { TaxParameters } from "../../data/TaxData";
+import { TaxState } from "../../components/Objects/Taxes/TaxContext";
+import { AssumptionsState } from "../../components/Objects/Assumptions/AssumptionsContext";
+import {
+    YearPlan,
+    PlannedWithdrawal,
+    PlannedConversion,
+    DecisionLogEntry,
+    YearPlanTax,
+    ConversionTaxSource,
+    TaxOptimizationTarget,
+    ConversionConstraints,
+    ConversionLimitingFactor,
+    BaselineProjections,
+} from "./types";
+import { WithdrawalResult } from "../WithdrawalStrategies";
+import { classifyIncome, getTotalSSBenefits } from "./IncomeClassifier";
+import { planWithdrawals, createOrderedSnapshots } from "./WithdrawalPlanner";
+import * as TaxService from "../../components/Objects/Taxes/TaxService";
+import { getLTCGRate } from "../../components/Objects/Taxes/taxService/capitalGainsTax";
+import { calculateEffectiveConversionTax, ACAOptions } from "./helpers";
+import { getRMDStartAge } from "../../data/RMDData";
+import {
+    calculateDynamicConversionCeiling,
+    coarseToFineSearch,
+    getAcaCliffThreshold,
+} from "./TaxOptimizedWithdrawal";
+import { estimateFixedIncomeAtRMD } from "./helpers";
+import { allocateSurplus, SurplusAllocationSettings } from "./SurplusAllocator";
+import { getIRALimit } from "../../data/ContributionLimits";
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const DEFAULT_GROWTH_RATE = 0.07;
+const DEFAULT_EMERGENCY_FUND_TARGET = 30000;
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface YearSolverInput {
+    year: number;
+    currentAge: number;
+    isRetired: boolean;
+
+    // Income & Expenses
+    incomes: AnyIncome[];
+    expenses: AnyExpense[];
+    totalLivingExpenses: number;
+    rmdAmount: number;
+
+    // Accounts
+    accounts: AnyAccount[];
+    withdrawalOrder: { accountId: string }[];
+
+    // Tax state
+    taxState: TaxState;
+    assumptions: AssumptionsState;
+
+    // Strategy
+    strategyResult?: WithdrawalResult;
+
+    // Settings
+    taxOptimizationEnabled: boolean;
+    acaAware: boolean;
+
+    // Prior year data (for GK and conversions)
+    previousSimulation?: { year: number; accounts: AnyAccount[] }[];
+
+    // GK Guardrails (optional - only passed when withdrawal strategy is active)
+    gkBudget?: number;           // The GK-adjusted spending budget
+    fixedExpenses?: number;      // Fixed (non-discretionary) expenses
+    discretionaryExpenses?: number; // Discretionary expenses (may be eliminated)
+
+    // Baseline projections from a per-year forward sub-simulation (std-ded-only
+    // conversions). When provided, the conversion ceiling calculator uses these as
+    // the source of truth for SS/pension/passive/Trad-balance at RMD age — more
+    // accurate than COLA-only fallbacks or naive forward-compounding of today's
+    // Trad balance.
+    baselineProjections?: BaselineProjections;
+
+    // Conversion mode. 'rate-match' (default) runs the full bracket-walking
+    // algorithm. 'std-ded-only' is used by `runProjectionSubsim` to do only
+    // standard-deduction-headroom conversions while projecting the baseline
+    // trajectory for the main sim's rate-match decisions.
+    conversionMode?: 'rate-match' | 'std-ded-only';
+
+    // Precomputed conversion plan keyed by simulation year. Populated only when
+    // `assumptions.investments.rothConversionStrategy === 'dp-precomputed'`. The
+    // DP strategy looks up this year's amount and skips per-year bracket-walking.
+    dpConversionPlan?: Map<number, number>;
+    // Per-year debug-log strings from the DP solver. planConversionDP appends
+    // them to its decisions so they surface in the year inspector. Only set
+    // when the DP strategy is in use.
+    dpDebugByYear?: Map<number, string[]>;
+}
+
+export interface ConversionPlan {
+    conversion: PlannedConversion | null;
+    conversionTax: number;
+    taxSource: ConversionTaxSource;
+    additionalOrdinaryIncome: number;
+    decisions: DecisionLogEntry[];
+    taxOptimizationTarget?: TaxOptimizationTarget;
+    bracketSpaceForSpending: number;  // bracket space reserved for Traditional spending
+}
+
+/**
+ * A conversion-amount-deciding strategy. Implementations decide how much (if any)
+ * Traditional → Roth conversion to do for a single year, given the year's tax
+ * context. The rate-match implementation walks brackets per-year; future DP
+ * implementations precompute a per-year plan and look it up. Both must satisfy
+ * the same input/output contract.
+ */
+export type ConversionStrategy = (
+    input: YearSolverInput,
+    baseOrdinaryIncome: number,
+    socialSecurityBenefits: number,
+    nonSSOrdinaryIncome: number,
+    fedParams: TaxParameters,
+    stateParams: TaxParameters | null,
+    surplus: number,
+    spendingDeficit: number,
+) => ConversionPlan;
+
+/**
+ * Pick the conversion strategy for the current run. The DP path requires a
+ * precomputed plan to be on `input.dpConversionPlan` (built upstream by
+ * `runSimulationWithOptimization`); without it, the DP strategy returns a
+ * no-conversion plan for the year.
+ */
+function selectConversionStrategy(
+    strategyName: 'rate-match' | 'dp-precomputed' | undefined,
+): ConversionStrategy {
+    if (strategyName === 'dp-precomputed') return planConversionDP;
+    return planConversion;
+}
+
+// =============================================================================
+// HELPER FUNCTIONS
+// =============================================================================
+
+function getTotalTraditionalBalance(accounts: AnyAccount[]): number {
+    return accounts
+        .filter(a => a instanceof InvestedAccount &&
+            (a.taxType === 'Traditional 401k' || a.taxType === 'Traditional IRA'))
+        .reduce((sum, a) => sum + (a as InvestedAccount).vestedAmount, 0);
+}
+
+function getTotalBrokerageBalance(accounts: AnyAccount[]): number {
+    return accounts
+        .filter(a => a instanceof InvestedAccount && a.taxType === 'Brokerage')
+        .reduce((sum, a) => sum + (a as InvestedAccount).vestedAmount, 0);
+}
+
+function getFirstTraditionalAccount(accounts: AnyAccount[]): InvestedAccount | null {
+    return accounts.find(a =>
+        a instanceof InvestedAccount &&
+        (a.taxType === 'Traditional 401k' || a.taxType === 'Traditional IRA') &&
+        a.vestedAmount > 0
+    ) as InvestedAccount | null;
+}
+
+function getFirstRothAccount(accounts: AnyAccount[]): InvestedAccount | null {
+    return accounts.find(a =>
+        a instanceof InvestedAccount &&
+        (a.taxType === 'Roth 401k' || a.taxType === 'Roth IRA')
+    ) as InvestedAccount | null;
+}
+
+/**
+ * Get the weighted average gain ratio for brokerage accounts.
+ * Used for estimating LTCG from potential withdrawals.
+ */
+function getBrokerageGainRatio(accounts: AnyAccount[]): number {
+    let totalBalance = 0;
+    let totalGains = 0;
+
+    for (const account of accounts) {
+        if (account instanceof InvestedAccount && account.taxType === 'Brokerage') {
+            const balance = account.vestedAmount;
+            const gains = Math.max(0, balance - account.costBasis);
+            totalBalance += balance;
+            totalGains += gains;
+        }
+    }
+
+    return totalBalance > 0 ? totalGains / totalBalance : 0;
+}
+
+/**
+ * Get LTCG rate based on ordinary income level.
+ * Thin alias over the shared getLTCGRate helper in capitalGainsTax.
+ */
+const getLTCGRateForIncome = getLTCGRate;
+
+/**
+ * Estimate LTCG that would result from covering a deficit via brokerage withdrawal.
+ * Formula: LTCG = grossWithdrawal × gainRatio
+ *          grossWithdrawal = deficit / (1 - gainRatio × ltcgRate)
+ *          When ltcgRate = 0: grossWithdrawal = deficit, LTCG = deficit × gainRatio
+ */
+function estimateLTCGFromDeficit(deficit: number, gainRatio: number, ltcgRate: number = 0): number {
+    if (deficit <= 0 || gainRatio <= 0) return 0;
+
+    const effectiveRate = gainRatio * ltcgRate;
+    const grossWithdrawal = effectiveRate < 1 ? deficit / (1 - effectiveRate) : deficit;
+    return grossWithdrawal * gainRatio;
+}
+
+// =============================================================================
+// CONVERSION PLANNING
+// =============================================================================
+
+/**
+ * Build the inputs for and call calculateDynamicConversionCeiling. Extracted so
+ * both planConversion (rate-match) and planConversionDP can compute the same
+ * ceiling and bracket-space figures — DP uses them only for the spending
+ * reservation gate, rate-match uses them for conversion sizing too.
+ */
+function computeCeilingContext(
+    input: YearSolverInput,
+    baseOrdinaryIncome: number,
+    socialSecurityBenefits: number,
+    fedParams: TaxParameters,
+    stateParams: TaxParameters | null,
+): {
+    ceilingResult: ReturnType<typeof calculateDynamicConversionCeiling>;
+    rmdStartAge: number;
+    yearsUntilRMD: number;
+    fixedIncomeAtRMD: ReturnType<typeof estimateFixedIncomeAtRMD>;
+    passiveIncome: number;
+    growthRate: number;
+    acaOptions?: ACAOptions;
+    traditionalBalance: number;
+} {
+    const traditionalBalance = getTotalTraditionalBalance(input.accounts);
+    const birthYear = input.year - input.currentAge;
+    const rmdStartAge = getRMDStartAge(birthYear);
+    const yearsUntilRMD = Math.max(0, rmdStartAge - input.currentAge);
+
+    const pensionIncome = input.incomes
+        .filter(i => (i as any).className?.includes('Pension'))
+        .reduce((sum, i) => sum + i.getAnnualAmount(input.year), 0);
+
+    const passiveIncome = input.incomes
+        .filter(i => (i as any).className === 'PassiveIncome' && (i as any).sourceType !== 'RMD')
+        .reduce((sum, i) => sum + i.getAnnualAmount(input.year), 0);
+
+    const futureSS = input.incomes.find(i => (i as any).className === 'FutureSocialSecurityIncome') as
+        { calculatedPIA?: number; claimingAge?: number; name?: string; amount?: number; projectedPIA?: number } | undefined;
+    const futureSS_PIA = (futureSS?.projectedPIA && futureSS.projectedPIA > 0)
+        ? futureSS.projectedPIA
+        : (futureSS?.amount ? futureSS.amount / 12 : (futureSS?.calculatedPIA ?? 0));
+    const ssClaimingAge = futureSS?.claimingAge ?? 67;
+
+    const inflationAdjusted = input.assumptions.macro.inflationAdjusted;
+    const ssCola = inflationAdjusted ? 0.02 : 0;
+    const pensionCola = inflationAdjusted ? 0.02 : 0;
+
+    const fixedIncomeAtRMD = estimateFixedIncomeAtRMD(
+        socialSecurityBenefits,
+        futureSS_PIA,
+        pensionIncome,
+        input.currentAge,
+        rmdStartAge,
+        ssClaimingAge,
+        ssCola,
+        pensionCola
+    );
+
+    const grossRoR = input.assumptions.investments.returnRates.ror ?? (DEFAULT_GROWTH_RATE * 100);
+    const tradAccounts = input.accounts.filter(a =>
+        a instanceof InvestedAccount &&
+        (a.taxType === 'Traditional 401k' || a.taxType === 'Traditional IRA')
+    ) as InvestedAccount[];
+    const totalTradBalance = tradAccounts.reduce((sum, a) => sum + a.vestedAmount, 0);
+    const weightedER = totalTradBalance > 0
+        ? tradAccounts.reduce((sum, a) => sum + a.expenseRatio * a.vestedAmount, 0) / totalTradBalance
+        : 0;
+    const growthRate = (grossRoR - weightedER) / 100;
+
+    let acaOptions: ACAOptions | undefined;
+    if (input.acaAware && input.currentAge < 65) {
+        // Use the shared 400% FPL cliff (by year + filing status) rather than hardcoded
+        // values, matching RothConversionDP. The old constants ($125k MFJ / $62.5k single)
+        // diverged from the real thresholds (~$81.8k / $60.2k for 2024).
+        const acaFiling: 'single' | 'married_filing_jointly' =
+            input.taxState.filingStatus === 'Married Filing Jointly' ? 'married_filing_jointly' : 'single';
+        acaOptions = {
+            currentAge: input.currentAge,
+            acaSubsidyAware: true,
+            acaCliffThreshold: getAcaCliffThreshold(acaFiling, input.year),
+            estimatedSubsidyLoss: 12000,
+        };
+    }
+
+    const ceilingResult = calculateDynamicConversionCeiling(
+        traditionalBalance,
+        yearsUntilRMD,
+        fixedIncomeAtRMD.pensionAtRMD,
+        fixedIncomeAtRMD.ssAtRMD,
+        passiveIncome,
+        baseOrdinaryIncome,
+        socialSecurityBenefits,
+        0,
+        growthRate,
+        rmdStartAge,
+        fedParams,
+        input.taxState,
+        stateParams,
+        acaOptions,
+        input.baselineProjections,
+        input.assumptions,
+        input.conversionMode ?? 'rate-match'
+    );
+
+    return {
+        ceilingResult,
+        rmdStartAge,
+        yearsUntilRMD,
+        fixedIncomeAtRMD,
+        passiveIncome,
+        growthRate,
+        acaOptions,
+        traditionalBalance,
+    };
+}
+
+/**
+ * Plan Roth conversion for the year.
+ *
+ * Conversion is planned FIRST because it affects:
+ * 1. Ordinary income (determines marginal rates)
+ * 2. LTCG rate (stacks on top of ordinary income)
+ * 3. SS taxability (provisional income includes conversion)
+ */
+function planConversion(
+    input: YearSolverInput,
+    baseOrdinaryIncome: number, // non-SS ordinary income + taxable SS (federal bracket-positioning base)
+    socialSecurityBenefits: number,
+    nonSSOrdinaryIncome: number, // ordinary income EXCLUDING SS entirely (taxableBase - fullSS)
+    fedParams: TaxParameters,
+    stateParams: TaxParameters | null,
+    surplus: number, // Cash surplus that could pay conversion tax
+    spendingDeficit: number  // pre-tax deficit estimate (expenses + roughTax - spendable - RMD)
+): ConversionPlan {
+    const decisions: DecisionLogEntry[] = [];
+    let bracketSpaceForSpending = 0;
+
+    const traditionalBalance = getTotalTraditionalBalance(input.accounts);
+
+    // Skip conversion if not enabled or not retired
+    if (!input.taxOptimizationEnabled || !input.isRetired) {
+        const limitingFactor: ConversionLimitingFactor = !input.isRetired ? 'NOT_RETIRED' : 'OPTIMIZATION_DISABLED';
+        return {
+            conversion: null,
+            conversionTax: 0,
+            taxSource: 'SURPLUS',
+            additionalOrdinaryIncome: 0,
+            decisions,
+            bracketSpaceForSpending: 0,
+            taxOptimizationTarget: {
+                yearsUntilRMD: 0,
+                rmdStartAge: 73,
+                targetBracketCeiling: 0,
+                bracketSpaceThisYear: 0,
+                ssAtRMD: 0,
+                pensionAtRMD: 0,
+                currentTraditionalBalance: traditionalBalance,
+                limitingFactor,
+                actualConversion: 0,
+            },
+        };
+    }
+
+    if (traditionalBalance <= 0) {
+        decisions.push({
+            category: 'conversion',
+            description: 'Skipped Roth conversion: no Traditional balance available.',
+        });
+        return {
+            conversion: null,
+            conversionTax: 0,
+            taxSource: 'SURPLUS',
+            additionalOrdinaryIncome: 0,
+            decisions,
+            bracketSpaceForSpending: 0,
+            taxOptimizationTarget: {
+                yearsUntilRMD: 0,
+                rmdStartAge: 73,
+                targetBracketCeiling: 0,
+                bracketSpaceThisYear: 0,
+                ssAtRMD: 0,
+                pensionAtRMD: 0,
+                currentTraditionalBalance: 0,
+                limitingFactor: 'TRADITIONAL_DEPLETED',
+                actualConversion: 0,
+            },
+        };
+    }
+
+    const {
+        ceilingResult,
+        rmdStartAge,
+        yearsUntilRMD,
+        fixedIncomeAtRMD,
+        acaOptions,
+    } = computeCeilingContext(input, baseOrdinaryIncome, socialSecurityBenefits, fedParams, stateParams);
+
+    // Log ceiling decision so it's visible in the year inspector
+    decisions.push({
+        category: 'conversion',
+        description:
+            `Ceiling: ${yearsUntilRMD}yr to RMD, ` +
+            `Trad@RMD ~$${Math.round(ceilingResult.projectedBalanceAtRMD).toLocaleString()} ` +
+            `(baseline no-conversion), ` +
+            `peak RMD ~$${Math.round(ceilingResult.peakRMD).toLocaleString()}/yr ` +
+            `→ ${(ceilingResult.peakRMDBracket * 100).toFixed(0)}% bracket ` +
+            `→ ceiling ${ceilingResult.conversionCeiling > 0 ? (ceilingResult.conversionCeiling * 100).toFixed(0) + '%' : 'none (0%)'}.`,
+    });
+
+    // Build constraint details for debugging
+    const constraintDetails: ConversionConstraints = {
+        bracketCeiling: ceilingResult.conversionCeiling,
+        bracketTop: 0, // Will be calculated below
+        currentAGI: baseOrdinaryIncome,
+        rawBracketSpace: ceilingResult.bracketSpacePerYear,
+        ssTorpedoReduction: 0,
+        acaCliffReduction: 0,
+        effectiveBracketSpace: ceilingResult.bracketSpacePerYear,
+        ssTorpedoTriggered: false,
+        acaCliffTriggered: false,
+    };
+
+    // Calculate bracket top based on filing status and target ceiling
+    const bracketThresholds = fedParams.brackets.filter(b => b.rate <= ceilingResult.conversionCeiling);
+    if (bracketThresholds.length > 0) {
+        const topBracket = bracketThresholds[bracketThresholds.length - 1];
+        // Next bracket threshold is the top of current bracket
+        const nextBracketIdx = fedParams.brackets.findIndex(b => b.rate > ceilingResult.conversionCeiling);
+        if (nextBracketIdx > 0) {
+            constraintDetails.bracketTop = fedParams.brackets[nextBracketIdx].threshold + fedParams.standardDeduction;
+        } else {
+            // At highest bracket
+            constraintDetails.bracketTop = topBracket.threshold + fedParams.standardDeduction + 1000000;
+        }
+    }
+
+    // Build the tax optimization target info for UI display
+    const taxOptimizationTarget: TaxOptimizationTarget = {
+        yearsUntilRMD,
+        rmdStartAge,
+        targetBracketCeiling: ceilingResult.conversionCeiling,
+        bracketSpaceThisYear: ceilingResult.bracketSpacePerYear,
+        ssAtRMD: fixedIncomeAtRMD.ssAtRMD,
+        pensionAtRMD: fixedIncomeAtRMD.pensionAtRMD,
+        projectedBalanceAtRMD: ceilingResult.projectedBalanceAtRMD,
+        currentTraditionalBalance: traditionalBalance,
+        constraintDetails,
+        rateMatchWalk: ceilingResult.rateMatchWalk,
+    };
+
+    // Calculate bracket space
+    let bracketSpace = Math.max(0, ceilingResult.bracketSpacePerYear);
+
+    if (bracketSpace <= 0) {
+        decisions.push({
+            category: 'conversion',
+            description: `Skipped Roth conversion: no bracket space (income $${baseOrdinaryIncome.toLocaleString()} at ceiling ${(ceilingResult.conversionCeiling * 100).toFixed(0)}% bracket).`,
+        });
+        taxOptimizationTarget.limitingFactor = 'NO_BRACKET_SPACE';
+        taxOptimizationTarget.actualConversion = 0;
+        return {
+            conversion: null,
+            conversionTax: 0,
+            taxSource: 'SURPLUS',
+            additionalOrdinaryIncome: 0,
+            decisions,
+            bracketSpaceForSpending: 0,
+            taxOptimizationTarget,
+        };
+    }
+
+    // =========================================================================
+    // SPENDING DEFICIT: Reserve bracket space for Traditional withdrawals
+    // =========================================================================
+    // When there's a spending deficit and brokerage can't cover it, the solver
+    // would convert Traditional→Roth then withdraw Roth for spending — a wasteful
+    // roundtrip. Instead, reserve bracket space for direct Traditional withdrawal.
+    //
+    // Two guards:
+    // 1. Age >= 59.5 only. Under 59.5, conversion is strictly cheaper than
+    //    penalized Traditional withdrawal. Spending comes from Roth contribution
+    //    basis (penalty-free FIFO) or brokerage.
+    // 2. Brokerage insufficient. When brokerage covers the deficit, no roundtrip
+    //    exists — conversion fills brackets while brokerage handles spending.
+    //    Only reserve for the shortfall that would spill into Roth.
+    const penaltyApplies = input.currentAge < 59.5;
+    if (spendingDeficit > 0 && traditionalBalance > 0 && bracketSpace > 0 && !penaltyApplies) {
+        // Check how much of the deficit brokerage can cover
+        const brokerageBalance = getTotalBrokerageBalance(input.accounts);
+        const brokerageGainRatio = getBrokerageGainRatio(input.accounts);
+        const ltcgRate = getLTCGRateForIncome(baseOrdinaryIncome, fedParams);
+        // Gross down: brokerage withdrawal of $B yields $B × (1 - gainRatio × ltcgRate) net
+        const brokerageCoverage = brokerageBalance * (1 - brokerageGainRatio * ltcgRate);
+        const rothBoundDeficit = Math.max(0, spendingDeficit - brokerageCoverage);
+
+        if (rothBoundDeficit > 0) {
+            const marginalResult = TaxService.getMarginalTaxRate(
+                Math.max(0, baseOrdinaryIncome - fedParams.standardDeduction),
+                fedParams
+            );
+            const stateRate = stateParams
+                ? TaxService.getMarginalTaxRate(
+                    Math.max(0, baseOrdinaryIncome - stateParams.standardDeduction),
+                    stateParams
+                  ).rate
+                : 0;
+
+            // Only reserve when marginal rate is at or below the ceiling
+            if (marginalResult.rate <= ceilingResult.conversionCeiling + 0.005) {
+                // Gross-up the Roth-bound portion to bracket space terms
+                const totalEffectiveRate = marginalResult.rate + stateRate;
+                const grossForDeficit = rothBoundDeficit / Math.max(0.5, 1 - totalEffectiveRate);
+                bracketSpaceForSpending = Math.min(grossForDeficit, bracketSpace, traditionalBalance);
+
+                // Reduce bracket space available for conversion
+                bracketSpace = Math.max(0, bracketSpace - bracketSpaceForSpending);
+
+                decisions.push({
+                    category: 'conversion',
+                    amount: bracketSpaceForSpending,
+                    description: `Reserved $${Math.round(bracketSpaceForSpending).toLocaleString()} bracket space ` +
+                        `for Traditional spending (Roth-bound deficit $${Math.round(rothBoundDeficit).toLocaleString()} ` +
+                        `of $${Math.round(spendingDeficit).toLocaleString()} total, ` +
+                        `brokerage covers $${Math.round(brokerageCoverage).toLocaleString()}, ` +
+                        `marginal rate ${(marginalResult.rate * 100).toFixed(1)}% ` +
+                        `vs ${(ceilingResult.conversionCeiling * 100).toFixed(0)}% ceiling).`,
+                });
+
+                if (bracketSpace <= 0) {
+                    taxOptimizationTarget.limitingFactor = 'SPENDING_DEFICIT';
+                }
+            }
+        }
+    }
+
+    // Calculate conversion amount: min of bracket space (after spending reservation)
+    // and available Traditional balance. Iterative refinement of baselineProjections
+    // (in runSimulationWithOptimization) handles the "smooth glidepath" behavior
+    // PMT pacing previously aimed for.
+    const availableTraditional = traditionalBalance - bracketSpaceForSpending;
+    let conversionAmount = Math.min(bracketSpace, availableTraditional);
+
+    // Use coarse-to-fine search for optimal amount considering SS torpedo.
+    // Federal-only rates: the ceiling (e.g., 12%) is a federal bracket target.
+    // State tax is still fully accounted for in the actual conversion tax cost.
+    // Adjust base income and available balance for spending reservation.
+    // Base must EXCLUDE SS: the search → getEffectiveConversionRate →
+    // calculateEffectiveConversionTax re-derives taxable SS internally from the
+    // separate socialSecurityBenefits arg. Passing baseOrdinaryIncome (which
+    // already includes taxable SS) double-counts SS. Mirror the direct conversion-
+    // tax call below, which passes nonSSOrdinaryIncome.
+    const adjustedNonSSBaseIncome = nonSSOrdinaryIncome + bracketSpaceForSpending;
+    const searchResult = coarseToFineSearch(
+        ceilingResult.conversionCeiling,
+        traditionalBalance - bracketSpaceForSpending,
+        adjustedNonSSBaseIncome,
+        socialSecurityBenefits,
+        0, // ltcgIncome
+        fedParams,
+        input.taxState,
+        input.year,
+        null, // federal-only: state tax should not reduce conversion amount
+        acaOptions,
+        input.assumptions
+    );
+
+    if (searchResult.amount > 0) {
+        conversionAmount = Math.min(conversionAmount, searchResult.amount);
+    }
+
+    // Log conversion sizing breakdown so the user can see what constrained the amount
+    {
+        const constraints: string[] = [];
+        const rawBracketSpace = ceilingResult.bracketSpacePerYear;
+        const effectiveBracket = bracketSpace; // after spending reservation
+
+        if (bracketSpaceForSpending > 0) {
+            constraints.push(`spending reservation $${Math.round(bracketSpaceForSpending).toLocaleString()}`);
+        }
+        if (availableTraditional < effectiveBracket) {
+            constraints.push(`Traditional balance $${Math.round(availableTraditional).toLocaleString()}`);
+        }
+        if (searchResult.amount > 0 && searchResult.amount < conversionAmount + 100) {
+            constraints.push(`SS torpedo search $${Math.round(searchResult.amount).toLocaleString()}${searchResult.edgeType === 'SS_TORPEDO' ? ' (torpedo)' : ''}`);
+        }
+
+        const limitedBy = constraints.length > 0
+            ? `Limited by: ${constraints.join('; ')}.`
+            : `Using full bracket space.`;
+
+        decisions.push({
+            category: 'conversion',
+            amount: conversionAmount,
+            description: `Conversion sizing: bracket space $${Math.round(rawBracketSpace).toLocaleString()} ` +
+                `(ceiling ${(ceilingResult.conversionCeiling * 100).toFixed(0)}%), ` +
+                `result $${Math.round(conversionAmount).toLocaleString()}. ${limitedBy}`,
+        });
+    }
+
+    // =========================================================================
+    // ACA CLIFF ENFORCEMENT: Account for LTCG in MAGI calculation
+    // =========================================================================
+    // The algebraic approach:
+    //   MAGI = conversion + LTCG
+    //   LTCG comes from brokerage withdrawals to cover deficit
+    //   deficit = expenses + ordinaryTax(conversion) - income
+    // We need to find max conversion where MAGI ≤ cliff
+    if (acaOptions && input.acaAware && input.currentAge < 65 && conversionAmount > 0) {
+        const acaCliff = acaOptions.acaCliffThreshold;
+        const gainRatio = getBrokerageGainRatio(input.accounts);
+
+        // Get the EXACT same values the solver uses
+        const incomeClass = classifyIncome(input.incomes, input.rmdAmount, 0, input.year);
+        const spendableIncome = incomeClass.classified.spendable;
+        const preTaxDeductions = TaxService.getPreTaxExemptions(input.incomes, input.year, input.currentAge, true);
+        const ficaTax = TaxService.calculateFicaTax(input.taxState, input.incomes, input.year, input.assumptions);
+
+        // Function to estimate MAGI for a given conversion - uses EXACT same logic as solver
+        const estimateMAGI = (conversion: number): number => {
+            // 1. Calculate ordinary income with conversion (same as solver line 690)
+            const allOrdinaryIncome = baseOrdinaryIncome + conversion;
+
+            // 2. Calculate federal tax using the SAME function as solver (lines 716-724).
+            // First arg = ordinary income EXCLUDING SS. nonSSOrdinaryIncome already
+            // strips SS; baseOrdinaryIncome - socialSecurityBenefits would mis-net it
+            // (baseOrdinaryIncome holds taxable SS, not full SS).
+            const ordinaryTaxResult = TaxService.calculateTotalFederalTax(
+                nonSSOrdinaryIncome + conversion, // non-SS ordinary income
+                socialSecurityBenefits,
+                0, // STCG
+                0, // LTCG - not known yet
+                preTaxDeductions,
+                input.taxState.filingStatus,
+                fedParams
+            );
+
+            // 3. Calculate state tax (same as solver lines 726-728)
+            const stateTax = stateParams
+                ? TaxService.calculateTax(allOrdinaryIncome, preTaxDeductions, stateParams)
+                : 0;
+
+            // 4. Total ordinary tax (same as solver line 732)
+            const ordinaryTax = ordinaryTaxResult.totalTax + stateTax;
+
+            // 5. Calculate base deficit using SAME formula as solver
+            // Note: ordinaryTax already includes conversion tax (via allOrdinaryIncome),
+            // so no separate adjustment needed for taxSource='BROKERAGE'.
+            const estimatedDeficit = Math.max(0,
+                input.totalLivingExpenses + ordinaryTax + ficaTax - spendableIncome - input.rmdAmount
+            );
+
+            // 6. Calculate LTCG using gross-up formula
+            // Determine LTCG rate based on income level (same logic as WithdrawalPlanner)
+            const ltcgRate = getLTCGRateForIncome(allOrdinaryIncome, fedParams);
+            const estimatedLTCG = estimateLTCGFromDeficit(estimatedDeficit, gainRatio, ltcgRate);
+
+            // ACA MAGI = all gross income including 100% of SS (not just taxable portion)
+            // spendable + reinvested already includes full SS, so no separate SS addition needed.
+            // Previous formula (baseOrdinaryIncome + socialSecurityBenefits) double-counted SS
+            // because baseOrdinaryIncome already contains taxableSS.
+            const grossIncomeBase = incomeClass.classified.spendable + incomeClass.classified.reinvested;
+            return grossIncomeBase + conversion + estimatedLTCG;
+        };
+
+        const originalConversion = conversionAmount;
+        const initialMAGI = estimateMAGI(conversionAmount);
+
+        if (initialMAGI > acaCliff) {
+            // Need to reduce conversion - use binary search
+            const ACA_BUFFER = 1000; // $1k buffer under cliff
+            const targetMAGI = acaCliff - ACA_BUFFER;
+
+            let lo = 0;
+            let hi = conversionAmount;
+            let bestConversion = 0;
+
+            // Binary search for max conversion where MAGI ≤ targetMAGI
+            for (let i = 0; i < 20 && hi - lo > 100; i++) {
+                const mid = (lo + hi) / 2;
+                const magi = estimateMAGI(mid);
+
+                if (magi <= targetMAGI) {
+                    bestConversion = mid;
+                    lo = mid;
+                } else {
+                    hi = mid;
+                }
+            }
+
+            // If buffer was too aggressive (MAGI at conv=0 is between target and cliff),
+            // retry with no buffer to squeeze in a small conversion
+            if (bestConversion === 0 && estimateMAGI(0) < acaCliff) {
+                lo = 0;
+                hi = conversionAmount;
+                for (let i = 0; i < 20 && hi - lo > 100; i++) {
+                    const mid = (lo + hi) / 2;
+                    if (estimateMAGI(mid) <= acaCliff) {
+                        bestConversion = mid;
+                        lo = mid;
+                    } else {
+                        hi = mid;
+                    }
+                }
+            }
+
+            conversionAmount = Math.max(0, Math.floor(bestConversion));
+
+            // Log the reduction
+            if (conversionAmount < originalConversion) {
+                const finalMAGI = estimateMAGI(conversionAmount);
+                const acaReduction = originalConversion - conversionAmount;
+                decisions.push({
+                    category: 'conversion',
+                    amount: acaReduction,
+                    description: `Conversion reduced from $${originalConversion.toLocaleString()} to $${conversionAmount.toLocaleString()}: MAGI ($${Math.round(finalMAGI).toLocaleString()}) would exceed ACA cliff ($${acaCliff.toLocaleString()}) with estimated LTCG.`,
+                });
+                // Update constraint details with ACA info
+                constraintDetails.acaCliffTriggered = true;
+                constraintDetails.acaCliffReduction = acaReduction;
+                constraintDetails.currentMAGI = finalMAGI;
+                constraintDetails.acaCliffThreshold = acaCliff;
+                constraintDetails.brokerageGainRatio = gainRatio;
+                taxOptimizationTarget.limitingFactor = 'ACA_CLIFF';
+            }
+        }
+    }
+
+    // Update constraint details if SS torpedo was detected
+    if (searchResult.edgeType === 'SS_TORPEDO') {
+        constraintDetails.ssTorpedoTriggered = true;
+        // Calculate how much was lost to SS torpedo
+        const torpedoReduction = Math.max(0, bracketSpace - searchResult.amount);
+        constraintDetails.ssTorpedoReduction = torpedoReduction;
+        constraintDetails.effectiveBracketSpace = searchResult.amount;
+        if (!taxOptimizationTarget.limitingFactor) {
+            taxOptimizationTarget.limitingFactor = 'SS_TORPEDO';
+        }
+    }
+
+    if (conversionAmount <= 0) {
+        // Log why conversion was skipped — but don't overwrite limitingFactor if already set (e.g., by ACA cliff)
+        if (!taxOptimizationTarget.limitingFactor) {
+            decisions.push({
+                category: 'conversion',
+                description: `Skipped Roth conversion: no bracket space available.`,
+            });
+            taxOptimizationTarget.limitingFactor = 'NO_BRACKET_SPACE';
+        }
+        taxOptimizationTarget.actualConversion = 0;
+        return {
+            conversion: null,
+            conversionTax: 0,
+            taxSource: 'SURPLUS',
+            additionalOrdinaryIncome: 0,
+            decisions,
+            bracketSpaceForSpending,
+            taxOptimizationTarget,
+        };
+    }
+
+    // Estimate LTCG that the year will realize. Brokerage gets sold for two
+    // reasons: covering this year's spending deficit, and covering the
+    // conversion tax (when taxSource is BROKERAGE). The LTCG bumps the
+    // conversion's tax cost (LTCG rate goes from 0% → 15% / 15% → 20% as
+    // ordinary income rises), so we want it reflected in the displayed
+    // conversionTax. Same formula the ACA-cliff binary-search uses above.
+    const ltcgGainRatio = getBrokerageGainRatio(input.accounts);
+    const ltcgRateAtIncome = getLTCGRateForIncome(baseOrdinaryIncome + conversionAmount, fedParams);
+    const estimatedLTCGForYear = estimateLTCGFromDeficit(
+        Math.max(0, spendingDeficit),
+        ltcgGainRatio,
+        ltcgRateAtIncome,
+    );
+
+    // Calculate conversion tax.
+    // First arg must be ordinary income EXCLUDING SS — the function re-derives
+    // taxable SS internally from the separate socialSecurityBenefits arg. Passing
+    // baseOrdinaryIncome (which already includes taxable SS) double-counts SS.
+    const conversionTaxResult = calculateEffectiveConversionTax(
+        nonSSOrdinaryIncome,
+        socialSecurityBenefits,
+        estimatedLTCGForYear,
+        conversionAmount,
+        input.taxState.filingStatus,
+        fedParams,
+        stateParams,
+        acaOptions
+    );
+
+    const conversionTax = conversionTaxResult.taxIncrease;
+    const conversionFedTax = conversionTaxResult.breakdown.federalOrdinaryTaxCost
+                           + conversionTaxResult.breakdown.ssTorpedoCost
+                           + conversionTaxResult.breakdown.ltcgBumpCost
+                           + conversionTaxResult.breakdown.niitCost;
+    const conversionStateTax = conversionTaxResult.breakdown.stateTaxCost;
+
+    // Determine tax payment source
+    let taxSource: ConversionTaxSource = 'SURPLUS';
+    let netToRoth = conversionAmount;
+
+    const brokerageBalance = getTotalBrokerageBalance(input.accounts);
+
+    if (surplus >= conversionTax) {
+        taxSource = 'SURPLUS';
+    } else if (brokerageBalance >= conversionTax) {
+        taxSource = 'BROKERAGE';
+    } else {
+        // No surplus or brokerage to pay tax — tax is covered by the
+        // spending deficit (which already includes conversion tax via
+        // finalFedResult.totalTax). Full conversion amount reaches Roth.
+        taxSource = 'WITHHOLD';
+    }
+
+    // Find source and target accounts
+    const sourceAccount = getFirstTraditionalAccount(input.accounts);
+    const targetAccount = getFirstRothAccount(input.accounts);
+
+    if (!sourceAccount || !targetAccount) {
+        decisions.push({
+            category: 'conversion',
+            description: 'Skipped Roth conversion: no valid source or target account.',
+        });
+        return {
+            conversion: null,
+            conversionTax: 0,
+            taxSource: 'SURPLUS',
+            additionalOrdinaryIncome: 0,
+            decisions,
+            bracketSpaceForSpending,
+            taxOptimizationTarget,
+        };
+    }
+
+    const conversion: PlannedConversion = {
+        amount: conversionAmount,
+        fromAccountId: sourceAccount.id,
+        toAccountId: targetAccount.id,
+        taxSource,
+        taxAmount: conversionTax,
+        federalTaxCost: conversionFedTax,
+        stateTaxCost: conversionStateTax,
+        netToRoth,
+        reason: `Roth conversion to fill ${(ceilingResult.conversionCeiling * 100).toFixed(0)}% bracket. Tax paid from ${taxSource.toLowerCase()}.`,
+    };
+
+    decisions.push({
+        category: 'conversion',
+        account: sourceAccount.name,
+        amount: conversionAmount,
+        description: `Converted $${conversionAmount.toLocaleString()} from ${sourceAccount.name} to Roth. Tax: $${conversionTax.toLocaleString()} (${taxSource.toLowerCase()}).`,
+    });
+
+    // Update actual conversion amount and determine limiting factor if not already set
+    taxOptimizationTarget.actualConversion = conversionAmount;
+
+    // Determine limiting factor if not already set. Without PMT, the conversion is
+    // either capped by bracket space (most common) or by available Traditional balance.
+    if (!taxOptimizationTarget.limitingFactor) {
+        if (conversionAmount >= availableTraditional - 1) {
+            taxOptimizationTarget.limitingFactor = 'TRADITIONAL_DEPLETED';
+        } else {
+            taxOptimizationTarget.limitingFactor = 'BRACKET_CEILING';
+        }
+    }
+
+    return {
+        conversion,
+        conversionTax,
+        taxSource,
+        additionalOrdinaryIncome: conversionAmount,
+        decisions,
+        bracketSpaceForSpending,
+        taxOptimizationTarget,
+    };
+}
+
+/**
+ * DP-precomputed conversion strategy. Reads `input.dpConversionPlan?.get(year)`
+ * (set upstream by `runSimulationWithOptimization`), clamps to available trad
+ * balance, then runs the same downstream tax-payment / account-selection logic
+ * as the rate-match path.
+ *
+ * Skip cases: not retired, optimization off, no DP plan, no traditional
+ * balance, no source/target account. Falls through with the no-conversion
+ * shape — same as rate-match's skip cases.
+ */
+function planConversionDP(
+    input: YearSolverInput,
+    baseOrdinaryIncome: number, // non-SS ordinary income + taxable SS (federal bracket-positioning base)
+    socialSecurityBenefits: number,
+    nonSSOrdinaryIncome: number, // ordinary income EXCLUDING SS entirely (taxableBase - fullSS)
+    fedParams: TaxParameters,
+    stateParams: TaxParameters | null,
+    surplus: number,
+    spendingDeficit: number,
+): ConversionPlan {
+    const decisions: DecisionLogEntry[] = [];
+    const traditionalBalance = getTotalTraditionalBalance(input.accounts);
+    let bracketSpaceForSpending = 0;
+
+    // Surface DP solver's per-year debug into the year inspector.
+    const dpDebugLines = input.dpDebugByYear?.get(input.year) ?? [];
+    for (const line of dpDebugLines) {
+        decisions.push({ category: 'conversion', description: line });
+    }
+
+    const skipReturn = (limitingFactor: ConversionLimitingFactor, description?: string): ConversionPlan => {
+        if (description) {
+            decisions.push({ category: 'conversion', description });
+        }
+        return {
+            conversion: null,
+            conversionTax: 0,
+            taxSource: 'SURPLUS',
+            additionalOrdinaryIncome: 0,
+            decisions,
+            bracketSpaceForSpending,
+            taxOptimizationTarget: {
+                yearsUntilRMD: Math.max(0, getRMDStartAge(input.year - input.currentAge) - input.currentAge),
+                rmdStartAge: getRMDStartAge(input.year - input.currentAge),
+                targetBracketCeiling: 0,
+                bracketSpaceThisYear: 0,
+                ssAtRMD: 0,
+                pensionAtRMD: 0,
+                currentTraditionalBalance: traditionalBalance,
+                limitingFactor,
+                actualConversion: 0,
+            },
+        };
+    };
+
+    if (!input.taxOptimizationEnabled || !input.isRetired) {
+        return skipReturn('NOT_RETIRED');
+    }
+    if (traditionalBalance <= 0) {
+        return skipReturn('TRADITIONAL_DEPLETED', 'Skipped Roth conversion: no Traditional balance available.');
+    }
+
+    // Spending-deficit reservation. Mirrors planConversion: when there's a
+    // Roth-bound spending deficit (brokerage can't cover it) and we're not
+    // penalized (age >= 59.5), reserve trad bracket space for direct
+    // Traditional withdrawal — avoids the wasteful "convert → withdraw Roth
+    // for spending" round-trip. Downstream in solveRetirementYear, a non-zero
+    // bracketSpaceForSpending puts trad first (capped at the reservation).
+    //
+    // Gate uses the same conversion ceiling as rate-match (computed via
+    // computeCeilingContext). When ceiling=0% (future RMDs land in 12% or
+    // lower, no incentive to convert into a taxable bracket), reservation
+    // only fires if first-dollar marginal is also 0% — preventing the
+    // bracket-crossing $219k withdrawals at 22% marginal that the older
+    // hardcoded-24% gate produced.
+    const penaltyApplies = input.currentAge < 59.5;
+    if (spendingDeficit > 0 && !penaltyApplies) {
+        const { ceilingResult } = computeCeilingContext(
+            input, baseOrdinaryIncome, socialSecurityBenefits, fedParams, stateParams,
+        );
+        const conversionCeiling = ceilingResult.conversionCeiling;
+        const bracketSpacePerYear = Math.max(0, ceilingResult.bracketSpacePerYear);
+
+        const brokerageBalance = getTotalBrokerageBalance(input.accounts);
+        const brokerageGainRatio = getBrokerageGainRatio(input.accounts);
+        const ltcgRate = getLTCGRateForIncome(baseOrdinaryIncome, fedParams);
+        const brokerageCoverage = brokerageBalance * (1 - brokerageGainRatio * ltcgRate);
+        const rothBoundDeficit = Math.max(0, spendingDeficit - brokerageCoverage);
+
+        if (rothBoundDeficit > 0 && bracketSpacePerYear > 0) {
+            const marginalResult = TaxService.getMarginalTaxRate(
+                Math.max(0, baseOrdinaryIncome - fedParams.standardDeduction),
+                fedParams,
+            );
+            const stateRate = stateParams
+                ? TaxService.getMarginalTaxRate(
+                    Math.max(0, baseOrdinaryIncome - stateParams.standardDeduction),
+                    stateParams,
+                  ).rate
+                : 0;
+
+            const gateOk = marginalResult.rate <= conversionCeiling + 0.005;
+            if (gateOk) {
+                const totalEffectiveRate = marginalResult.rate + stateRate;
+                const grossForDeficit = rothBoundDeficit / Math.max(0.5, 1 - totalEffectiveRate);
+                bracketSpaceForSpending = Math.min(grossForDeficit, bracketSpacePerYear, traditionalBalance);
+
+                decisions.push({
+                    category: 'conversion',
+                    amount: bracketSpaceForSpending,
+                    description: `Reserved $${Math.round(bracketSpaceForSpending).toLocaleString()} bracket space ` +
+                        `for Traditional spending (Roth-bound deficit $${Math.round(rothBoundDeficit).toLocaleString()} ` +
+                        `of $${Math.round(spendingDeficit).toLocaleString()} total, ` +
+                        `brokerage covers $${Math.round(brokerageCoverage).toLocaleString()}, ` +
+                        `marginal rate ${(marginalResult.rate * 100).toFixed(1)}% ` +
+                        `vs ${(conversionCeiling * 100).toFixed(0)}% ceiling).`,
+                });
+            } else {
+                decisions.push({
+                    category: 'conversion',
+                    description: `[DEBUG DP exec] year=${input.year}: spending reservation skipped — ` +
+                        `marginal ${(marginalResult.rate * 100).toFixed(1)}% > ceiling ${(conversionCeiling * 100).toFixed(0)}%; ` +
+                        `Roth-bound deficit $${Math.round(rothBoundDeficit).toLocaleString()} stays Roth-funded.`,
+                });
+            }
+        }
+    }
+
+    // Look up the precomputed conversion amount. Clamp to (traditional - reserved
+    // for spending) so the conversion doesn't compete with the spending withdrawal.
+    const availableTradForConversion = Math.max(0, traditionalBalance - bracketSpaceForSpending);
+    const targetConversion = input.dpConversionPlan?.get(input.year) ?? 0;
+    const conversionAmount = Math.max(0, Math.min(targetConversion, availableTradForConversion));
+
+    // Log real-sim balances side-by-side with DP's projection so we can spot
+    // when DP's forward-sweep state diverges from reality.
+    const realRothBalance = input.accounts
+        .filter(a => a instanceof InvestedAccount && a.taxType === 'Roth IRA')
+        .reduce((sum, a) => sum + (a as InvestedAccount).vestedAmount, 0);
+    const realBrokerageBalance = getTotalBrokerageBalance(input.accounts);
+    decisions.push({
+        category: 'conversion',
+        description:
+            `[DEBUG DP exec] year=${input.year}: plan-lookup=${'$' + Math.round(targetConversion).toLocaleString()}, ` +
+            `traditional=${'$' + Math.round(traditionalBalance).toLocaleString()}, ` +
+            `bracketSpaceForSpending=${'$' + Math.round(bracketSpaceForSpending).toLocaleString()}, ` +
+            `availableTrad=${'$' + Math.round(availableTradForConversion).toLocaleString()}, ` +
+            `clampedAmount=${'$' + Math.round(conversionAmount).toLocaleString()}, ` +
+            `dpPlanProvided=${input.dpConversionPlan ? 'yes' : 'no'}`,
+    });
+    decisions.push({
+        category: 'conversion',
+        description:
+            `[DEBUG DP reality] year=${input.year}: ` +
+            `realTrad=${'$' + Math.round(traditionalBalance).toLocaleString()}, ` +
+            `realRoth=${'$' + Math.round(realRothBalance).toLocaleString()}, ` +
+            `realBrokerage=${'$' + Math.round(realBrokerageBalance).toLocaleString()} ` +
+            `— compare against [DEBUG DP solver] tradEntering and [DEBUG DP baseline] for divergence.`,
+    });
+
+    if (conversionAmount <= 0) {
+        // Spending reservation may still be nonzero — preserve it via skipReturn.
+        return skipReturn(
+            bracketSpaceForSpending > 0 ? 'SPENDING_DEFICIT' : 'NO_BRACKET_SPACE',
+            `DP-precomputed conversion for year ${input.year}: $0 (no plan or zero amount).`,
+        );
+    }
+
+    const sourceAccount = getFirstTraditionalAccount(input.accounts);
+    const targetAccount = getFirstRothAccount(input.accounts);
+    if (!sourceAccount || !targetAccount) {
+        return skipReturn('TRADITIONAL_DEPLETED', 'Skipped DP conversion: no valid source or target account.');
+    }
+
+    // ACA options for the tax cost calc (same logic as rate-match path).
+    let acaOptions: ACAOptions | undefined;
+    if (input.acaAware && input.currentAge < 65) {
+        // Use the shared 400% FPL cliff (by year + filing status) rather than hardcoded
+        // values, matching RothConversionDP. The old constants ($125k MFJ / $62.5k single)
+        // diverged from the real thresholds (~$81.8k / $60.2k for 2024).
+        const acaFiling: 'single' | 'married_filing_jointly' =
+            input.taxState.filingStatus === 'Married Filing Jointly' ? 'married_filing_jointly' : 'single';
+        acaOptions = {
+            currentAge: input.currentAge,
+            acaSubsidyAware: true,
+            acaCliffThreshold: getAcaCliffThreshold(acaFiling, input.year),
+            estimatedSubsidyLoss: 12000,
+        };
+    }
+
+    // Estimate this year's LTCG (mirrors the rate-match path) so the
+    // conversion's displayed Tax Cost reflects the LTCG bump.
+    const ltcgGainRatio = getBrokerageGainRatio(input.accounts);
+    const ltcgRateAtIncome = getLTCGRateForIncome(baseOrdinaryIncome + conversionAmount, fedParams);
+    const estimatedLTCGForYear = estimateLTCGFromDeficit(
+        Math.max(0, spendingDeficit),
+        ltcgGainRatio,
+        ltcgRateAtIncome,
+    );
+
+    // First arg must be ordinary income EXCLUDING SS — the function re-derives
+    // taxable SS internally from the separate socialSecurityBenefits arg. Passing
+    // baseOrdinaryIncome (which already includes taxable SS) double-counts SS.
+    const conversionTaxResult = calculateEffectiveConversionTax(
+        nonSSOrdinaryIncome,
+        socialSecurityBenefits,
+        estimatedLTCGForYear,
+        conversionAmount,
+        input.taxState.filingStatus,
+        fedParams,
+        stateParams,
+        acaOptions,
+    );
+    const conversionTax = conversionTaxResult.taxIncrease;
+    const conversionFedTax = conversionTaxResult.breakdown.federalOrdinaryTaxCost
+        + conversionTaxResult.breakdown.ssTorpedoCost
+        + conversionTaxResult.breakdown.ltcgBumpCost
+        + conversionTaxResult.breakdown.niitCost;
+    const conversionStateTax = conversionTaxResult.breakdown.stateTaxCost;
+
+    // Tax payment source selection (same priority as rate-match).
+    const brokerageBalance = getTotalBrokerageBalance(input.accounts);
+    let taxSource: ConversionTaxSource;
+    if (surplus >= conversionTax) {
+        taxSource = 'SURPLUS';
+    } else if (brokerageBalance >= conversionTax) {
+        taxSource = 'BROKERAGE';
+    } else {
+        taxSource = 'WITHHOLD';
+    }
+
+    const conversion: PlannedConversion = {
+        amount: conversionAmount,
+        fromAccountId: sourceAccount.id,
+        toAccountId: targetAccount.id,
+        taxSource,
+        taxAmount: conversionTax,
+        federalTaxCost: conversionFedTax,
+        stateTaxCost: conversionStateTax,
+        netToRoth: conversionAmount,
+        reason: `DP-precomputed conversion of $${Math.round(conversionAmount).toLocaleString()}. Tax paid from ${taxSource.toLowerCase()}.`,
+    };
+
+    decisions.push({
+        category: 'conversion',
+        account: sourceAccount.name,
+        amount: conversionAmount,
+        description: `DP-planned: $${Math.round(conversionAmount).toLocaleString()} from ${sourceAccount.name} to Roth. Tax: $${Math.round(conversionTax).toLocaleString()} (${taxSource.toLowerCase()}).`,
+    });
+
+    const rmdStartAge = getRMDStartAge(input.year - input.currentAge);
+    return {
+        conversion,
+        conversionTax,
+        taxSource,
+        additionalOrdinaryIncome: conversionAmount,
+        decisions,
+        bracketSpaceForSpending,
+        taxOptimizationTarget: {
+            yearsUntilRMD: Math.max(0, rmdStartAge - input.currentAge),
+            rmdStartAge,
+            targetBracketCeiling: 0,
+            bracketSpaceThisYear: conversionAmount,
+            ssAtRMD: 0,
+            pensionAtRMD: 0,
+            currentTraditionalBalance: traditionalBalance,
+            limitingFactor: conversionAmount >= availableTradForConversion - 1
+                ? 'TRADITIONAL_DEPLETED'
+                : 'BRACKET_CEILING',
+            actualConversion: conversionAmount,
+        },
+    };
+}
+
+// =============================================================================
+// MAIN SOLVER
+// =============================================================================
+
+/**
+ * Solve a retirement year.
+ *
+ * Flow:
+ * 1. Classify income (spendable vs reinvested)
+ * 2. Plan Roth conversion FIRST
+ * 3. Calculate ordinary tax (with conversion)
+ * 4. Calculate base deficit
+ * 5. Plan withdrawals with algebraic gross-up
+ * 6. Loop if bracket crossing (rare)
+ * 7. Calculate surplus/deficit
+ */
+export function solveRetirementYear(input: YearSolverInput): YearPlan {
+    const decisions: DecisionLogEntry[] = [];
+
+    // Get tax parameters
+    const fedParams = TaxService.getTaxParameters(
+        input.year,
+        input.taxState.filingStatus,
+        'federal',
+        undefined,
+        input.assumptions
+    );
+    const stateParams = TaxService.getTaxParameters(
+        input.year,
+        input.taxState.filingStatus,
+        'state',
+        input.taxState.stateResidency,
+        input.assumptions
+    );
+
+    if (!fedParams) {
+        throw new Error(`No federal tax parameters for year ${input.year}`);
+    }
+
+    // Step A: Classify income (before conversion)
+    const incomeClassification = classifyIncome(
+        input.incomes,
+        input.rmdAmount,
+        0, // No conversion yet
+        input.year
+    );
+
+    // Get SS benefits for taxability calculation
+    const socialSecurityBenefits = getTotalSSBenefits(input.incomes, input.year);
+
+    // ==========================================================================
+    // GK GUARDRAILS: Determine effective spending target
+    // ==========================================================================
+    // When GK budget is provided, enforce spending caps:
+    // - If fixed expenses > GK budget: use fixed expenses (can't cut fixed costs)
+    // - If fixed expenses <= GK budget: use min(totalLivingExpenses, gkBudget)
+    // - Log appropriate warnings and decisions
+    let effectiveLivingExpenses = input.totalLivingExpenses;
+
+    if (input.gkBudget !== undefined) {
+        const gkBudget = input.gkBudget;
+        const fixedExpenses = input.fixedExpenses ?? input.totalLivingExpenses;
+        const discretionaryExpenses = input.discretionaryExpenses ?? 0;
+
+        if (fixedExpenses > gkBudget) {
+            // Fixed expenses exceed GK budget - eliminate discretionary but cover fixed
+            effectiveLivingExpenses = fixedExpenses;
+
+            // Log warning about fixed expenses exceeding guardrails budget
+            decisions.push({
+                category: 'warning',
+                amount: fixedExpenses - gkBudget,
+                description: `Fixed expenses ($${fixedExpenses.toLocaleString()}) exceed guardrails budget ($${gkBudget.toLocaleString()}). Discretionary spending eliminated.`,
+            });
+
+            // Log decision about discretionary elimination
+            if (discretionaryExpenses > 0) {
+                decisions.push({
+                    category: 'spending',
+                    amount: discretionaryExpenses,
+                    description: `Discretionary expenses ($${discretionaryExpenses.toLocaleString()}) eliminated due to GK guardrails cap.`,
+                });
+            }
+        } else {
+            // GK budget can accommodate fixed expenses
+            // Use the lesser of total requested expenses and GK budget
+            effectiveLivingExpenses = Math.min(input.totalLivingExpenses, gkBudget);
+
+            if (input.totalLivingExpenses > gkBudget) {
+                // Need to trim discretionary
+                const trimAmount = input.totalLivingExpenses - gkBudget;
+                decisions.push({
+                    category: 'spending',
+                    amount: trimAmount,
+                    description: `Discretionary expenses trimmed by $${trimAmount.toLocaleString()} to stay within GK budget of $${gkBudget.toLocaleString()}.`,
+                });
+            }
+        }
+    }
+
+    // Calculate initial ordinary income (without conversion)
+    // Include reinvested income - it's taxable even though it's not spendable
+    const taxableBase = incomeClassification.classified.spendable + incomeClassification.classified.reinvested;
+    const baseOrdinaryIncome =
+        taxableBase -
+        socialSecurityBenefits + // Remove SS, add back taxable portion
+        TaxService.getTaxableSocialSecurityBenefits(
+            socialSecurityBenefits,
+            taxableBase - socialSecurityBenefits,
+            0, // taxExemptInterest
+            input.taxState.filingStatus
+        );
+
+    // Initial surplus estimate (for determining if conversion tax can be paid from surplus).
+    // Note: classifyIncome adds rmdAmount to spendable, so we don't add it again here.
+    const initialSurplusEstimate = Math.max(0,
+        incomeClassification.classified.spendable -
+        effectiveLivingExpenses
+    );
+
+    // Rough tax estimate for preliminary deficit (before conversion is known)
+    const roughPreTaxDeductions = TaxService.getPreTaxExemptions(input.incomes, input.year, input.currentAge, true);
+    const roughFedTax = TaxService.calculateTotalFederalTax(
+        taxableBase - socialSecurityBenefits, // non-SS ordinary income (baseOrdinaryIncome holds taxable SS)
+        socialSecurityBenefits,
+        0, 0, // no STCG/LTCG
+        roughPreTaxDeductions,
+        input.taxState.filingStatus,
+        fedParams
+    ).totalTax;
+    const roughStateTax = stateParams
+        ? TaxService.calculateTax(baseOrdinaryIncome, roughPreTaxDeductions, stateParams)
+        : 0;
+    const roughFica = TaxService.calculateFicaTax(input.taxState, input.incomes, input.year, input.assumptions);
+    const roughTax = roughFedTax + roughStateTax + roughFica;
+
+    // Note: classifyIncome adds rmdAmount to spendable, so we don't subtract it again.
+    const preliminaryDeficit = Math.max(0,
+        effectiveLivingExpenses + roughTax -
+        incomeClassification.classified.spendable
+    );
+
+    // Step B: Plan Roth conversion FIRST
+    const conversionStrategy = selectConversionStrategy(
+        input.assumptions.investments.rothConversionStrategy,
+    );
+    const conversionPlan = conversionStrategy(
+        input,
+        baseOrdinaryIncome,
+        socialSecurityBenefits,
+        // True non-SS ordinary income (excludes SS entirely). baseOrdinaryIncome
+        // already folds in taxable SS, so it must NOT be reused where the federal
+        // tax contract expects SS-free ordinary income (calculateTotalFederalTax /
+        // calculateEffectiveConversionTax re-derive taxable SS internally).
+        taxableBase - socialSecurityBenefits,
+        fedParams,
+        stateParams ?? null, // Convert undefined to null
+        initialSurplusEstimate,
+        preliminaryDeficit
+    );
+    decisions.push(...conversionPlan.decisions);
+
+    // Update income classification with conversion
+    const finalIncomeClassification = classifyIncome(
+        input.incomes,
+        input.rmdAmount,
+        conversionPlan.additionalOrdinaryIncome,
+        input.year
+    );
+
+    // Step C: Calculate ordinary tax (with conversion)
+    //
+    // Income views for tax computation:
+    //   nonSSBaseIncome: all income EXCLUDING Social Security (stable base for iteration)
+    //   allOrdinaryIncome: nonSS + conversion (used for state tax and planner — excludes SS)
+    //   currentSSTaxable: taxable portion of SS, computed externally with Trad withdrawal
+    //                     in combined income. Added to allOrdinaryIncome for federal tax only.
+    //
+    // Why separate? DC (and most states) exempts SS from state tax. The planner also needs
+    // the state starting position without SS. Federal tax needs SS taxable in the income base.
+    const nonSSBaseIncome = taxableBase - socialSecurityBenefits;
+    const conversionAdded = conversionPlan.additionalOrdinaryIncome;
+
+    // Initial SS taxable estimate (no Traditional withdrawal yet)
+    let currentSSTaxable = TaxService.getTaxableSocialSecurityBenefits(
+        socialSecurityBenefits,
+        nonSSBaseIncome + conversionAdded,
+        0,
+        input.taxState.filingStatus
+    );
+
+    // allOrdinaryIncome: includes taxable SS. Used for federal tax and planner's federal bracket
+    // positioning. For state tax (and planner's state brackets), currentSSTaxable is excluded
+    // since DC and most states exempt SS from income tax.
+    let allOrdinaryIncome = nonSSBaseIncome + currentSSTaxable + conversionAdded;
+
+    // Calculate FICA (only on wages)
+    const ficaTax = TaxService.calculateFicaTax(
+        input.taxState,
+        input.incomes,
+        input.year,
+        input.assumptions
+    );
+
+    // We'll calculate final tax after knowing withdrawals (for LTCG)
+
+    // Step D: Calculate base deficit
+    // Start with conservative estimate (no LTCG tax yet)
+    const preTaxDeductions = TaxService.getPreTaxExemptions(input.incomes, input.year, input.currentAge, true);
+
+    // Step D+E: Iterative LTCG-aware deficit and withdrawal planning
+    //
+    // We use calculateTotalFederalTax() with bracket-stacked LTCG as the authoritative
+    // tax source. The planner's flat-rate gross-up is kept as-is for withdrawal sizing.
+    // We iterate because:
+    //   - Total tax (including LTCG) affects the deficit
+    //   - LTCG depends on withdrawal amount (which depends on deficit)
+    //   - Converges in 2-3 iterations since LTCG tax is a fraction of total withdrawal
+
+    let withdrawals: PlannedWithdrawal[] = [];
+    let withdrawalOrdinaryTax = 0;
+    let withdrawalDecisions: DecisionLogEntry[] = [];
+    let totalPenalties = 0;
+    let iterations = 0;
+    let converged = false;
+
+    if (input.rmdAmount > 0) {
+        // Find Traditional accounts for RMD source
+        const tradAccount = getFirstTraditionalAccount(input.accounts);
+        if (tradAccount) {
+            withdrawals.push({
+                source: tradAccount.taxType === 'Traditional 401k' ? 'traditional_401k' : 'traditional_ira',
+                accountId: tradAccount.id,
+                accountName: tradAccount.name,
+                gross: input.rmdAmount,
+                net: input.rmdAmount, // RMD tax is on the income side, not withheld
+                penalty: 0,
+                tax: 0,
+                reason: 'Required Minimum Distribution',
+            });
+
+            decisions.push({
+                category: 'rmd',
+                account: tradAccount.name,
+                amount: input.rmdAmount,
+                description: `RMD of $${input.rmdAmount.toLocaleString()} from ${tradAccount.name}.`,
+            });
+        }
+    }
+
+    // Create account snapshots in withdrawal order (before the loop - these don't change)
+    let accountSnapshots = createOrderedSnapshots(
+        input.accounts, input.withdrawalOrder, input.currentAge, input.year
+    );
+
+    // Reserve the RMD against the Traditional account it draws from. The RMD already
+    // claims `input.rmdAmount` from that account (recorded as a negative userInflow,
+    // applied later by growAccounts), but createOrderedSnapshots reads the raw balance,
+    // so without this the discretionary planner could plan to withdraw dollars the RMD
+    // already took — over-draining the account and surfacing phantom spendable cash.
+    if (input.rmdAmount > 0) {
+        const rmdAccount = getFirstTraditionalAccount(input.accounts);
+        if (rmdAccount) {
+            accountSnapshots = accountSnapshots.map(s =>
+                s.accountId === rmdAccount.id
+                    ? { ...s, vestedBalance: Math.max(0, s.vestedBalance - input.rmdAmount) }
+                    : s
+            );
+        }
+    }
+
+    if (conversionPlan.bracketSpaceForSpending > 0) {
+        // Tax-optimized order: put capped Traditional first, then normal order
+        const allSnapshots = accountSnapshots;
+        const tradSnapshots: typeof allSnapshots = [];
+        const otherSnapshots: typeof allSnapshots = [];
+        let remainingCap = conversionPlan.bracketSpaceForSpending;
+
+        for (const s of allSnapshots) {
+            if ((s.accountType === 'traditional_401k' || s.accountType === 'traditional_ira')
+                && remainingCap > 0) {
+                const capped = Math.min(s.vestedBalance, remainingCap);
+                tradSnapshots.push({ ...s, vestedBalance: capped });
+                remainingCap -= capped;
+                const remainder = s.vestedBalance - capped;
+                if (remainder > 0) {
+                    otherSnapshots.push({ ...s, vestedBalance: remainder });
+                }
+            } else {
+                otherSnapshots.push(s);
+            }
+        }
+
+        accountSnapshots = [...tradSnapshots, ...otherSnapshots];
+
+        decisions.push({
+            category: 'withdrawal',
+            description: `Tax-optimized order: Traditional first ` +
+                `(cap $${Math.round(conversionPlan.bracketSpaceForSpending).toLocaleString()}) ` +
+                `then normal order.`,
+        });
+    }
+
+    // ACA withdrawal options (computed once, used in each iteration)
+    const acaWithdrawalOpts = input.acaAware && input.currentAge < 65
+        ? {
+            acaCliffThreshold: getAcaCliffThreshold(
+                input.taxState.filingStatus === 'Married Filing Jointly' ? 'married_filing_jointly' : 'single',
+                input.year
+            ),
+            // ACA MAGI = all gross income including 100% of SS benefits.
+            // taxableBase (= spendable + reinvested) already includes full SS,
+            // so we just add conversion income on top.
+            currentMAGI: taxableBase + conversionPlan.additionalOrdinaryIncome,
+        }
+        : undefined;
+
+    // Iterative deficit loop: converges on LTCG and SS taxability.
+    //
+    // Two circular dependencies resolved by iteration:
+    //   1. LTCG depends on withdrawal → withdrawal depends on deficit → deficit depends on LTCG tax
+    //   2. SS taxable depends on combined income (includes Traditional withdrawal) →
+    //      fed tax depends on SS taxable → deficit depends on fed → withdrawal depends on deficit
+    //
+    // Architecture: calculateTotalFederalTax() computes SS taxable internally from provisional
+    // income. But its ordinaryTax covers ALL income passed in (including Traditional withdrawal),
+    // while withdrawalOrdinaryTax from the planner separately covers the withdrawal tax.
+    // To avoid double-counting, we compute SS taxable EXTERNALLY (with Traditional withdrawal
+    // in combined income) and pass SS=0 to calculateTotalFederalTax(), with the pre-computed
+    // taxable SS baked into allOrdinaryIncome. This way the function computes tax only on
+    // base income + taxable SS, and the planner handles withdrawal tax separately.
+    //
+    // Convergence: SS taxable is piecewise-linear and monotonic, so 2-4 iterations.
+    let estimatedLTCG = 0;
+    let estimatedTradWithdrawal = 0;
+
+    // Initial federal tax: SS taxable computed without Traditional withdrawal
+    // Pass allOrdinaryIncome (which includes taxable SS) with SS=0 to skip internal SS calc
+    let finalFedResult = TaxService.calculateTotalFederalTax(
+        allOrdinaryIncome, // nonSS + taxableSS + conversion (SS pre-computed externally)
+        0, // SS=0: taxable SS already in allOrdinaryIncome
+        0, // STCG
+        0, // LTCG - not known yet
+        preTaxDeductions,
+        input.taxState.filingStatus,
+        fedParams
+    );
+    // State tax: exclude SS taxable (DC and most states exempt SS from income tax)
+    // State tax on the Traditional withdrawal is in withdrawalOrdinaryTax from the planner.
+    let finalStateTax = stateParams
+        ? TaxService.calculateTax(allOrdinaryIncome - currentSSTaxable, preTaxDeductions, stateParams)
+        : 0;
+
+    const MAX_ITERATIONS = 10;
+    for (let iter = 0; iter < MAX_ITERATIONS; iter++) {
+        if (iter > 0) {
+            // Recompute SS taxable with Traditional withdrawal in combined income.
+            // IRS combined income = AGI excluding SS + 50% × SS.
+            // AGI excluding SS includes: base income + conversion + Trad withdrawal + LTCG.
+            const updatedSSTaxable = TaxService.getTaxableSocialSecurityBenefits(
+                socialSecurityBenefits,
+                nonSSBaseIncome + conversionAdded + estimatedTradWithdrawal + estimatedLTCG,
+                0,
+                input.taxState.filingStatus
+            );
+
+            // Update SS taxable and allOrdinaryIncome
+            currentSSTaxable = updatedSSTaxable;
+            allOrdinaryIncome = nonSSBaseIncome + currentSSTaxable + conversionAdded;
+
+            // Federal tax: allOrdinaryIncome includes taxable SS, pass SS=0
+            finalFedResult = TaxService.calculateTotalFederalTax(
+                allOrdinaryIncome,
+                0, // SS=0: taxable SS already in allOrdinaryIncome
+                0, // STCG
+                estimatedLTCG,
+                preTaxDeductions,
+                input.taxState.filingStatus,
+                fedParams
+            );
+
+            // State tax: exclude SS taxable (DC and most states exempt SS)
+            // Include LTCG in base (DC and most states tax gains as ordinary income)
+            finalStateTax = stateParams
+                ? TaxService.calculateTax(allOrdinaryIncome - currentSSTaxable + estimatedLTCG, preTaxDeductions, stateParams)
+                : 0;
+        }
+
+        // Deficit includes authoritative LTCG tax (via finalFedResult.totalTax).
+        // Note: classifyIncome adds rmdAmount to spendable, so we don't subtract it again.
+        const deficit =
+            effectiveLivingExpenses +
+            finalFedResult.totalTax +
+            finalStateTax +
+            ficaTax -
+            incomeClassification.classified.spendable;
+
+        if (deficit <= 0) {
+            // Surplus year: nothing to solve, this is a genuine (converged) outcome.
+            converged = true;
+            break;
+        }
+
+        // Plan withdrawals - planner uses allOrdinaryIncome as starting income position
+        // Pass currentSSTaxable as stateExemptIncome so the planner excludes it from
+        // state bracket positioning (DC and most states exempt SS from income tax)
+        const withdrawalResult = planWithdrawals(
+            deficit,
+            accountSnapshots,
+            input.currentAge,
+            input.year,
+            input.taxState,
+            allOrdinaryIncome,
+            input.assumptions,
+            'Spending deficit',
+            acaWithdrawalOpts,
+            currentSSTaxable
+        );
+
+        // Update tracking variables from this iteration
+        withdrawals = [
+            ...withdrawals.filter(w => w.reason === 'Required Minimum Distribution'), // Keep RMD
+            ...withdrawalResult.withdrawals,
+        ];
+        withdrawalOrdinaryTax = withdrawalResult.withdrawals
+            .filter(w => w.capitalGains === undefined)
+            .reduce((sum, w) => sum + w.tax, 0);
+        totalPenalties = withdrawalResult.totalPenalties;
+        withdrawalDecisions = withdrawalResult.decisions;
+        iterations = iter + 1;
+
+
+        // Extract Traditional spending withdrawal (exclude RMDs — already in nonSSBaseIncome)
+        const newTradWithdrawal = withdrawalResult.withdrawals
+            .filter(w => w.source === 'traditional_401k' || w.source === 'traditional_ira')
+            .reduce((sum, w) => sum + w.gross, 0);
+
+        // Check convergence: both LTCG and Traditional withdrawal (which drives SS taxable) must stabilize
+        const newLTCG = withdrawalResult.totalLTCG;
+        const ltcgDelta = Math.abs(newLTCG - estimatedLTCG);
+        const tradDelta = Math.abs(newTradWithdrawal - estimatedTradWithdrawal);
+        estimatedLTCG = newLTCG;
+        estimatedTradWithdrawal = newTradWithdrawal;
+
+        if (ltcgDelta < 1 && tradDelta < 1) {
+            converged = true;
+            break;
+        }
+    }
+
+    // DO NOT recompute tax after the loop with plan.totalLTCG.
+    // The withdrawal was sized for the deficit computed from finalFedResult/finalStateTax.
+    // Recomputing with the planner's actual LTCG (which differs by up to the convergence
+    // threshold from estimatedLTCG) would create a mismatch between reported taxes and
+    // withdrawal amount, causing Sankey balance leaks.
+
+    decisions.push(...withdrawalDecisions);
+
+    // Step F: Calculate final surplus using authoritative tax values.
+    // Exclude RMD entries from totalGrossWithdrawals — RMD is already in spendable
+    // (classifyIncome puts it there) and including it here would double-count cash in.
+    const totalGrossWithdrawals = withdrawals
+        .filter(w => w.reason !== 'Required Minimum Distribution')
+        .reduce((sum, w) => sum + w.gross, 0);
+
+    // Total tax uses authoritative federal (ordinary + LTCG + NIIT) + state (with LTCG)
+    // + withdrawal ordinary tax (Roth 5-year, Traditional, HSA) + FICA + penalties
+    const totalTax = finalFedResult.totalTax + finalStateTax + withdrawalOrdinaryTax + ficaTax + totalPenalties;
+
+    // Final cash flow.
+    // LTCG tax is a pass-through: brokerage gross-up pays it directly to the government.
+    // The deficit already included LTCG (via finalFedResult.totalTax), so the gross withdrawal
+    // is deficit + ltcgTax. Counting that full gross as spendable cash-in would create a phantom
+    // surplus equal to ltcgTax. Subtract it so only the net (post-tax) portion is cash-in.
+    const actualLTCGTax = withdrawals
+        .filter(w => w.capitalGains !== undefined)
+        .reduce((sum, w) => sum + w.tax, 0);
+
+    const cashIn =
+        incomeClassification.classified.spendable +
+        totalGrossWithdrawals -
+        actualLTCGTax;
+
+    const cashOut =
+        effectiveLivingExpenses +
+        totalTax;
+
+    const surplus = Math.max(0, cashIn - cashOut);
+    const rawDeficit = cashOut - cashIn;
+    const unfundedDeficit = rawDeficit < 0.01 ? 0 : rawDeficit;
+
+    if (unfundedDeficit > 0) {
+        decisions.push({
+            category: 'warning',
+            amount: unfundedDeficit,
+            description: `Unfunded deficit of $${unfundedDeficit.toLocaleString()}. Insufficient account balances.`,
+        });
+    }
+
+    // Build tax summary with authoritative values
+    // federal: ordinaryTax only (LTCG and NIIT are separate line items)
+    // state: includes LTCG in income base (DC and most states tax gains as ordinary)
+    // capitalGainsLT: authoritative bracket-stacked LTCG tax from calculateTotalFederalTax
+    // niit: from calculateTotalFederalTax (3.8% on investment income above threshold)
+    const taxSummary: YearPlanTax = {
+        federal: finalFedResult.ordinaryTax,
+        state: finalStateTax,
+        fica: ficaTax,
+        capitalGainsLT: finalFedResult.ltcgTax,
+        capitalGainsST: 0,
+        withdrawalOrdinaryTax,
+        niit: finalFedResult.niitTax,
+        penalties: totalPenalties,
+        total: totalTax,
+    };
+
+    // Step G: Allocate surplus (if any)
+    let surplusAllocations: YearPlan['surplusAllocations'] = [];
+    let surplusDeficitDebtPayment = 0;
+    if (surplus > 0) {
+        const priorityBuckets = (input.assumptions.priorities || []).map((p, idx) => ({
+            accountId: p.accountId || '',
+            priority: idx,
+            capType: p.capType,
+            capValue: p.capValue,
+        })).filter(p => p.accountId);
+
+        const earnedIncome = TaxService.getEarnedIncome(input.incomes, input.year);
+        const surplusSettings: SurplusAllocationSettings = {
+            emergencyFundTarget: DEFAULT_EMERGENCY_FUND_TARGET,
+            rothIRAContributionEnabled: true,
+            rothIRALimit: getIRALimit(input.year, input.currentAge, input.assumptions.macro.inflationAdjusted),
+            rothIRAContributedThisYear: 0,
+            monthlyExpenses: effectiveLivingExpenses / 12,
+        };
+
+        const surplusResult = allocateSurplus(
+            surplus,
+            input.accounts,
+            priorityBuckets,
+            earnedIncome,
+            surplusSettings
+        );
+
+        surplusAllocations = surplusResult.allocations;
+        surplusDeficitDebtPayment = surplusResult.deficitDebtPayment;
+        decisions.push(...surplusResult.decisions);
+    }
+
+    return {
+        year: input.year,
+        isRetired: input.isRetired,
+        income: finalIncomeClassification.classified,
+        withdrawals,
+        conversion: conversionPlan.conversion,
+        contributions: [], // No contributions in retirement
+        surplusAllocations,
+        deficitDebtPayment: surplusDeficitDebtPayment,
+        tax: taxSummary,
+        surplus,
+        unfundedDeficit,
+        totalExpenses: effectiveLivingExpenses,
+        strategyResult: input.strategyResult,
+        iterations,
+        converged,
+        decisions,
+        taxOptimizationTarget: conversionPlan.taxOptimizationTarget,
+    };
+}
+
+/**
+ * Solve a working year (no conversions, but withdrawals occur if income < expenses).
+ */
+export function solveWorkingYear(input: YearSolverInput): YearPlan {
+    const decisions: DecisionLogEntry[] = [];
+
+    // Get tax parameters
+    const fedParams = TaxService.getTaxParameters(
+        input.year,
+        input.taxState.filingStatus,
+        'federal',
+        undefined,
+        input.assumptions
+    );
+    const stateParams = TaxService.getTaxParameters(
+        input.year,
+        input.taxState.filingStatus,
+        'state',
+        input.taxState.stateResidency,
+        input.assumptions
+    );
+
+    if (!fedParams) {
+        throw new Error(`No federal tax parameters for year ${input.year}`);
+    }
+
+    // Classify income
+    const incomeClassification = classifyIncome(
+        input.incomes,
+        0, // No RMD
+        0, // No conversion
+        input.year
+    );
+
+    // Calculate deductions
+    const preTaxDeductions = TaxService.getPreTaxExemptions(input.incomes, input.year, input.currentAge, true);
+    const postTaxDeductions = TaxService.getPostTaxExemptions(input.incomes, input.year, input.currentAge, true);
+    const socialSecurityBenefits = getTotalSSBenefits(input.incomes, input.year);
+
+    // Include reinvested income in tax base - it's taxable even though it's not spendable
+    const taxableOrdinaryBase = incomeClassification.classified.spendable + incomeClassification.classified.reinvested;
+
+    const taxResult = TaxService.calculateTotalFederalTax(
+        taxableOrdinaryBase - socialSecurityBenefits,
+        socialSecurityBenefits,
+        0,
+        0,
+        preTaxDeductions,
+        input.taxState.filingStatus,
+        fedParams
+    );
+
+    const ficaTax = TaxService.calculateFicaTax(
+        input.taxState,
+        input.incomes,
+        input.year,
+        input.assumptions
+    );
+
+    const stateTax = stateParams
+        ? TaxService.calculateTax(
+            taxableOrdinaryBase,  // Include reinvested income in state tax too
+            preTaxDeductions,
+            stateParams
+        )
+        : 0;
+
+    const totalTax = taxResult.totalTax + stateTax + ficaTax;
+
+    // Calculate initial surplus/deficit
+    // IMPORTANT: Must subtract pre-tax deductions (401k, HSA) and post-tax deductions
+    // (Roth 401k, after-tax contributions) from cashIn because they reduce spendable
+    // cash even though they may reduce taxes or be after-tax.
+    // Note: spendable already excludes reinvested income (handled by classifyIncome).
+    const incomeCashIn = incomeClassification.classified.spendable - preTaxDeductions - postTaxDeductions;
+    const incomeCashOut = input.totalLivingExpenses + totalTax;
+    const initialDeficit = Math.max(0, incomeCashOut - incomeCashIn);
+
+    // Plan withdrawals if income doesn't cover expenses
+    let withdrawals: PlannedWithdrawal[] = [];
+    let ltcgTax = 0;
+    let withdrawalOrdinaryTax = 0;
+    let totalPenalties = 0;
+
+    if (initialDeficit > 0) {
+        const accountSnapshots = createOrderedSnapshots(
+            input.accounts, input.withdrawalOrder, input.currentAge, input.year
+        );
+
+        const withdrawalResult = planWithdrawals(
+            initialDeficit,
+            accountSnapshots,
+            input.currentAge,
+            input.year,
+            input.taxState,
+            taxableOrdinaryBase, // ordinary income for LTCG bracket determination
+            input.assumptions,
+            'Spending deficit'
+        );
+
+        withdrawals = withdrawalResult.withdrawals;
+        ltcgTax = withdrawalResult.withdrawals
+            .filter(w => w.capitalGains !== undefined)
+            .reduce((sum, w) => sum + w.tax, 0);
+        withdrawalOrdinaryTax = withdrawalResult.withdrawals
+            .filter(w => w.capitalGains === undefined)
+            .reduce((sum, w) => sum + w.tax, 0);
+        totalPenalties = withdrawalResult.totalPenalties;
+        decisions.push(...withdrawalResult.decisions);
+    }
+
+    // Final cash flow including withdrawals
+    const totalGrossWithdrawals = withdrawals.reduce((sum, w) => sum + w.gross, 0);
+    const finalTotalTax = totalTax + ltcgTax + withdrawalOrdinaryTax + totalPenalties;
+
+    const finalCashIn = incomeCashIn + totalGrossWithdrawals;
+    const finalCashOut = input.totalLivingExpenses + finalTotalTax;
+    const surplus = Math.max(0, finalCashIn - finalCashOut);
+    const unfundedDeficit = Math.max(0, finalCashOut - finalCashIn);
+
+    if (unfundedDeficit > 0) {
+        decisions.push({
+            category: 'warning',
+            amount: unfundedDeficit,
+            description: `Unfunded deficit of $${unfundedDeficit.toLocaleString()}. Insufficient account balances.`,
+        });
+    }
+
+    const taxSummary: YearPlanTax = {
+        federal: taxResult.totalTax,
+        state: stateTax,
+        fica: ficaTax,
+        capitalGainsLT: ltcgTax,
+        capitalGainsST: 0,
+        withdrawalOrdinaryTax,
+        niit: 0,
+        penalties: totalPenalties,
+        total: finalTotalTax,
+    };
+
+    // Allocate surplus (if any)
+    let surplusAllocations: YearPlan['surplusAllocations'] = [];
+    let surplusDeficitDebtPayment = 0;
+    if (surplus > 0) {
+        const priorityBuckets = (input.assumptions.priorities || []).map((p, idx) => ({
+            accountId: p.accountId || '',
+            priority: idx,
+            capType: p.capType,
+            capValue: p.capValue,
+        })).filter(p => p.accountId);
+
+        const earnedIncome = TaxService.getEarnedIncome(input.incomes, input.year);
+        const surplusSettings: SurplusAllocationSettings = {
+            emergencyFundTarget: DEFAULT_EMERGENCY_FUND_TARGET,
+            rothIRAContributionEnabled: true,
+            rothIRALimit: getIRALimit(input.year, input.currentAge, input.assumptions.macro.inflationAdjusted),
+            rothIRAContributedThisYear: 0,
+            monthlyExpenses: input.totalLivingExpenses / 12,
+        };
+
+        const surplusResult = allocateSurplus(
+            surplus,
+            input.accounts,
+            priorityBuckets,
+            earnedIncome,
+            surplusSettings
+        );
+
+        surplusAllocations = surplusResult.allocations;
+        surplusDeficitDebtPayment = surplusResult.deficitDebtPayment;
+        decisions.push(...surplusResult.decisions);
+    }
+
+    return {
+        year: input.year,
+        isRetired: false,
+        income: incomeClassification.classified,
+        withdrawals,
+        conversion: null,
+        contributions: [], // Will be filled by contribution planning
+        surplusAllocations,
+        deficitDebtPayment: surplusDeficitDebtPayment,
+        tax: taxSummary,
+        surplus,
+        unfundedDeficit,
+        totalExpenses: input.totalLivingExpenses,
+        strategyResult: input.strategyResult,
+        iterations: 1,
+        converged: true,
+        decisions,
+    };
+}
+
+/**
+ * Main entry point - routes to working or retirement solver.
+ */
+export function solveYear(input: YearSolverInput): YearPlan {
+    if (input.isRetired) {
+        return solveRetirementYear(input);
+    } else {
+        return solveWorkingYear(input);
+    }
+}

--- a/src/services/simulation/helpers.ts
+++ b/src/services/simulation/helpers.ts
@@ -1,0 +1,419 @@
+import { AnyAccount, InvestedAccount, SavedAccount, ESPPAccount } from "../../components/Objects/Accounts/models";
+import { FilingStatus, TaxParameters } from "../../data/TaxData";
+import * as TaxService from "../../components/Objects/Taxes/TaxService";
+
+export type TaxCategory = 'tax-deferred' | 'tax-free' | 'taxable' | 'mixed';
+
+/**
+ * Classify an account by its tax treatment for withdrawal ordering.
+ */
+export function classifyAccountTaxCategory(account: AnyAccount): TaxCategory {
+    if (account instanceof SavedAccount) return 'tax-free';
+    if (account instanceof InvestedAccount) {
+        switch (account.taxType) {
+            case 'Traditional 401k':
+            case 'Traditional IRA':
+                return 'tax-deferred';
+            case 'Roth 401k':
+            case 'Roth IRA':
+            case 'HSA':
+                return 'tax-free';
+            case 'Brokerage':
+            default:
+                return 'taxable';
+        }
+    }
+    if (account instanceof ESPPAccount) return 'mixed';
+    return 'taxable';
+}
+
+export interface ACAOptions {
+    currentAge: number;
+    acaSubsidyAware: boolean;
+    acaCliffThreshold: number;
+    estimatedSubsidyLoss: number;  // What would be lost if cliff crossed
+}
+
+export interface ConversionTaxBreakdown {
+    federalOrdinaryTaxCost: number;
+    ssTorpedoCost: number;
+    ltcgBumpCost: number;
+    niitCost: number;
+    stateTaxCost: number;
+    acaSubsidyLost: number;
+}
+
+export interface EffectiveConversionTaxResult {
+    taxBefore: number;
+    taxAfter: number;
+    taxIncrease: number;
+    effectiveRate: number;
+    breakdown: ConversionTaxBreakdown;
+    crossesACACliff: boolean;
+}
+
+/**
+ * Calculate the effective tax cost of a Roth conversion, including:
+ * - SS "tax torpedo" effect (conversion pushes more SS into taxable territory)
+ * - LTCG bump (conversion can push LTCG from 0% to 15% bracket)
+ * - State tax on the conversion
+ * - ACA subsidy cliff (for early retirees under 65)
+ *
+ * Uses calculateTotalFederalTax for unified tax calculation with proper
+ * SS taxability and LTCG stacking.
+ *
+ * @param nonSSIncome - AGI excluding Social Security benefits
+ * @param totalSSBenefits - Total Social Security benefits received
+ * @param ltcgIncome - Long-term capital gains income (0 if none)
+ * @param conversionAmount - Amount of Roth conversion
+ * @param filingStatus - Tax filing status
+ * @param fedParams - Federal tax parameters
+ * @param stateParams - State tax parameters (null if no state tax)
+ * @param acaOptions - ACA subsidy awareness options (undefined if not applicable)
+ */
+// NOTE: This function's ACA-MAGI check (magiBefore = nonSSIncome + totalSSBenefits)
+// previously double-counted Social Security because callers passed `baseOrdinaryIncome`
+// (= non-SS income + taxableSS) into the `nonSSIncome` slot. The conversion review fixed
+// the call sites to pass true non-SS ordinary income, so `nonSSIncome + totalSSBenefits`
+// now correctly equals actual-non-SS + full SS.
+export function calculateEffectiveConversionTax(
+    nonSSIncome: number,
+    totalSSBenefits: number,
+    ltcgIncome: number,
+    conversionAmount: number,
+    filingStatus: FilingStatus,
+    fedParams: TaxParameters,
+    stateParams: TaxParameters | null,
+    acaOptions?: ACAOptions
+): EffectiveConversionTaxResult {
+    // =========================================================================
+    // CALCULATE FULL TAX BEFORE AND AFTER CONVERSION
+    // =========================================================================
+    // Use calculateTotalFederalTax for unified handling of SS taxability and LTCG stacking
+    // Note: ltcgIncome is passed as longTermCapitalGains (4th param), STCG is 0 (3rd param)
+    const taxResultBefore = TaxService.calculateTotalFederalTax(
+        nonSSIncome,
+        totalSSBenefits,
+        0,          // shortTermCapitalGains
+        ltcgIncome, // longTermCapitalGains
+        0,          // preTaxDeductions - already accounted for in nonSSIncome
+        filingStatus,
+        fedParams
+    );
+
+    const taxResultAfter = TaxService.calculateTotalFederalTax(
+        nonSSIncome + conversionAmount,
+        totalSSBenefits,
+        0,          // shortTermCapitalGains
+        ltcgIncome, // longTermCapitalGains
+        0,          // preTaxDeductions
+        filingStatus,
+        fedParams
+    );
+
+    // =========================================================================
+    // CALCULATE BREAKDOWN COMPONENTS
+    // =========================================================================
+
+    // LTCG bump: direct comparison from unified results
+    const ltcgBumpCost = taxResultAfter.ltcgTax - taxResultBefore.ltcgTax;
+
+    // NIIT cost: 3.8% on investment income above threshold when MAGI exceeds threshold
+    const niitCost = taxResultAfter.niitTax - taxResultBefore.niitTax;
+
+    // -------------------------------------------------------------------------
+    // SS Torpedo Calculation
+    // -------------------------------------------------------------------------
+    // The "torpedo" is specifically about MORE SS becoming taxable due to the
+    // conversion. When SS is already at 85% taxable, there's no torpedo effect.
+    //
+    // We calculate a "frozen SS" scenario: what would the tax be after conversion
+    // if SS taxability stayed the same as before?
+    //
+    // federalOrdinaryTaxCost = marginal tax at current bracket (with existing taxable SS)
+    // ssTorpedoCost = extra tax from the INCREASE in taxable SS
+    // -------------------------------------------------------------------------
+
+    const taxableSS_before = taxResultBefore.taxableSS;
+    // Note: taxResultAfter.taxableSS available for debugging if needed
+
+    // Calculate tax with "frozen" SS (what if SS didn't become more taxable?)
+    // We add taxableSS_before to ordinary income manually (with no SS benefits)
+    // to simulate the conversion without additional SS becoming taxable
+    const taxFrozenSS = TaxService.calculateTotalFederalTax(
+        nonSSIncome + conversionAmount + taxableSS_before,  // use taxableSS_before
+        0,          // no SS benefits (we're adding taxableSS manually to ordinary)
+        0,          // shortTermCapitalGains
+        ltcgIncome, // longTermCapitalGains
+        0,          // preTaxDeductions
+        filingStatus,
+        fedParams
+    );
+
+    // Also need the "before" state with SS added manually for apples-to-apples comparison
+    const taxBeforeManualSS = TaxService.calculateTotalFederalTax(
+        nonSSIncome + taxableSS_before,
+        0,          // no SS benefits
+        0,          // shortTermCapitalGains
+        ltcgIncome, // longTermCapitalGains
+        0,          // preTaxDeductions
+        filingStatus,
+        fedParams
+    );
+
+    // federalOrdinaryTaxCost = marginal tax at current bracket (with existing taxable SS held constant)
+    const federalOrdinaryTaxCost = taxFrozenSS.ordinaryTax - taxBeforeManualSS.ordinaryTax;
+
+    // ssTorpedoCost = extra tax from MORE SS becoming taxable
+    // This is the difference between actual tax after and the "frozen SS" scenario
+    const ssTorpedoCost = taxResultAfter.ordinaryTax - taxFrozenSS.ordinaryTax;
+
+    // =========================================================================
+    // STATE TAX
+    // =========================================================================
+    let stateTaxCost = 0;
+    if (stateParams) {
+        // Most states tax LTCG as ordinary income (no preferential rate).
+        // Include LTCG in state income to get correct marginal rate on conversion.
+        const stateIncome = nonSSIncome + ltcgIncome;
+        const stateTaxBefore = TaxService.calculateTax(stateIncome, 0, stateParams);
+        const stateTaxAfter = TaxService.calculateTax(stateIncome + conversionAmount, 0, stateParams);
+        stateTaxCost = stateTaxAfter - stateTaxBefore;
+    }
+
+    // =========================================================================
+    // ACA SUBSIDY CLIFF
+    // =========================================================================
+    let crossesACACliff = false;
+    let acaSubsidyLost = 0;
+    if (acaOptions && acaOptions.acaSubsidyAware && acaOptions.currentAge < 65) {
+        // MAGI for ACA includes 100% of SS benefits (not just taxable portion) and
+        // capital gains (LTCG is part of AGI), so cliff crossings are detected for
+        // retirees with capital gains.
+        const magiBefore = nonSSIncome + totalSSBenefits + ltcgIncome;
+        const magiAfter = magiBefore + conversionAmount;
+
+        if (magiBefore < acaOptions.acaCliffThreshold && magiAfter >= acaOptions.acaCliffThreshold) {
+            crossesACACliff = true;
+            acaSubsidyLost = acaOptions.estimatedSubsidyLoss;
+        }
+    }
+
+    // =========================================================================
+    // TOTALS
+    // =========================================================================
+    const taxBefore = taxResultBefore.totalTax;
+    const taxAfter = taxResultAfter.totalTax;
+    const taxIncrease = (taxAfter - taxBefore) + stateTaxCost + acaSubsidyLost;
+    const effectiveRate = conversionAmount > 0 ? taxIncrease / conversionAmount : 0;
+
+    return {
+        taxBefore,
+        taxAfter,
+        taxIncrease,
+        effectiveRate,
+        breakdown: {
+            federalOrdinaryTaxCost,
+            ssTorpedoCost,
+            ltcgBumpCost,
+            niitCost,
+            stateTaxCost,
+            acaSubsidyLost
+        },
+        crossesACACliff
+    };
+}
+
+
+// =============================================================================
+// FIXED INCOME AT RMD PROJECTION
+// =============================================================================
+
+/**
+ * Result of projecting fixed income to RMD age
+ */
+export interface FixedIncomeAtRMDResult {
+    /** Projected Social Security income at RMD age (with COLA) */
+    ssAtRMD: number;
+    /** Projected pension income at RMD age (with COLA) */
+    pensionAtRMD: number;
+    /** Projected passive income at RMD age (no growth assumed) */
+    passiveAtRMD: number;
+    /** Years of COLA applied */
+    yearsProjected: number;
+}
+
+/**
+ * Default COLA rate for SS (historical average is ~2.5%, use conservative 2%)
+ */
+export const DEFAULT_SS_COLA = 0.02;
+
+/**
+ * Default COLA rate for FERS pensions (typically CPI-based, ~2%)
+ */
+export const DEFAULT_PENSION_COLA = 0.02;
+
+/**
+ * Estimate fixed income (SS + pensions) at RMD age by projecting with COLA.
+ *
+ * This is the FALLBACK calculation used when baselineProjections is not available.
+ * It projects current SS and pension income forward using COLA rates.
+ *
+ * @param currentSSIncome - Current year's Social Security income (0 if not yet claiming)
+ * @param futureSS_PIA - Monthly PIA from FutureSocialSecurityIncome (if not yet claiming)
+ * @param currentPensionIncome - Current year's pension income
+ * @param currentAge - Current age in simulation
+ * @param rmdStartAge - Age when RMDs begin (72, 73, or 75)
+ * @param ssClaimingAge - Age when SS will be claimed (for projecting PIA forward)
+ * @param ssCola - Annual SS COLA rate (default 2%)
+ * @param pensionCola - Annual pension COLA rate (default 2%)
+ * @param currentPassiveIncome - Current year's passive income (rental, dividends, etc.)
+ * @returns Projected SS, pension, and passive income at RMD age
+ */
+export function estimateFixedIncomeAtRMD(
+    currentSSIncome: number,
+    futureSS_PIA: number,
+    currentPensionIncome: number,
+    currentAge: number,
+    rmdStartAge: number,
+    ssClaimingAge: number = 67,
+    ssCola: number = DEFAULT_SS_COLA,
+    pensionCola: number = DEFAULT_PENSION_COLA,
+    currentPassiveIncome: number = 0
+): FixedIncomeAtRMDResult {
+    // If already at or past RMD age, no projection needed
+    if (currentAge >= rmdStartAge) {
+        return {
+            ssAtRMD: currentSSIncome,
+            pensionAtRMD: currentPensionIncome,
+            passiveAtRMD: currentPassiveIncome,
+            yearsProjected: 0
+        };
+    }
+
+    const yearsUntilRMD = rmdStartAge - currentAge;
+
+    // --- Project SS to RMD age ---
+    let ssAtRMD: number;
+
+    if (currentSSIncome > 0) {
+        // Already receiving SS - project forward with COLA
+        ssAtRMD = currentSSIncome * Math.pow(1 + ssCola, yearsUntilRMD);
+    } else if (futureSS_PIA > 0) {
+        // Not yet receiving SS - use PIA and project with COLA
+        // PIA is monthly, convert to annual
+        const annualSS = futureSS_PIA * 12;
+
+        // Calculate years of COLA from claiming age to RMD age
+        // SS benefits get COLA starting the year after claiming
+        const yearsOfSSCola = Math.max(0, rmdStartAge - ssClaimingAge);
+        ssAtRMD = annualSS * Math.pow(1 + ssCola, yearsOfSSCola);
+    } else {
+        // No SS info available - default to $0
+        // User should add a FutureSocialSecurityIncome object for accurate planning
+        ssAtRMD = 0;
+    }
+
+    // --- Project Pension to RMD age ---
+    let pensionAtRMD: number;
+
+    if (currentPensionIncome > 0) {
+        // Project pension forward with COLA
+        pensionAtRMD = currentPensionIncome * Math.pow(1 + pensionCola, yearsUntilRMD);
+    } else {
+        // No pension or not yet receiving
+        pensionAtRMD = 0;
+    }
+
+    return {
+        ssAtRMD,
+        pensionAtRMD,
+        passiveAtRMD: currentPassiveIncome,
+        yearsProjected: yearsUntilRMD
+    };
+}
+
+// =============================================================================
+// INCOME EXTRACTION FOR RMD PLANNING
+// =============================================================================
+
+/**
+ * Result of extracting income sources for RMD planning
+ */
+export interface ExtractedIncomeForRMD {
+    /** Current Social Security income (0 if not yet claiming) */
+    socialSecurityBenefits: number;
+    /** Monthly PIA from FutureSocialSecurityIncome (0 if not available) */
+    futureSS_PIA: number;
+    /** Age when SS will be claimed */
+    ssClaimingAge: number;
+    /** Current pension income */
+    pensionIncome: number;
+    /** Current passive income (rental, dividends, interest) */
+    passiveIncome: number;
+    /** Social Security COLA rate */
+    ssCola: number;
+    /** Pension COLA rate */
+    pensionCola: number;
+}
+
+/**
+ * Extract Social Security and pension income from income context for RMD planning.
+ *
+ * This helper extracts the necessary income data from plain JSON income objects
+ * (after localStorage deserialization) to feed into estimateFixedIncomeAtRMD().
+ *
+ * Use this when you need to project fixed income to RMD age but only have access
+ * to the income context, not simulation results.
+ *
+ * @param incomes - Array of income objects from IncomeContext (class instances with className property)
+ * @param currentYear - Current calendar year for getAnnualAmount() calls
+ * @param inflationAdjusted - Whether to apply COLA (from state.macro.inflationAdjusted)
+ * @returns Extracted income data ready for estimateFixedIncomeAtRMD()
+ */
+export function extractIncomeForRMDEstimate(
+    incomes: any[], // AnyIncome[] - class instances with className property
+    currentYear: number,
+    inflationAdjusted: boolean
+): ExtractedIncomeForRMD {
+    // Extract current SS income (if already claiming)
+    // Includes both SocialSecurityIncome (legacy) and CurrentSocialSecurityIncome (disability, survivor, already-claimed)
+    const socialSecurityBenefits = incomes
+        .filter(i => i.className === 'SocialSecurityIncome' || i.className === 'CurrentSocialSecurityIncome')
+        .reduce((sum, i) => sum + i.getAnnualAmount(currentYear), 0);
+
+    // Extract future SS (if not yet claiming)
+    const futureSS = incomes.find(i =>
+        i.className === 'FutureSocialSecurityIncome'
+    ) as { calculatedPIA?: number; claimingAge?: number; amount?: number; projectedPIA?: number } | undefined;
+    // Use projectedPIA if > 0, then fall back to amount/12, then calculatedPIA, then 0.
+    // Cannot use ?? because projectedPIA defaults to 0 (not undefined), so ?? treats it as valid.
+    const futureSS_PIA = (futureSS?.projectedPIA && futureSS.projectedPIA > 0)
+        ? futureSS.projectedPIA
+        : (futureSS?.amount ? futureSS.amount / 12 : (futureSS?.calculatedPIA ?? 0));
+    const ssClaimingAge = futureSS?.claimingAge ?? 67;
+
+    // Extract pension income
+    const pensionIncome = incomes
+        .filter(i => i.className && i.className.includes('Pension'))
+        .reduce((sum, i) => sum + i.getAnnualAmount(currentYear), 0);
+
+    // Extract passive income (rental, dividends, interest, etc.)
+    const passiveIncome = incomes
+        .filter(i => i.className === 'PassiveIncome')
+        .reduce((sum, i) => sum + i.getAnnualAmount(currentYear), 0);
+
+    // Get inflation settings
+    const ssCola = inflationAdjusted ? 0.02 : 0;
+    const pensionCola = inflationAdjusted ? 0.02 : 0;
+
+    return {
+        socialSecurityBenefits,
+        futureSS_PIA,
+        ssClaimingAge,
+        pensionIncome,
+        passiveIncome,
+        ssCola,
+        pensionCola
+    };
+}

--- a/src/services/simulation/types.ts
+++ b/src/services/simulation/types.ts
@@ -1,0 +1,654 @@
+import { AnyAccount } from "../../components/Objects/Accounts/models";
+import { AnyExpense } from "../../components/Objects/Expense/models";
+import { AnyIncome } from "../../components/Objects/Income/models";
+import { WithdrawalResult, GuardrailTrigger } from "../WithdrawalStrategies";
+import { RMDCalculation } from "../../data/RMDData";
+
+/**
+ * Per-source income line for cashflow display.
+ * `kind` mirrors what classifyIncome would assign.
+ */
+export type CashflowIncomeKind = 'work' | 'ss' | 'pension' | 'passive' | 'reinvested' | 'rmd';
+
+export interface CashflowIncomeSource {
+    name: string;
+    amount: number;
+    kind: CashflowIncomeKind;
+    /** For reinvested passive income: the account that holds the reinvested cash. */
+    accountName?: string;
+}
+
+/**
+ * Detailed cashflow breakdown the simulation has already computed but
+ * historically wasn't surfaced. The Sankey chart uses these values directly
+ * instead of re-deriving them from raw incomes/expenses (which led to drift).
+ */
+export interface CashflowDetail {
+    /** Per-source income lines (post earnings test, post-classification). */
+    incomeBySource: CashflowIncomeSource[];
+    /** Pre-tax 401k contributions, summed across active work incomes. */
+    userPreTax401k: number;
+    /** Roth 401k contributions, summed across active work incomes. */
+    userRoth401k: number;
+    /** Employer match flowing into Traditional accounts. */
+    employerMatchPreTax: number;
+    /** Employer match flowing into Roth accounts (rare). */
+    employerMatchRoth: number;
+    /** Insurance payroll deduction (mirror of taxDetails.insurance). */
+    insurance: number;
+    /** Mortgage principal portion of total mortgage payment. */
+    mortgagePrincipal: number;
+    /** Mortgage interest + escrow portion of total mortgage payment. */
+    mortgageInterestEscrow: number;
+    /** Living expense totals by category (excludes mortgage; mortgage is split above). */
+    expensesByCategory: Record<string, number>;
+    /**
+     * Long-term capital gains tax that the planner withheld from a brokerage/ESPP
+     * gross-up. Conceptually this dollar amount never reached the user — the
+     * brokerage routes it directly to the government when sizing the gross-up.
+     *
+     * Equals `sum(w.tax)` over withdrawals with `capitalGains` set. The Sankey
+     * chart subtracts this from gross withdrawals on the inflow side so it
+     * doesn't appear as residual "remaining" cash; SimulationEngine subtracts it
+     * from `totalCashAvailable` when computing `trueUserSaved`, mirroring
+     * YearSolver Step F's `actualLTCGTax` subtraction in `cashIn`.
+     *
+     * Zero when planner LTCG rate is 0 (low ordinary income) since no gross-up
+     * was applied; auth LTCG in that case is captured by `unfundedDeficit`.
+     */
+    brokerageLTCGFromGross: number;
+}
+
+// Define the shape of a single year's result
+export interface SimulationYear {
+    year: number;
+    incomes: AnyIncome[];
+    expenses: AnyExpense[];
+    accounts: AnyAccount[];
+    cashflow: {
+        totalIncome: number;
+        totalExpense: number; // Taxes + Living Expenses + Payroll Deductions
+        livingExpenses: number; // Living expenses only (excluding taxes)
+        discretionary: number; // Unspent cash
+        investedUser: number;  // User contributions + Saved Cash
+        investedMatch: number; // Employer Match
+        totalInvested: number; // Sum
+        bucketAllocations: number; // Priority Bucket contributions
+        bucketDetail: Record<string, number>; // Breakdown
+        withdrawals: number; // Total withdrawn from accounts
+        withdrawalDetail: Record<string, number>; // Per-account breakdown
+    };
+    /** Detailed breakdown for the cashflow Sankey chart. */
+    cashflowDetail?: CashflowDetail;
+    taxDetails: {
+        fed: number; // Federal income tax + early-withdrawal penalty (penalty is also broken out in earlyWithdrawalPenalty)
+        state: number;
+        fica: number;
+        preTax: number;
+        insurance: number;
+        postTax: number;
+        capitalGains: number; // Capital gains tax on brokerage/ESPP withdrawals only
+        withdrawalOrdinaryTax: number; // Tax on Roth earnings (5-year rule), Traditional, HSA non-medical
+        niit: number; // Net Investment Income Tax (3.8%)
+        earlyWithdrawalPenalty?: number; // 10% early-withdrawal penalty (Traditional pre-59.5, Roth conversion 5-year rule). Already included in `fed`; surfaced separately for diagnostics.
+        longTermCapitalGains?: number; // LTCG amount realized this year (for AGI-equivalent denominator in effective-rate calcs). Surfaces WithdrawalState.longTermCapitalGains.
+    };
+    logs: string[];
+    // Withdrawal strategy tracking (for multi-year calculations)
+    strategyWithdrawal?: WithdrawalResult;
+    // Guyton-Klinger strategy adjustment tracking
+    strategyAdjustment?: {
+        guardrailTriggered: GuardrailTrigger;
+        requiredAdjustment: number;      // $ amount GK wants to cut/add
+        actualAdjustment: number;        // $ amount actually cut/added
+        discretionaryAvailable: number;  // $ of discretionary expenses available
+        warning?: string;                // Warning if cut couldn't be fully applied
+    };
+    // Auto Roth conversion tracking
+    rothConversion?: {
+        amount: number;                  // Total amount converted
+        taxCost: number;                 // Tax paid on conversion (legacy: fed-only in V1, fed+state in V2 — prefer federalTaxCost/stateTaxCost)
+        federalTaxCost: number;          // Federal-only tax increase from the conversion
+        stateTaxCost: number;            // State-only tax increase from the conversion
+        taxAfter: number;               // Total federal tax after conversion
+        fromAccounts: Record<string, number>;  // Amount from each Traditional account (by name)
+        toAccounts: Record<string, number>;    // Amount to each Roth account (by name)
+        fromAccountIds: Record<string, number>;  // Amount from each Traditional account (by id)
+        toAccountIds: Record<string, number>;    // Amount to each Roth account (by id)
+    };
+    // Required Minimum Distribution tracking
+    rmdDetails?: {
+        totalRMD: number;                         // Total RMD required this year
+        totalWithdrawn: number;                   // Actual amount withdrawn for RMD
+        accountBreakdown: RMDCalculation[];       // Per-account RMD details
+        shortfall: number;                        // Amount not withdrawn (if any)
+        penalty: number;                          // 25% penalty on shortfall
+    };
+    // Milestone tracking
+    milestoneEvents?: MilestoneReachEvent[];      // Milestones reached this year
+    activeMilestones?: string[];                   // All milestone IDs reached so far
+    taxOptimizationTarget?: TaxOptimizationTarget;
+    /**
+     * Per-year trace from the DP-precomputed conversion strategy. Populated only
+     * when `assumptions.investments.rothConversionStrategy === 'dp-precomputed'`
+     * and the year is within the DP horizon (retirement-onward, pre-RMD-end).
+     * Surfaces the structured math behind each year's conversion choice for the
+     * Roth debug screen.
+     */
+    dpTrace?: DPYearTrace;
+    /**
+     * Lifetime sum of (federal + state + FICA + capital gains) tax under the
+     * std-ded-only conversion baseline — i.e., what taxes would be if only
+     * the always-free standard-deduction-headroom conversions ran. Set on
+     * year 0 of the simulation result so the Withdrawal tab's comparison
+     * panel can display "your strategy vs free conversions only" without
+     * re-running an extra sim.
+     */
+    stdDedBaselineLifetimeTax?: number;
+    // Marks a synthetic "projected end of current year" data point inserted between Year 0 and Year 1
+    isEndOfYearProjection?: boolean;
+}
+
+/**
+ * Structured per-year trace of the DP-precomputed Roth conversion solver's
+ * decision-making. Mirrors the data emitted in the [DEBUG DP …] log lines but
+ * in numeric form so the Roth debug screen can render charts/tables instead of
+ * parsing text.
+ */
+export interface DPYearTrace {
+    year: number;
+    age: number;
+
+    // Decision outcome
+    chosenC: number;
+    yearTax: number;
+    conversionMarginal: number;
+    discountedFuture: number;
+    totalCost: number;
+
+    // State entering the year
+    tradEntering: number;
+    rothEntering: number;
+    rmdAtEntering: number;
+    cMax: number;
+    /** Tax at conversion=0, used for marginal-cost diagnostic. */
+    taxBaselineNoConv: number;
+
+    // State at end of year (under chosen plan)
+    tradNext: number;
+    rothNext: number;
+
+    // Waterfall: spendingNeed + yearTax − cashFromOrdinary = gap → sources
+    spendingNeed: number;
+    cashFromOrdinary: number;
+    gap: number;
+    fromBrokerage: number;
+    fromRoth: number;
+    tradSpending: number;
+    unmetNeed: number;
+    baselineBrokerageCap: number;
+
+    /** Cost-curve samples at the conversion values we evaluated. */
+    costCurve: Array<{
+        c: number;
+        yearTax: number;
+        discountedFuture: number;
+        totalCost: number;
+        tradNext: number;
+        rothNext: number;
+    }>;
+
+    // Baseline (std-ded sub-sim) reference values for this year — for divergence checks.
+    baselineTrad?: number;
+    baselineRoth?: number;
+    baselineBrokerage?: number;
+    baselineConversion?: number;
+
+    // Per-year grid scales (for sanity-checking V-table resolution).
+    dB: number;
+    dRoth: number;
+}
+
+// Internal withdrawal tracking state passed between simulation phases
+export interface WithdrawalState {
+    userInflows: Record<string, number>;
+    employerInflows: Record<string, number>;
+    withdrawalTaxes: number;
+    capitalGainsTaxTotal: number; // Capital gains tax from brokerage/ESPP withdrawals only
+    withdrawalOrdinaryTaxTotal: number; // Tax from Roth earnings (5-year rule), Traditional, HSA non-medical
+    strategyWithdrawalExecuted: number;
+    totalWithdrawals: number;
+    withdrawalDetail: Record<string, number>;
+    withdrawalPenalties: number;
+    totalGrossIncome: number;
+    // Capital gains tracking
+    longTermCapitalGains: number;
+    shortTermCapitalGains: number;
+    stateCapitalGainsTax: number;
+    // Traditional withdrawal tracking for tax calculations
+    traditionalWithdrawals: number;
+}
+
+// Milestone-based trigger types
+export type MilestoneOperator = '>=' | '<=' | '=' | '>' | '<';
+
+export type MilestoneConditionType =
+    | 'NET_WORTH'              // Total assets - liabilities
+    | 'LIQUID_NET_WORTH'       // Brokerage + Savings only (not retirement accounts)
+    | 'TOTAL_DEBT'             // All debt accounts + loan balances
+    | 'YEAR'                   // Fixed calendar year
+    | 'AGE';                   // User's age
+
+// What the right side of the condition compares against
+export type MilestoneValueType =
+    | 'FIXED'                  // Just a number (default)
+    | 'EXPENSES'               // value × annual expenses (e.g., 25x for 4% rule) - living expenses only
+    | 'EXPENSES_GROSSED_UP'    // value × (expenses / (1 - tax_rate)) - includes estimated taxes
+    | 'MILESTONE_PLUS';        // milestone year/age + value offset
+
+export interface MilestoneCondition {
+    type: MilestoneConditionType;
+    operator: MilestoneOperator;
+    value: number;
+    valueType?: MilestoneValueType;        // Default 'FIXED' for backwards compatibility
+    referenceMilestoneId?: string;         // For MILESTONE_PLUS - which milestone to reference
+}
+
+export interface CustomMilestone {
+    id: string;
+    name: string;                      // "Coast FIRE", "Debt Free", etc.
+    conditions: MilestoneCondition[];  // All must be met (AND logic)
+    color?: string;                    // For timeline display
+}
+
+export interface MilestoneReachEvent {
+    milestoneId: string;
+    yearReached: number;
+    ageReached: number;
+}
+
+/**
+ * Baseline projections extracted from a deterministic simulation run.
+ * Used to inform Roth conversion ceiling calculations.
+ */
+export interface BaselineProjections {
+    /** Total Traditional balance at RMD start age */
+    traditionalBalanceAtRMD: number;
+    /** Projected Social Security income at RMD age (with COLA) */
+    ssAtRMD: number;
+    /** Projected pension income at RMD age (with COLA) */
+    pensionAtRMD: number;
+    /** Projected passive income at RMD age (rental, dividends, interest, etc. — excludes RMDs) */
+    passiveAtRMD: number;
+    /** The year when RMDs start */
+    rmdYear: number;
+}
+
+// =============================================================================
+// YEAR SOLVER TYPES (v2 Rewrite)
+// =============================================================================
+
+/**
+ * Income classified by spendability for deficit calculation.
+ */
+export interface ClassifiedIncome {
+    /** Cash available for expenses (work, SS, pensions, RMDs, rental) */
+    spendable: number;
+    /** Goes back into accounts, not available for spending (reinvested dividends) */
+    reinvested: number;
+    /** Required distributions - always spendable and taxable */
+    rmdIncome: number;
+    /** Roth conversions - taxable but NOT spendable (it's a transfer) */
+    conversionIncome: number;
+    /** Everything that appears on tax return */
+    taxableTotal: number;
+    /** Breakdown by source for logging/debugging */
+    breakdown: {
+        wages: number;
+        socialSecurity: number;
+        pensions: number;
+        passive: number;
+        rmd: number;
+        reinvested: number;
+    };
+}
+
+/**
+ * Decision log entry for transparency.
+ */
+export interface DecisionLogEntry {
+    category: 'withdrawal' | 'conversion' | 'contribution' | 'surplus' | 'tax' | 'rmd' | 'warning' | 'spending';
+    account?: string;
+    amount?: number;
+    description: string;
+}
+
+/**
+ * Tax payment source for conversions.
+ */
+export type ConversionTaxSource = 'SURPLUS' | 'BROKERAGE' | 'WITHHOLD';
+
+/**
+ * Account type for withdrawals.
+ */
+export type WithdrawalAccountType =
+    | 'savings'
+    | 'brokerage'
+    | 'traditional_401k'
+    | 'traditional_ira'
+    | 'roth_401k'
+    | 'roth_ira'
+    | 'hsa'
+    | 'espp';
+
+/**
+ * Individual planned withdrawal from an account.
+ */
+export interface PlannedWithdrawal {
+    /** Account type for tax treatment */
+    source: WithdrawalAccountType;
+    /** Account ID */
+    accountId: string;
+    /** Account name (for logging) */
+    accountName: string;
+    /** Gross amount withdrawn */
+    gross: number;
+    /** Net amount received after tax/penalty */
+    net: number;
+    /** Capital gains breakdown (for brokerage/ESPP) */
+    capitalGains?: {
+        shortTerm: number;
+        longTerm: number;
+    };
+    /** Early withdrawal penalty (if under 59.5) */
+    penalty: number;
+    /** Tax on this withdrawal */
+    tax: number;
+    /** Reason for withdrawal */
+    reason: 'Required Minimum Distribution' | 'Spending deficit' | 'Conversion tax' | 'Healthcare expense' | 'ACA cliff Roth substitution';
+}
+
+/**
+ * Planned Roth conversion.
+ */
+export interface PlannedConversion {
+    /** Amount converted */
+    amount: number;
+    /** Source Traditional account ID */
+    fromAccountId: string;
+    /** Target Roth account ID */
+    toAccountId: string;
+    /** How the conversion tax is paid */
+    taxSource: ConversionTaxSource;
+    /** Total tax cost of conversion (federal + state + ACA subsidy lost) */
+    taxAmount: number;
+    /** Federal-only portion of the conversion tax (ordinary + SS torpedo + LTCG bump + NIIT) */
+    federalTaxCost: number;
+    /** State-only portion of the conversion tax */
+    stateTaxCost: number;
+    /** Net amount going to Roth (= amount when SURPLUS/BROKERAGE, < amount when WITHHOLD) */
+    netToRoth: number;
+    /** Reason/explanation */
+    reason: string;
+}
+
+/**
+ * Planned contribution (working years).
+ */
+export interface PlannedContribution {
+    /** Account ID */
+    accountId: string;
+    /** Amount contributed */
+    amount: number;
+    /** Contribution type */
+    type: 'employee_pretax' | 'employee_roth' | 'employer_match' | 'espp' | 'roth_ira' | 'savings';
+}
+
+/**
+ * Planned surplus allocation.
+ */
+export interface PlannedSurplusAllocation {
+    /** Account ID */
+    accountId: string;
+    /** Amount allocated */
+    amount: number;
+    /** Reason for allocation */
+    reason: string;
+}
+
+/**
+ * Tax summary for the year.
+ */
+export interface YearPlanTax {
+    federal: number;
+    state: number;
+    fica: number;
+    capitalGainsLT: number;
+    capitalGainsST: number;
+    /** Tax on Roth earnings (5-year rule), Traditional withdrawals, HSA non-medical */
+    withdrawalOrdinaryTax: number;
+    niit: number;
+    penalties: number;
+    total: number;
+}
+
+/**
+ * Detailed breakdown of what's constraining Roth conversions for this year.
+ * Used for debugging why conversions aren't meeting targets.
+ */
+export interface ConversionConstraints {
+    /** Target bracket rate (e.g., 0.22 for 22%) */
+    bracketCeiling: number;
+    /** Dollar amount at top of target bracket */
+    bracketTop: number;
+    /** AGI before any conversion */
+    currentAGI: number;
+    /** Raw bracket space = bracketTop - currentAGI */
+    rawBracketSpace: number;
+    /** Amount lost to SS torpedo effect */
+    ssTorpedoReduction: number;
+    /** Amount lost to ACA cliff avoidance */
+    acaCliffReduction: number;
+    /** Final usable bracket space after all reductions */
+    effectiveBracketSpace: number;
+    /** Whether SS torpedo is affecting conversions */
+    ssTorpedoTriggered: boolean;
+    /** Whether ACA cliff avoidance is affecting conversions */
+    acaCliffTriggered: boolean;
+    /** Current MAGI for ACA calculation (if applicable) */
+    currentMAGI?: number;
+    /** ACA cliff threshold (if applicable) */
+    acaCliffThreshold?: number;
+    /** Brokerage gain ratio (unrealized gains / balance) — drives LTCG component of MAGI */
+    brokerageGainRatio?: number;
+}
+
+/**
+ * What caused the conversion limit to be reached this year.
+ */
+export type ConversionLimitingFactor =
+    | 'BRACKET_CEILING'       // Hit target tax bracket ceiling
+    | 'SS_TORPEDO'            // SS torpedo caused effective rate to spike
+    | 'ACA_CLIFF'             // ACA cliff avoidance limited conversion
+    | 'NO_BRACKET_SPACE'      // Already in or above target bracket
+    | 'TRADITIONAL_DEPLETED'  // No Traditional balance left to convert
+    | 'NOT_RETIRED'           // Not retired yet, no conversions
+    | 'OPTIMIZATION_DISABLED' // Tax optimization disabled in settings
+    | 'AT_RMD_AGE'            // At or past RMD age, no conversions
+    | 'SPENDING_DEFICIT';      // Bracket space shared with Traditional spending withdrawals
+
+/**
+ * One step in the rate-match walk (debug-only).
+ *
+ * The rate-match walk considers each bracket from std-ded headroom upward and
+ * decides whether to fill it. Each row records the inputs and decision so the
+ * Roth Debug page can reproduce the algorithm's reasoning.
+ */
+export interface RateMatchWalkRow {
+    /** Marginal rate of this chunk (0 for std-ded headroom, then bracket rates). */
+    currentRate: number;
+    /** Lower edge of this chunk's taxable-income window (post-stdDed). */
+    chunkStart: number;
+    /** Upper edge of this chunk's taxable-income window (post-stdDed). */
+    chunkEnd: number;
+    /** Dollars available in this chunk before the balance/cap clamp. */
+    chunkSize: number;
+    /** Projected RMD-year marginal rate if we convert up through this chunk. */
+    futureMarginal: number;
+    /** futureMarginal - currentRate (the rate gap). */
+    gap: number;
+    /** Decision: convert or stop. The first 'stop' row is the limiting factor. */
+    decision: 'convert' | 'stop';
+    /** Cumulative dollars converted including this chunk (only when decision='convert'). */
+    cumulative: number;
+}
+
+/**
+ * Tax optimization target information (for UI display).
+ * Calculated by the V2 solver to show the user what the engine is targeting.
+ */
+export interface TaxOptimizationTarget {
+    /** Years until RMD age */
+    yearsUntilRMD: number;
+    /** RMD start age */
+    rmdStartAge: number;
+    /** Top conversion rate the rate-match walk reached this year (e.g., 0.22) */
+    targetBracketCeiling: number;
+    /** Bracket space available this year */
+    bracketSpaceThisYear: number;
+    /** Projected SS at RMD age */
+    ssAtRMD: number;
+    /** Projected pension at RMD age */
+    pensionAtRMD: number;
+    /** Projected Traditional balance at RMD age given current conversion trajectory */
+    projectedBalanceAtRMD?: number;
+    /** What's limiting conversions this year */
+    limitingFactor?: ConversionLimitingFactor;
+    /** Detailed constraint breakdown for debugging */
+    constraintDetails?: ConversionConstraints;
+    /** Current Traditional balance at start of year */
+    currentTraditionalBalance?: number;
+    /** Actual conversion amount executed this year */
+    actualConversion?: number;
+    /** Bracket-by-bracket trace of the rate-match walk (for the Roth Debug page) */
+    rateMatchWalk?: RateMatchWalkRow[];
+}
+
+/**
+ * Complete plan for a simulation year (Phase 2 output).
+ *
+ * This is a PURE DATA STRUCTURE - no mutations, no side effects.
+ * Phase 3 uses this to execute changes on cloned accounts.
+ */
+export interface YearPlan {
+    /** Year being simulated */
+    year: number;
+
+    /** Whether this is a retirement year */
+    isRetired: boolean;
+
+    /** Classified income for the year */
+    income: ClassifiedIncome;
+
+    /** Planned withdrawals (includes RMDs) */
+    withdrawals: PlannedWithdrawal[];
+
+    /** Planned Roth conversion (null if none) */
+    conversion: PlannedConversion | null;
+
+    /** Planned contributions (working years) */
+    contributions: PlannedContribution[];
+
+    /** Planned surplus allocations */
+    surplusAllocations: PlannedSurplusAllocation[];
+
+    /** Amount allocated to pay down deficit debt from surplus */
+    deficitDebtPayment: number;
+
+    /** Tax summary */
+    tax: YearPlanTax;
+
+    /** Net surplus (positive) or unfunded deficit (negative) */
+    surplus: number;
+
+    /** Amount that couldn't be funded (when all accounts exhausted) */
+    unfundedDeficit: number;
+
+    /** Total living expenses for the year */
+    totalExpenses: number;
+
+    /** Spending strategy result (if applicable) */
+    strategyResult?: WithdrawalResult;
+
+    // Metadata
+
+    /** Number of solver iterations */
+    iterations: number;
+
+    /** Whether the solver converged */
+    converged: boolean;
+
+    /** Decision log */
+    decisions: DecisionLogEntry[];
+
+    /** Tax optimization target (for UI display) */
+    taxOptimizationTarget?: TaxOptimizationTarget;
+}
+
+/**
+ * Account balance snapshot for withdrawal planning.
+ */
+export interface AccountBalanceSnapshot {
+    accountId: string;
+    accountName: string;
+    accountType: WithdrawalAccountType;
+    balance: number;
+    vestedBalance: number;
+    /** For brokerage: unrealized gains / balance */
+    gainRatio: number;
+    /** For Roth: contribution basis available for tax-free withdrawal */
+    rothContributions?: number;
+    /** For Roth: conversion history for 5-year rule */
+    conversionHistory?: { year: number; amount: number }[];
+    /** For ESPP: pre-computed per-lot disposition data */
+    esppLots?: {
+        lotId: string;
+        shares: number;
+        currentValuePerShare: number;
+        purchasePricePerShare: number;
+        dispositionType: 'qualifying' | 'disqualifying';
+        ordinaryIncomePerShare: number;
+        ltcgPerShare: number;
+        totalValue: number;
+    }[];
+}
+
+/**
+ * Input for withdrawal planning.
+ */
+export interface WithdrawalPlannerInput {
+    /** Net amount needed after taxes */
+    netNeeded: number;
+    /** Ordered list of accounts to tap (in priority order) */
+    accountOrder: AccountBalanceSnapshot[];
+    /** Current age for penalty calculations */
+    currentAge: number;
+    /** Current year */
+    year: number;
+    /** Current ordinary income (for marginal rate calculation) */
+    currentOrdinaryIncome: number;
+    /** Filing status */
+    filingStatus: 'single' | 'married_filing_jointly' | 'married_filing_separately' | 'head_of_household';
+    /** Federal tax parameters */
+    fedParams: { brackets: { threshold: number; rate: number }[]; standardDeduction: number };
+    /** State tax parameters (null if no state tax) */
+    stateParams: { brackets: { threshold: number; rate: number }[]; standardDeduction: number } | null;
+}
+
+/**
+ * Result from income classification.
+ */
+export interface IncomeClassificationResult {
+    classified: ClassifiedIncome;
+    logs: string[];
+}


### PR DESCRIPTION
----------------------------------------------------------------------
   Scoped review of the simulation / tax core. ONLY the source files added in
   the diff are under review. The test files in this branch are a behavioral
   reference ONLY (not in the diff) and may be wrong or timezone-dependent: if
   source and a test disagree, flag it as a question, do not assume the test.

   This core has been through several prior scoped reviews. Recurring problem
   areas — each has actually bitten us, so give them extra scrutiny:

     1. Date-only / timezone handling (UNRESOLVED — please determine the correct
        convention). Date-only values are CREATED inconsistently: parseDate
        (modelUtils.ts) builds them at LOCAL midnight (new Date(y, m-1, d)), but
        many sites build them at UTC midnight via Date.UTC() (form defaults in
        AddExpenseModal / incomeFormTypes, pension + SS dates in IncomeProjection,
        ESPP in AccountGrowth). The reader functions are correspondingly split —
        some use getUTC*, some local. Empirically: in negative-offset (US) zones
        getUTC* reads BOTH constructions correctly and local breaks the
        Date.UTC-built ones; in positive-offset zones it flips and neither is
        universally right. The unit suite runs in UTC, so it structurally cannot
        catch any of this, and comments claiming "parseDate returns UTC" are
        stale. The real fix is a SINGLE convention for both creation and reads —
        please determine which, and which call sites are wrong.
     2. Social Security tax. Taxable SS double-counted in Roth-conversion sizing
        (provisional income); the three SS income classes are siblings, so a
        filter listing only two silently drops the third; SS-exempt-state logic.
     3. Duplicated logic that drifts. calculateStateTax vs
        calculateUnifiedStateTax applying deductions differently; duplicate RMD
        divisor tables; "recompute" paths that drift from the sim's actual values
        (e.g. employer match vs the 415(c)-trimmed deposit). Fix EVERY copy.
     4. Falsy-zero. '|| default' where 0 is a valid value (returnRate=0,
        costBasis, deductions, contributions) should be '?? default'.
     5. Persistence / migration. A deep-merge that copies only keys present in
        the DEFAULTS silently drops saved-only fields (e.g. imported SSA
        earnings) on reload.
     6. Roth conversion mechanics. IRS ordering (contributions -> oldest
        conversions -> earnings) and the 5-year clock; the ACA look-ahead and the
        main withdrawal loop must drain the SAME conversion list (no double-spend).
     7. Contribution / RMD modeling. 415(c) combined employee+employer cap; RMD
        basis (vested vs full balance); RMD divisor values at extreme ages.
     8. Gross-up sizing. Binary-search bounds, and omitting a tax component from
        the denominator (e.g. the ordinary bargain element on an ESPP sale).
     9. Sankey cash accounting. inflows must equal outflows; never count one
        dollar as both income and a withdrawal (RMD is the classic trap).
    10. Tax data tables. Year-specific figures (SS wage base, LTCG thresholds,
        brackets) copy-pasted from a prior year instead of the real value.

   Advice for this final pass:
     * Verify every suspected bug against the actual implementation / data flow,
       not a comment or a variable name — comments in this code have been wrong.
     * Green tests do NOT mean correct: the suite runs in UTC (hides date bugs)
       and some oracle values were written to match buggy behavior. A failing
       oracle test may mean the TEST is wrong — flag it rather than matching it.
     * Before flagging, confirm it is not intended behavior — some "overshoots"
       are deliberate and have a test asserting them.
     * Prefer deep fixes over special-cases; name the inputs/state that trigger
       each bug and the wrong output it produces.
   ----------------------------------------------------------------------