### PR TITLE
Scope: year solver + withdrawal/allocation core (source)

### DIFF
--- a/src/services/simulation/SpendingStrategy.ts
+++ b/src/services/simulation/SpendingStrategy.ts
@@ -1,0 +1,203 @@
+import { AnyExpense, MortgageExpense, LoanExpense } from "../../components/Objects/Expense/models";
+import { AnyIncome, WorkIncome } from "../../components/Objects/Income/models";
+import { AnyAccount, InvestedAccount, SavedAccount, ESPPAccount } from "../../components/Objects/Accounts/models";
+import { AssumptionsState, getRetirementAge, getLifeExpectancy, getBirthYear } from "../../components/Objects/Assumptions/AssumptionsContext";
+import { calculateStrategyWithdrawal, WithdrawalResult } from "../WithdrawalStrategies";
+import { SimulationYear } from "./types";
+
+export interface SpendingStrategyResult {
+    nextExpenses: AnyExpense[];
+    strategyWithdrawalResult: WithdrawalResult | undefined;
+    strategyAdjustmentResult: SimulationYear['strategyAdjustment'];
+    totalLivingExpenses: number;
+    discretionaryCash: number;
+    logs: string[];
+}
+
+/**
+ * Calculate total discretionary expenses.
+ */
+export function calculateTotalDiscretionary(expenses: AnyExpense[], year: number): number {
+    return expenses.reduce((sum, exp) => {
+        if (!exp.isDiscretionary) return sum;
+        if (exp instanceof MortgageExpense) {
+            return sum + exp.calculateAnnualAmortization(year).totalPayment;
+        }
+        if (exp instanceof LoanExpense) {
+            return sum + exp.calculateAnnualAmortization(year).totalPayment;
+        }
+        return sum + exp.getAnnualAmount(year);
+    }, 0);
+}
+
+/**
+ * Apply lifestyle creep to discretionary expenses during working years.
+ */
+export function applyLifestyleCreep(
+    expenses: AnyExpense[],
+    incomes: AnyIncome[],
+    assumptions: AssumptionsState,
+    year: number,
+    isRetired: boolean,
+    logs: string[]
+): AnyExpense[] {
+    if (isRetired || assumptions.expenses.lifestyleCreep <= 0) {
+        return expenses;
+    }
+
+    const salaryGrowthRate = assumptions.income.salaryGrowth / 100;
+    let totalRaise = 0;
+    for (const prevInc of incomes) {
+        if (prevInc instanceof WorkIncome) {
+            const realRaise = prevInc.getAnnualAmount() * salaryGrowthRate;
+            if (realRaise > 0) {
+                totalRaise += realRaise;
+            }
+        }
+    }
+
+    if (totalRaise <= 0) return expenses;
+
+    const lifestyleCreepAmount = totalRaise * (assumptions.expenses.lifestyleCreep / 100);
+    const discretionaryExpenses = expenses.filter(exp => exp.isDiscretionary);
+    const totalDiscretionary = discretionaryExpenses.reduce((sum, exp) => {
+        return sum + exp.getAnnualAmount(year);
+    }, 0);
+
+    if (totalDiscretionary <= 0 || lifestyleCreepAmount <= 0) return expenses;
+
+    const increaseRatio = 1 + (lifestyleCreepAmount / totalDiscretionary);
+    const result = expenses.map(exp => {
+        if (exp.isDiscretionary) {
+            return exp.adjustAmount(increaseRatio);
+        }
+        return exp;
+    });
+
+    logs.push(`[FLOW] Lifestyle creep: Salary raise of $${totalRaise.toLocaleString(undefined, { maximumFractionDigits: 0 })}/yr → Discretionary expenses increased by $${lifestyleCreepAmount.toLocaleString(undefined, { maximumFractionDigits: 0 })}/yr (${assumptions.expenses.lifestyleCreep}%)`);
+
+    return result;
+}
+
+/**
+ * Calculate withdrawal strategy target for all strategies (GK, Fixed Real, Percentage).
+ * Returns undefined for 'None' and 'Needs Based' strategies.
+ */
+export function calculateStrategyTarget(
+    accounts: AnyAccount[],
+    assumptions: AssumptionsState,
+    previousSimulation: SimulationYear[],
+    year: number,
+    currentAge: number,
+    logs: string[]
+): WithdrawalResult | undefined {
+    const strategy = assumptions.investments.withdrawalStrategy;
+
+    // No target for these strategies
+    if (strategy === 'None' || strategy === 'Needs Based') {
+        return undefined;
+    }
+
+    const totalInvestedAssets = accounts.reduce((sum, acc) => {
+        if (acc instanceof InvestedAccount || acc instanceof SavedAccount || acc instanceof ESPPAccount) {
+            return sum + acc.amount;
+        }
+        return sum;
+    }, 0);
+
+    const previousStrategyResult = previousSimulation.length > 0
+        ? previousSimulation[previousSimulation.length - 1].strategyWithdrawal
+        : undefined;
+
+    const retirementStartYear = getBirthYear(assumptions.milestones) + getRetirementAge(assumptions.milestones);
+    const yearsInRetirement = year - retirementStartYear;
+
+    // yearsRemaining only needed for GK 15-year rule
+    const yearsRemaining = strategy === 'Guyton Klinger'
+        ? getLifeExpectancy(assumptions.milestones) - currentAge
+        : undefined;
+
+    const result = calculateStrategyWithdrawal({
+        strategy,
+        withdrawalRate: assumptions.investments.withdrawalRate,
+        currentPortfolio: totalInvestedAssets,
+        inflationRate: assumptions.macro.inflationRate,
+        yearsInRetirement,
+        previousWithdrawal: previousStrategyResult,
+        // GK-specific params (ignored by other strategies)
+        gkUpperGuardrail: assumptions.investments.gkUpperGuardrail,
+        gkLowerGuardrail: assumptions.investments.gkLowerGuardrail,
+        gkAdjustmentPercent: assumptions.investments.gkAdjustmentPercent,
+        yearsRemaining,
+    });
+
+    logs.push(`[INFO] Retirement withdrawal strategy: ${strategy}`);
+    logs.push(`  Target withdrawal: $${result.amount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`);
+    logs.push(`  Portfolio value: $${totalInvestedAssets.toLocaleString(undefined, { maximumFractionDigits: 0 })}`);
+
+    const effectiveRate = totalInvestedAssets > 0 ? (result.amount / totalInvestedAssets) * 100 : 0;
+    logs.push(`  Effective rate: ${effectiveRate.toFixed(2)}%`);
+
+    if (result.guardrailTriggered !== 'none') {
+        if (result.guardrailTriggered === 'capital-preservation') {
+            logs.push(`[CUT] GK Capital Preservation triggered: withdrawal target reduced by ${assumptions.investments.gkAdjustmentPercent}%`);
+        } else if (result.guardrailTriggered === 'prosperity') {
+            logs.push(`[FLOW] GK Prosperity triggered: withdrawal target increased by ${assumptions.investments.gkAdjustmentPercent}%`);
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Increase discretionary expenses to match budget when budget > current expenses.
+ * Any surplus beyond discretionary goes to brokerage.
+ *
+ * This implements "prosperity spending" - when the withdrawal strategy budget
+ * exceeds current expenses, we increase discretionary spending up to the budget,
+ * and any remaining surplus is invested.
+ */
+export function applyProsperitySpending(
+    expenses: AnyExpense[],
+    currentTotalExpenses: number,
+    budgetTarget: number,
+    year: number,
+    logs: string[]
+): { adjustedExpenses: AnyExpense[]; surplusToInvest: number; prosperityApplied: boolean } {
+    // If budget doesn't exceed expenses, no prosperity to apply
+    if (budgetTarget <= currentTotalExpenses) {
+        return { adjustedExpenses: expenses, surplusToInvest: 0, prosperityApplied: false };
+    }
+
+    const surplus = budgetTarget - currentTotalExpenses;
+    const totalDiscretionary = calculateTotalDiscretionary(expenses, year);
+
+    // If no discretionary expenses, invest the entire surplus
+    if (totalDiscretionary <= 0) {
+        logs.push(`[FLOW] Prosperity: Budget $${budgetTarget.toLocaleString(undefined, { maximumFractionDigits: 0 })} exceeds expenses $${currentTotalExpenses.toLocaleString(undefined, { maximumFractionDigits: 0 })} by $${surplus.toLocaleString(undefined, { maximumFractionDigits: 0 })}, but no discretionary expenses to increase. Surplus will be invested.`);
+        return { adjustedExpenses: expenses, surplusToInvest: surplus, prosperityApplied: false };
+    }
+
+    // Calculate how much we can increase discretionary expenses
+    // Cap increase at 100% of current discretionary (doubling max)
+    const maxIncrease = totalDiscretionary; // Can double discretionary spending
+    const actualIncrease = Math.min(surplus, maxIncrease);
+    const surplusAfterIncrease = surplus - actualIncrease;
+
+    // Apply proportional increase to all discretionary expenses
+    const increaseRatio = 1 + (actualIncrease / totalDiscretionary);
+    const adjustedExpenses = expenses.map(exp => {
+        if (exp.isDiscretionary) {
+            return exp.adjustAmount(increaseRatio);
+        }
+        return exp;
+    });
+
+    logs.push(`[FLOW] Prosperity: Budget $${budgetTarget.toLocaleString(undefined, { maximumFractionDigits: 0 })} exceeds expenses $${currentTotalExpenses.toLocaleString(undefined, { maximumFractionDigits: 0 })} → discretionary increased by $${actualIncrease.toLocaleString(undefined, { maximumFractionDigits: 0 })} (${((increaseRatio - 1) * 100).toFixed(0)}%)`);
+
+    if (surplusAfterIncrease > 0) {
+        logs.push(`[FLOW] Remaining surplus of $${surplusAfterIncrease.toLocaleString(undefined, { maximumFractionDigits: 0 })} will be invested`);
+    }
+
+    return { adjustedExpenses, surplusToInvest: surplusAfterIncrease, prosperityApplied: true };
+}

--- a/src/services/simulation/SurplusAllocator.ts
+++ b/src/services/simulation/SurplusAllocator.ts
@@ -1,0 +1,390 @@
+/**
+ * SurplusAllocator.ts
+ *
+ * Handles surplus allocation after all expenses and taxes are covered.
+ *
+ * Surplus occurs when:
+ * - RMDs exceed spending needs
+ * - Pension + SS fully covers expenses
+ * - Working year with excess income
+ *
+ * Allocation Priority (reuses paycheck allocator logic):
+ * 1. Pay down DeficitDebt first (if any exists)
+ * 2. Follow user's priority bucket order
+ * 3. Any remaining: Brokerage (default catch-all)
+ */
+
+import { AnyAccount, SavedAccount, InvestedAccount, DeficitDebtAccount } from "../../components/Objects/Accounts/models";
+import { PlannedSurplusAllocation, DecisionLogEntry } from "./types";
+import { CapType } from "../../components/Objects/Assumptions/AssumptionsContext";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface SurplusAllocationResult {
+    allocations: PlannedSurplusAllocation[];
+    decisions: DecisionLogEntry[];
+    /** Amount allocated to pay down deficit debt */
+    deficitDebtPayment: number;
+    /** Amount that couldn't be allocated (shouldn't happen) */
+    unallocated: number;
+}
+
+export interface SurplusAllocationSettings {
+    /** Target emergency fund balance */
+    emergencyFundTarget: number;
+    /** Whether Roth IRA contributions are enabled in priority buckets */
+    rothIRAContributionEnabled: boolean;
+    /** Annual Roth IRA contribution limit */
+    rothIRALimit: number;
+    /** Amount already contributed to Roth IRA this year */
+    rothIRAContributedThisYear: number;
+    /** Monthly expenses (used for MULTIPLE_OF_EXPENSES cap type) */
+    monthlyExpenses?: number;
+    /**
+     * Accounts reserved for a dedicated purpose (goal sinking funds) that the
+     * smart-default path must never pick as a general savings target.
+     */
+    reservedAccountIds?: Set<string>;
+}
+
+// =============================================================================
+// MAIN FUNCTION
+// =============================================================================
+
+/**
+ * Allocate surplus cash according to priority rules.
+ *
+ * @param surplus - Amount of surplus cash to allocate
+ * @param accounts - All accounts (for finding targets)
+ * @param priorityBuckets - User's priority bucket order with cap settings
+ * @param earnedIncome - Earned income this year (for Roth IRA eligibility)
+ * @param settings - Allocation settings
+ * @returns Allocation plan
+ */
+export function allocateSurplus(
+    surplus: number,
+    accounts: AnyAccount[],
+    priorityBuckets: { accountId: string; priority: number; capType?: CapType; capValue?: number }[],
+    earnedIncome: number,
+    settings: SurplusAllocationSettings
+): SurplusAllocationResult {
+    const allocations: PlannedSurplusAllocation[] = [];
+    const decisions: DecisionLogEntry[] = [];
+    let remaining = surplus;
+    let deficitDebtPayment = 0;
+
+    if (surplus <= 0) {
+        return { allocations, decisions, deficitDebtPayment: 0, unallocated: 0 };
+    }
+
+    // 1. Pay down DeficitDebt first
+    const deficitDebt = accounts.find(a => a instanceof DeficitDebtAccount) as DeficitDebtAccount | undefined;
+    if (deficitDebt && deficitDebt.amount > 0) {
+        const payment = Math.min(remaining, deficitDebt.amount);
+        deficitDebtPayment = payment;
+        remaining -= payment;
+
+        allocations.push({
+            accountId: deficitDebt.id,
+            amount: payment,
+            reason: `Paying down deficit debt balance of $${deficitDebt.amount.toLocaleString()}`,
+        });
+
+        decisions.push({
+            category: 'surplus',
+            account: 'DeficitDebt',
+            amount: payment,
+            description: `Paid down $${payment.toLocaleString()} of deficit debt.`,
+        });
+
+        if (remaining <= 0) {
+            return { allocations, decisions, deficitDebtPayment, unallocated: 0 };
+        }
+    }
+
+    // 2. Follow priority bucket order (or use smart defaults if no priorities configured)
+    const sortedBuckets = [...priorityBuckets].sort((a, b) => a.priority - b.priority);
+
+    // If no explicit priorities, use smart defaults: Emergency → Roth IRA → Brokerage
+    if (sortedBuckets.length === 0) {
+        // 2a. Find and fill emergency fund (SavedAccount) to target — skipping
+        // reserved accounts (goal sinking funds), which are funded directly by
+        // the engine and must not absorb general surplus.
+        const emergencyFund = accounts.find(a =>
+            a instanceof SavedAccount && !settings.reservedAccountIds?.has(a.id)
+        ) as SavedAccount | undefined;
+        if (emergencyFund && emergencyFund.amount < settings.emergencyFundTarget) {
+            const gap = settings.emergencyFundTarget - emergencyFund.amount;
+            const toAdd = Math.min(remaining, gap);
+
+            if (toAdd > 0) {
+                allocations.push({
+                    accountId: emergencyFund.id,
+                    amount: toAdd,
+                    reason: `Emergency fund contribution (target: $${settings.emergencyFundTarget.toLocaleString()}, current: $${emergencyFund.amount.toLocaleString()})`,
+                });
+
+                decisions.push({
+                    category: 'surplus',
+                    account: emergencyFund.name,
+                    amount: toAdd,
+                    description: `Allocated $${toAdd.toLocaleString()} to emergency fund (${emergencyFund.name}).`,
+                });
+
+                remaining -= toAdd;
+            }
+        }
+
+        // 2b. Find and contribute to Roth IRA (if eligible)
+        if (remaining > 0 && settings.rothIRAContributionEnabled && earnedIncome > 0) {
+            const rothIRA = accounts.find(a =>
+                a instanceof InvestedAccount && a.taxType === 'Roth IRA'
+            ) as InvestedAccount | undefined;
+
+            if (rothIRA) {
+                const contributionRoom = Math.max(0, settings.rothIRALimit - settings.rothIRAContributedThisYear);
+                const maxContribution = Math.min(remaining, earnedIncome, contributionRoom);
+
+                if (maxContribution > 0) {
+                    allocations.push({
+                        accountId: rothIRA.id,
+                        amount: maxContribution,
+                        reason: `Roth IRA contribution (earned income: $${earnedIncome.toLocaleString()}, room: $${contributionRoom.toLocaleString()})`,
+                    });
+
+                    decisions.push({
+                        category: 'surplus',
+                        account: rothIRA.name,
+                        amount: maxContribution,
+                        description: `Contributed $${maxContribution.toLocaleString()} to Roth IRA.`,
+                    });
+
+                    remaining -= maxContribution;
+                }
+            }
+        }
+
+        // 2c. Put remainder in brokerage (handled by step 3 below)
+    }
+
+    // Running total of Roth IRA contributions across ALL buckets in this pass.
+    // settings.rothIRAContributedThisYear is a fixed snapshot (caller passes 0)
+    // and is never mutated, so without this accumulator each Roth IRA bucket
+    // would independently see the full annual limit as available room.
+    let rothIRAContributedSoFar = settings.rothIRAContributedThisYear ?? 0;
+
+    for (const bucket of sortedBuckets) {
+        if (remaining <= 0) break;
+
+        const account = accounts.find(a => a.id === bucket.accountId);
+        if (!account) continue;
+
+        // Determine cap for this bucket
+        const capType = bucket.capType ?? 'REMAINDER';
+        const capValue = bucket.capValue ?? 0;
+        let bucketCap: number;
+
+        switch (capType) {
+            case 'FIXED':
+                // capValue is monthly amount → annual
+                bucketCap = capValue * 12;
+                break;
+            case 'MAX':
+                // capValue is max annual allocation
+                bucketCap = capValue;
+                break;
+            case 'MULTIPLE_OF_EXPENSES': {
+                // capValue is number of months of expenses → desired END balance.
+                // Subtract not just the start-of-year balance but also surplus
+                // already routed to this account earlier in this pass, so we
+                // don't overshoot the target balance.
+                // NOTE: payroll/other same-year contributions applied elsewhere
+                // are NOT visible here; fully closing that gap would require the
+                // caller to pass a projected-contributions figure per account.
+                const alreadyAllocatedThisAccount = allocations
+                    .filter(a => a.accountId === account.id)
+                    .reduce((sum, a) => sum + a.amount, 0);
+                bucketCap = Math.max(0,
+                    (settings.monthlyExpenses ?? 0) * capValue
+                    - account.amount
+                    - alreadyAllocatedThisAccount
+                );
+                break;
+            }
+            case 'REMAINDER':
+            default:
+                bucketCap = Infinity;
+                break;
+        }
+
+        // Apply cap to what we can allocate from remaining surplus
+        const maxForBucket = Math.min(remaining, bucketCap);
+        if (maxForBucket <= 0) continue;
+
+        // Handle different account types
+        if (account instanceof SavedAccount) {
+            const toAdd = maxForBucket;
+
+            allocations.push({
+                accountId: account.id,
+                amount: toAdd,
+                reason: capType === 'REMAINDER'
+                    ? `Savings contribution (remainder)`
+                    : `Savings contribution (${capType} cap: $${bucketCap.toLocaleString()})`,
+            });
+
+            decisions.push({
+                category: 'surplus',
+                account: account.name,
+                amount: toAdd,
+                description: `Allocated $${toAdd.toLocaleString()} to savings (${account.name}).`,
+            });
+
+            remaining -= toAdd;
+        } else if (account instanceof InvestedAccount) {
+            // Check if it's a Roth IRA
+            if (account.taxType === 'Roth IRA') {
+                // Can only contribute if there's earned income
+                if (!settings.rothIRAContributionEnabled) {
+                    decisions.push({
+                        category: 'surplus',
+                        account: account.name,
+                        description: `Skipped Roth IRA contribution: contributions not enabled in settings.`,
+                    });
+                    continue;
+                }
+
+                if (earnedIncome <= 0) {
+                    decisions.push({
+                        category: 'surplus',
+                        account: account.name,
+                        description: `Skipped Roth IRA contribution: no earned income this year.`,
+                    });
+                    continue;
+                }
+
+                // Calculate available contribution room against the running
+                // total so multiple Roth IRA buckets share the per-person limit.
+                const contributionRoom = Math.max(0, settings.rothIRALimit - rothIRAContributedSoFar);
+                const maxContribution = Math.min(maxForBucket, earnedIncome, contributionRoom);
+
+                if (maxContribution > 0) {
+                    allocations.push({
+                        accountId: account.id,
+                        amount: maxContribution,
+                        reason: `Roth IRA contribution (earned income: $${earnedIncome.toLocaleString()}, room: $${contributionRoom.toLocaleString()})`,
+                    });
+
+                    decisions.push({
+                        category: 'surplus',
+                        account: account.name,
+                        amount: maxContribution,
+                        description: `Contributed $${maxContribution.toLocaleString()} to Roth IRA.`,
+                    });
+
+                    remaining -= maxContribution;
+                    rothIRAContributedSoFar += maxContribution;
+                } else if (contributionRoom <= 0) {
+                    decisions.push({
+                        category: 'surplus',
+                        account: account.name,
+                        description: `Skipped Roth IRA contribution: annual limit reached.`,
+                    });
+                }
+            } else if (account.taxType === 'Brokerage') {
+                // Brokerage - allocate up to cap (or all remaining for REMAINDER)
+                const toAdd = maxForBucket;
+
+                allocations.push({
+                    accountId: account.id,
+                    amount: toAdd,
+                    reason: capType === 'REMAINDER'
+                        ? `Brokerage investment (surplus remainder)`
+                        : `Brokerage investment (${capType} cap: $${bucketCap.toLocaleString()})`,
+                });
+
+                decisions.push({
+                    category: 'surplus',
+                    account: account.name,
+                    amount: toAdd,
+                    description: `Invested $${toAdd.toLocaleString()} surplus in brokerage.`,
+                });
+
+                remaining -= toAdd;
+            }
+            // Skip other account types (Traditional, etc.) for surplus allocation
+        }
+    }
+
+    // Collect account IDs already allocated via priority buckets so catch-all
+    // doesn't deposit additional surplus into a capped account.
+    const bucketAccountIds = new Set(sortedBuckets.map(b => b.accountId));
+
+    // 3. If there's still remaining surplus, find any brokerage account
+    //    (skip accounts already in a priority bucket)
+    if (remaining > 0) {
+        const brokerage = accounts.find(a =>
+            a instanceof InvestedAccount && a.taxType === 'Brokerage'
+            && !bucketAccountIds.has(a.id)
+        );
+
+        if (brokerage) {
+            allocations.push({
+                accountId: brokerage.id,
+                amount: remaining,
+                reason: `Brokerage investment (default catch-all)`,
+            });
+
+            decisions.push({
+                category: 'surplus',
+                account: brokerage.name,
+                amount: remaining,
+                description: `Invested remaining $${remaining.toLocaleString()} surplus in brokerage (default).`,
+            });
+
+            remaining = 0;
+        }
+    }
+
+    // 4. If STILL remaining (no brokerage account), find any savings account
+    //    (skip accounts already in a priority bucket, and reserved goal funds
+    //    which are funded directly by the engine)
+    if (remaining > 0) {
+        const savings = accounts.find(a => a instanceof SavedAccount
+            && !bucketAccountIds.has(a.id)
+            && !settings.reservedAccountIds?.has(a.id));
+
+        if (savings) {
+            allocations.push({
+                accountId: savings.id,
+                amount: remaining,
+                reason: `Savings (no brokerage available)`,
+            });
+
+            decisions.push({
+                category: 'surplus',
+                account: savings.name,
+                amount: remaining,
+                description: `Deposited remaining $${remaining.toLocaleString()} surplus in savings (no brokerage available).`,
+            });
+
+            remaining = 0;
+        }
+    }
+
+    // NOTE (review #2): surplus that exceeds every priority cap with no uncapped
+    // destination is intentionally NOT force-deposited. A cap paces how much of
+    // income is *saved*; the remainder is discretionary spending, not lost wealth
+    // (force-filling a capped bucket would break FIXED/MAX caps and sinking-fund
+    // reservations — see GoalSinkingFund). It is surfaced as `unallocated` below.
+    const result = {
+        allocations,
+        decisions,
+        deficitDebtPayment,
+        unallocated: remaining,
+    };
+    return result;
+}
+

--- a/src/services/simulation/TaxOptimizedWithdrawal.ts
+++ b/src/services/simulation/TaxOptimizedWithdrawal.ts
@@ -1,0 +1,1058 @@
+/**
+ * Tax-Optimized Withdrawal and Roth Conversion Service
+ *
+ * Implements the tax optimization strategy described in TAX_OPTIMIZATION_IMPLEMENTATION.md.
+ * Key features:
+ * - Dynamic conversion ceiling based on projected RMD bracket
+ * - Target Traditional balance to keep RMDs in low brackets
+ * - SS torpedo and LTCG bump zone awareness
+ * - Four-phase withdrawal logic with survival spending priority
+ */
+
+import { TaxParameters, FilingStatus } from '../../data/TaxData';
+import * as TaxService from '../../components/Objects/Taxes/TaxService';
+import { TaxState } from '../../components/Objects/Taxes/TaxContext';
+import { AssumptionsState, getBirthYear } from '../../components/Objects/Assumptions/AssumptionsContext';
+import { calculateEffectiveConversionTax, ACAOptions } from './helpers';
+import { getDistributionPeriod } from '../../data/RMDData';
+import { BaselineProjections, RateMatchWalkRow } from './types';
+
+// Re-export for convenience
+export type { TaxParameters, FilingStatus, TaxState };
+
+// =============================================================================
+// TYPE DEFINITIONS
+// =============================================================================
+
+/**
+ * Which phase of retirement we're in
+ */
+export type Phase =
+    | 'BROKERAGE_AVAILABLE'    // Brokerage covers spending; conversions get full bracket space
+    | 'BROKERAGE_TRANSITION'   // Brokerage running low (0.5-2 years); reduce conversion aggressiveness
+    | 'BROKERAGE_DEPLETED'     // No brokerage; survival spending has first claim on bracket space
+    | 'ROTH_DEPLETED';         // No Roth either; Traditional is primary source, no conversions
+
+/**
+ * How conversion taxes will be funded
+ */
+export type TaxPaymentSource = 'BROKERAGE' | 'SAVINGS' | 'WITHHOLD' | 'NONE';
+
+/**
+ * What caused the effective rate limit to be reached
+ */
+export type EdgeType =
+    | 'SS_TORPEDO'        // Social Security taxation caused >25% rate jump
+    | 'LTCG_BUMP'         // Long-term capital gains pushed from 0% to 15%
+    | 'BRACKET_EDGE'      // Normal tax bracket boundary
+    | 'ALREADY_AT_CEILING'; // Already at or above target rate at zero conversion
+
+/**
+ * Result of calculating how much can be converted before exceeding target effective rate
+ */
+export interface EffectiveRateLimitResult {
+    /** Maximum conversion amount before exceeding target rate */
+    maxConversion: number;
+
+    /** The effective marginal rate at the max conversion amount */
+    effectiveRateAtMax: number;
+
+    /** The nominal tax bracket at the max conversion amount */
+    bracketAtMax: number;
+
+    /** What caused the limit (SS torpedo, LTCG bump, or bracket edge) */
+    edgeType: EdgeType | null;
+}
+
+/**
+ * Result of dynamic conversion ceiling calculation
+ */
+export interface ConversionCeilingResult {
+    /** The tax bracket rate to convert up to (e.g., 0.22 for 22%) */
+    conversionCeiling: number;
+
+    /** Bracket space available per year up to the ceiling */
+    bracketSpacePerYear: number;
+
+    /** What Traditional balance will realistically be at RMD age */
+    projectedBalanceAtRMD: number;
+
+    /** What bracket RMDs will land in given projected balance */
+    projectedRMDBracket: number;
+
+    /** Peak mid-retirement RMD amount (balance / 15) used to select ceiling */
+    peakRMD: number;
+
+    /** Tax bracket the peak RMD lands in — this is what drives ceiling selection */
+    peakRMDBracket: number;
+
+    /** Bracket-by-bracket trace of the rate-match walk (for the Roth Debug page) */
+    rateMatchWalk?: RateMatchWalkRow[];
+}
+
+/**
+ * Result of coarse-to-fine search for max conversion amount
+ */
+export interface CoarseToFineSearchResult {
+    /** Maximum conversion amount before exceeding target rate */
+    amount: number;
+
+    /** Whether the search converged within tolerance */
+    converged: boolean;
+
+    /** Type of edge that caused the limit (null if no limit reached) */
+    edgeType: EdgeType | null;
+}
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/**
+ * Configuration for coarse-to-fine search algorithm
+ */
+export const SEARCH_CONFIG = {
+    /** Coarse scan increment for initial sweep */
+    coarseStep: 5_000,
+
+    /** Minimum step size for fine binary search */
+    fineMinStep: 100,
+
+    /** Maximum iterations for binary search */
+    maxIterations: 50,
+
+    /** Tolerance for rate matching (±0.25%) */
+    epsilon: 0.0025,
+
+    /** Maximum conversion amount to consider (practical limit) */
+    maxConversionCap: 500_000,
+} as const;
+
+/**
+ * Maximum bracket for Roth conversions.
+ * We cap at 32% because prepaying 35%+ tax on conversions is rarely beneficial.
+ */
+export const MAX_CONVERSION_BRACKET = 0.32;
+
+/**
+ * Get bracket progression from tax parameters, capped at MAX_CONVERSION_BRACKET.
+ * We cap at 32% because prepaying 35%+ tax on conversions is rarely beneficial.
+ */
+export function getBracketProgression(taxParams: TaxParameters): number[] {
+    return taxParams.brackets
+        .map(b => b.rate)
+        .filter(rate => rate <= MAX_CONVERSION_BRACKET);
+}
+
+/**
+ * Get the RMD divisor for a given age.
+ *
+ * Delegates to the canonical IRS Uniform Lifetime Table in RMDData
+ * (getDistributionPeriod), which covers ages 72-120 accurately, instead of
+ * keeping a duplicate truncated table with an inaccurate >95 extrapolation.
+ * The "no RMD before 72 -> 0" sentinel is preserved here because RMDData's
+ * getDistributionPeriod returns the age-72 factor for ages < 72.
+ *
+ * @param age - Age at end of year
+ * @returns RMD divisor (distribution period), or 0 if no RMD applies
+ */
+export function getRMDDivisor(age: number): number {
+    if (age < 72) return 0; // No RMD before 72
+    return getDistributionPeriod(age);
+}
+
+// =============================================================================
+// HELPER FUNCTIONS
+// =============================================================================
+
+/**
+ * Get the damping factor for conversion calculations based on years until RMD.
+ * More aggressive (higher %) when time is short, conservative when time is long.
+ *
+ * @param yearsUntilRMD - Years remaining until Required Minimum Distributions start
+ * @returns Damping factor between 0.15 and 0.50
+ */
+export function getDampingFactor(yearsUntilRMD: number): number {
+    if (yearsUntilRMD >= 15) return 0.15;  // Very conservative when lots of time
+    if (yearsUntilRMD >= 10) return 0.20;
+    if (yearsUntilRMD >= 7) return 0.25;
+    if (yearsUntilRMD >= 5) return 0.30;
+    if (yearsUntilRMD >= 3) return 0.40;
+    return 0.50;  // Aggressive when time is very short
+}
+
+/**
+ * Get the ACA subsidy cliff threshold (400% FPL) for a given year and filing status.
+ * Values should be updated annually when FPL is published (typically January).
+ *
+ * @param filingStatus - 'single' or 'married_filing_jointly'
+ * @param year - The tax year
+ * @returns The income threshold where ACA subsidies phase out completely
+ */
+export function getAcaCliffThreshold(
+    filingStatus: 'single' | 'married_filing_jointly',
+    year: number
+): number {
+    // Base FPL values by year (update annually when published)
+    // 400% FPL = threshold where ACA subsidies phase out completely
+    const FPL_BASE: Record<number, { single: number; couple: number }> = {
+        2024: { single: 15_060, couple: 20_440 },
+        2025: { single: 15_650, couple: 21_150 },  // Estimated
+        2026: { single: 16_100, couple: 21_750 },  // Estimated ~3% inflation
+    };
+
+    // Use most recent known year if future year requested
+    const knownYears = Object.keys(FPL_BASE).map(Number).sort((a, b) => b - a);
+    const useYear = knownYears.find(y => y <= year) ?? knownYears[knownYears.length - 1];
+    const fpl = FPL_BASE[useYear];
+
+    const baseFPL = filingStatus === 'single' ? fpl.single : fpl.couple;
+
+    // 400% FPL is the cliff
+    return baseFPL * 4;
+}
+
+/**
+ * Get the effective MARGINAL tax rate for a conversion at a given amount.
+ * Calculates (total cost at amount+1 - total cost at amount) to get the marginal rate.
+ *
+ * This properly handles SS torpedo, LTCG bump, NIIT, state tax, and ACA cliff.
+ * Uses taxIncrease (which includes federal + state + ACA) not just taxAfter (federal only).
+ *
+ * Production reaches this through coarseToFineSearch; the export exists so unit
+ * tests can probe marginal-rate math directly (SS torpedo, ACA cliff, state
+ * stacking) without going through the opaque search wrapper.
+ *
+ * @public
+ */
+export function getEffectiveConversionRate(
+    conversionAmount: number,
+    ordinaryIncome: number,
+    ltcgIncome: number,
+    socialSecurity: number,
+    taxParams: TaxParameters,
+    taxState: TaxState,
+    _year: number,
+    stateParams: TaxParameters | null,
+    acaOptions?: ACAOptions
+): number {
+    // Calculate total cost of converting conversionAmount
+    // taxIncrease includes federal tax increase + state tax + ACA subsidy loss
+    const resultAtAmount = calculateEffectiveConversionTax(
+        ordinaryIncome,
+        socialSecurity,
+        ltcgIncome,
+        Math.max(0, conversionAmount),
+        taxState.filingStatus,
+        taxParams,
+        stateParams,
+        acaOptions
+    );
+
+    // Calculate total cost of converting conversionAmount + $1
+    const resultAtAmountPlus1 = calculateEffectiveConversionTax(
+        ordinaryIncome,
+        socialSecurity,
+        ltcgIncome,
+        Math.max(0, conversionAmount) + 1,
+        taxState.filingStatus,
+        taxParams,
+        stateParams,
+        acaOptions
+    );
+
+    // Marginal rate = difference in total cost for $1 more conversion
+    // taxIncrease is the cost of converting that amount vs not converting at all
+    // So the difference gives us the marginal cost of the last $1
+    return resultAtAmountPlus1.taxIncrease - resultAtAmount.taxIncrease;
+}
+
+/**
+ * Coarse-to-fine search for maximum conversion amount before exceeding target effective rate.
+ *
+ * Pure binary search fails on plateaus and discontinuities (SS torpedo, LTCG bump zones).
+ * This algorithm:
+ * 1. Coarse scan in $5k increments to find the edge
+ * 2. Identify edge type based on rate jump magnitude
+ * 3. Fine binary search within the identified window
+ * 4. Return conservative lower bound
+ *
+ * @param targetRate - Target effective tax rate to stay under (e.g., 0.22 for 22%)
+ * @param traditionalBalance - Available Traditional IRA/401k balance
+ * @param currentAGI - Current AGI before conversion (gross income)
+ * @param socialSecurity - Annual Social Security benefits
+ * @param ltcgIncome - Long-term capital gains income
+ * @param taxParams - Federal tax parameters
+ * @param taxState - Tax state (filing status, etc.)
+ * @param year - Tax year
+ * @param stateParams - State tax parameters (null if no state tax)
+ * @param acaOptions - ACA subsidy awareness options (undefined if not applicable)
+ * @param assumptions - Optional assumptions for inflation adjustments
+ * @returns Search result with amount, convergence status, and edge type
+ */
+export function coarseToFineSearch(
+    targetRate: number,
+    traditionalBalance: number,
+    currentAGI: number,
+    socialSecurity: number,
+    ltcgIncome: number,
+    taxParams: TaxParameters,
+    taxState: TaxState,
+    year: number,
+    stateParams: TaxParameters | null,
+    acaOptions: ACAOptions | undefined,
+    _assumptions?: AssumptionsState,  // Reserved for future inflation adjustments
+    _debugLabel?: string  // For debug logging
+): CoarseToFineSearchResult {
+    const maxAmount = Math.min(traditionalBalance, SEARCH_CONFIG.maxConversionCap);
+
+    // EDGE CASE: Check if we're already above target rate at zero conversion
+    const rateAtZero = getEffectiveConversionRate(
+        0,
+        currentAGI,
+        ltcgIncome,
+        socialSecurity,
+        taxParams,
+        taxState,
+        year,
+        stateParams,
+        acaOptions
+    );
+
+
+    if (rateAtZero > targetRate + SEARCH_CONFIG.epsilon) {
+        // Already ABOVE target rate from other income - cannot convert anything
+        // Note: if rateAtZero ≈ targetRate (within epsilon), we're IN the target bracket
+        // and can still convert up to the top of that bracket
+        return { amount: 0, converged: true, edgeType: 'ALREADY_AT_CEILING' };
+    }
+
+    // PHASE 1: Coarse scan to find the bracket edge
+    let edgeFound = false;
+    let edgeLow = 0;
+    let edgeHigh = 0;
+    let edgeType: EdgeType | null = null;
+
+    // Special case: Check ACA cliff threshold specifically since coarse step might jump over it
+    // The cliff creates a rate spike at exactly the crossing point
+    if (acaOptions && acaOptions.acaSubsidyAware && acaOptions.currentAge < 65) {
+        const cliffConversion = Math.max(0, acaOptions.acaCliffThreshold - currentAGI);
+        if (cliffConversion > 0 && cliffConversion <= maxAmount) {
+            // Check rate just before and at the cliff
+            const rateBeforeCliff = getEffectiveConversionRate(
+                cliffConversion - 1,
+                currentAGI,
+                ltcgIncome,
+                socialSecurity,
+                taxParams,
+                taxState,
+                year,
+                stateParams,
+                acaOptions
+            );
+            if (rateBeforeCliff > targetRate) {
+                // Already over target before cliff
+                edgeFound = true;
+                edgeLow = 0;
+                edgeHigh = cliffConversion - 1;
+                edgeType = 'BRACKET_EDGE';
+            } else {
+                // Check if the cliff crossing exceeds target
+                const rateAtCliff = getEffectiveConversionRate(
+                    cliffConversion,
+                    currentAGI,
+                    ltcgIncome,
+                    socialSecurity,
+                    taxParams,
+                    taxState,
+                    year,
+                    stateParams,
+                    acaOptions
+                );
+                // The cliff causes a massive spike at exactly cliffConversion - 1
+                // (because converting $1 more would cross the cliff)
+                if (rateAtCliff > targetRate || rateAtCliff >= 1.0) {
+                    // Cliff crossing would exceed target - cap at cliff - 1
+                    return {
+                        amount: Math.max(0, cliffConversion - 1),
+                        converged: true,
+                        edgeType: 'BRACKET_EDGE'
+                    };
+                }
+            }
+        }
+    }
+
+    for (let amount = 0; amount <= maxAmount; amount += SEARCH_CONFIG.coarseStep) {
+        const rate = getEffectiveConversionRate(
+            amount,
+            currentAGI,
+            ltcgIncome,
+            socialSecurity,
+            taxParams,
+            taxState,
+            year,
+            stateParams,
+            acaOptions
+        );
+
+        // Use epsilon tolerance to avoid numerical precision issues
+        // We want to find where rate CLEARLY exceeds target, not just barely
+        if (rate > targetRate + SEARCH_CONFIG.epsilon) {
+            // Found the edge - it's somewhere in the previous $5k window
+            edgeFound = true;
+            edgeLow = Math.max(0, amount - SEARCH_CONFIG.coarseStep);
+            edgeHigh = amount;
+
+            // Identify edge type for logging based on rate jump magnitude
+            const rateBefore = getEffectiveConversionRate(
+                edgeLow,
+                currentAGI,
+                ltcgIncome,
+                socialSecurity,
+                taxParams,
+                taxState,
+                year,
+                stateParams,
+                acaOptions
+            );
+            const rateJump = rate - rateBefore;
+
+            // Thresholds based on actual discontinuity magnitudes:
+            // - SS torpedo: Can cause 40%+ effective rates (jump of 25%+)
+            // - LTCG bump: 0% to 15% LTCG rate (jump of ~12-15%)
+            // - Bracket edge: Normal bracket transitions (10-12% jumps max)
+            if (rateJump > 0.25) {
+                edgeType = 'SS_TORPEDO';
+            } else if (rateJump > 0.12) {
+                edgeType = 'LTCG_BUMP';
+            } else {
+                edgeType = 'BRACKET_EDGE';
+            }
+            break;
+        }
+    }
+
+    if (!edgeFound) {
+        // Never exceeded target rate - can convert everything
+        return { amount: maxAmount, converged: true, edgeType: null };
+    }
+
+    // PHASE 2: Fine binary search within the identified window
+    let low = edgeLow;
+    let high = edgeHigh;
+    let iterations = 0;
+
+    while (high - low > SEARCH_CONFIG.fineMinStep &&
+           iterations < SEARCH_CONFIG.maxIterations) {
+        const mid = Math.floor((low + high) / 2);
+        const rate = getEffectiveConversionRate(
+            mid,
+            currentAGI,
+            ltcgIncome,
+            socialSecurity,
+            taxParams,
+            taxState,
+            year,
+            stateParams,
+            acaOptions
+        );
+
+        // We want to find the MAXIMUM conversion where rate <= target
+        // When rate ≈ target (within epsilon), it's still valid, so search higher
+        // Only search lower when rate clearly exceeds target
+        if (rate <= targetRate + SEARCH_CONFIG.epsilon) {
+            low = mid;  // Valid amount, search higher for max
+        } else {
+            high = mid;  // Too high, search lower
+        }
+        iterations++;
+    }
+
+    // Return conservative lower bound
+    return {
+        amount: low,
+        converged: iterations < SEARCH_CONFIG.maxIterations,
+        edgeType
+    };
+}
+
+/**
+ * Calculate how much can be converted before effective marginal rate exceeds a target rate.
+ *
+ * Uses coarse-to-fine search to handle the complexities of the SS tax torpedo
+ * (effective rates can be much higher than nominal brackets) and other
+ * discontinuities like LTCG bump zones.
+ *
+ * Properly handles SS torpedo, LTCG bump, NIIT, state tax, and ACA cliff
+ * via calculateEffectiveConversionTax.
+ *
+ * @param currentAGI - AGI before conversion (gross income)
+ * @param socialSecurityBenefits - Total SS benefits
+ * @param ltcgIncome - Long-term capital gains (for bump zone detection)
+ * @param targetEffectiveRate - Stop when effective rate exceeds this
+ * @param traditionalBalance - Available Traditional IRA/401k balance
+ * @param taxParams - Federal tax parameters
+ * @param taxState - Tax state (filing status, etc.)
+ * @param year - Tax year
+ * @param stateParams - State tax parameters (null if no state tax)
+ * @param acaOptions - ACA subsidy awareness options (undefined if not applicable)
+ * @param assumptions - Optional assumptions for inflation adjustments
+ * @returns Result with maxConversion, effectiveRateAtMax, bracketAtMax, and edgeType
+ *
+ * Test-only entry point. Production calls coarseToFineSearch directly; this
+ * wrapper exists so Bug-C/D regression tests and the refactor-sanity suite
+ * can probe the search at a single point with a target effective rate.
+ *
+ * @public
+ */
+export function calculateEffectiveRateConversionLimit(
+    currentAGI: number,
+    socialSecurityBenefits: number,
+    ltcgIncome: number,
+    targetEffectiveRate: number,
+    traditionalBalance: number,
+    taxParams: TaxParameters,
+    taxState: TaxState,
+    year: number,
+    stateParams: TaxParameters | null,
+    acaOptions: ACAOptions | undefined,
+    assumptions?: AssumptionsState
+): EffectiveRateLimitResult {
+    // Use coarse-to-fine search to find max conversion staying below target effective rate
+    const searchResult = coarseToFineSearch(
+        targetEffectiveRate,
+        traditionalBalance,
+        currentAGI,
+        socialSecurityBenefits,
+        ltcgIncome,
+        taxParams,
+        taxState,
+        year,
+        stateParams,
+        acaOptions,
+        assumptions
+    );
+
+    // Calculate the effective rate at the found amount
+    const effectiveRateAtMax = getEffectiveConversionRate(
+        searchResult.amount,
+        currentAGI,
+        ltcgIncome,
+        socialSecurityBenefits,
+        taxParams,
+        taxState,
+        year,
+        stateParams,
+        acaOptions
+    );
+
+    // Find nominal bracket at the conversion amount
+    // Approximate by looking at total income
+    const totalIncome = currentAGI + searchResult.amount;
+    const taxableAtMax = Math.max(0, totalIncome - taxParams.standardDeduction);
+    let bracketAtMax = 0;
+    for (const bracket of taxParams.brackets) {
+        if (taxableAtMax >= bracket.threshold) {
+            bracketAtMax = bracket.rate;
+        }
+    }
+
+    return {
+        maxConversion: searchResult.amount,
+        effectiveRateAtMax,
+        bracketAtMax,
+        edgeType: searchResult.edgeType
+    };
+}
+
+/**
+ * Result of rate-matched conversion calculation.
+ */
+export interface RateMatchedConversion {
+    /** Total dollars to convert this year */
+    optimalConversion: number;
+    /** Marginal rate of the last bracket converted into (e.g., 0.12 if conversion stopped after filling 12%) */
+    topConversionRate: number;
+    /** Projected future marginal rate after this conversion (used to compute the gap that stopped us) */
+    futureMarginalAtStop: number;
+    /** Why we stopped converting */
+    stopReason: 'gap-closed' | 'no-balance' | 'no-future-tax';
+    /** Bracket-by-bracket walk trace (for the Roth Debug page). */
+    walk: RateMatchWalkRow[];
+}
+
+/**
+ * Compute the optimal Roth conversion for a single year using direct rate-match.
+ *
+ * The principle: a dollar is worth converting today only if today's marginal rate
+ * is meaningfully lower than the rate it'd be taxed at when withdrawn from Trad
+ * later (as RMD). For each chunk of conversion (std-ded headroom, then each
+ * federal bracket), compute:
+ *   - current_marginal_rate: rate of the bracket this chunk would be taxed at
+ *   - future_marginal_rate: rate the LAST RMD dollar would face if we converted
+ *     up through this chunk and stopped (depends on remaining Trad balance)
+ *
+ * Convert the chunk if (future − current) ≥ minimumRateGap. Stop otherwise.
+ *
+ * Compared to bracket-fill ceilings: this naturally adapts to the actual
+ * rate-arbitrage available. Heavy conversions when future is much higher than
+ * current; tapers off automatically as remaining Trad shrinks and future rate
+ * drops with it.
+ *
+ * Limitations (handled downstream by SS-torpedo / ACA / LTCG-bump logic):
+ *   - Doesn't model SS-taxability bumps mid-conversion
+ *   - Doesn't model LTCG bracket stacking
+ *   - Doesn't model ACA cliff
+ * The conversion amount returned here is the rate-arbitrage optimum; downstream
+ * coarseToFineSearch can reduce it further to avoid those discontinuities.
+ */
+export function computeRateMatchedConversion(
+    currentTraditionalBalance: number,
+    yearsUntilRMD: number,
+    pensionIncomeAtRMD: number,
+    ssAtRMD: number,
+    passiveIncomeAtRMD: number,
+    currentAGI: number,
+    growthRate: number,
+    currentTaxParams: TaxParameters,
+    rmdYearTaxParams: TaxParameters,
+    taxState: TaxState,
+    minimumRateGap: number = 0.05,
+    projectedTradAtRMD?: number
+): RateMatchedConversion {
+    const walk: RateMatchWalkRow[] = [];
+
+    if (currentTraditionalBalance <= 0 || yearsUntilRMD <= 0) {
+        return {
+            optimalConversion: 0,
+            topConversionRate: 0,
+            futureMarginalAtStop: 0,
+            stopReason: 'no-balance',
+            walk,
+        };
+    }
+
+    const PEAK_RMD_DIVISOR = 15;
+    const stdDed = currentTaxParams.standardDeduction;
+    const growthFactor = Math.pow(1 + growthRate, yearsUntilRMD);
+    // Baseline projected Traditional balance at RMD age. When the caller supplies a
+    // sub-sim-derived value, use it as a fixed target (independent of how much we
+    // convert this year). Fallback: naive forward-compound of today's balance —
+    // matches the legacy algebra so existing tests stay green.
+    const baselineProjectedTrad = projectedTradAtRMD ?? currentTraditionalBalance * growthFactor;
+
+    // Helper: project future marginal rate given dollars converted in the current year.
+    // balanceAtRMD = baseline projected balance MINUS the conversion compounded forward.
+    const futureMarginalAt = (convertedSoFar: number): number => {
+        const balanceAtRMD = Math.max(0, baselineProjectedTrad - convertedSoFar * growthFactor);
+        if (balanceAtRMD <= 0) return 0;
+        const projectedRMD = balanceAtRMD / PEAK_RMD_DIVISOR;
+        const projectedTaxableSS = TaxService.getTaxableSocialSecurityBenefits(
+            ssAtRMD,
+            projectedRMD + pensionIncomeAtRMD + passiveIncomeAtRMD,
+            0,
+            taxState.filingStatus
+        );
+        const projectedTaxableIncome =
+            projectedRMD + pensionIncomeAtRMD + passiveIncomeAtRMD + projectedTaxableSS - rmdYearTaxParams.standardDeduction;
+        return TaxService.getMarginalTaxRate(Math.max(0, projectedTaxableIncome), rmdYearTaxParams).rate;
+    };
+
+    let totalConverted = 0;
+    let topRate = 0;
+
+    // Chunk 0: std-ded headroom (effectively 0% rate). Conversion that just fills
+    // standard deduction produces no taxable income → no current tax → always
+    // worth doing if there's any future tax to dodge.
+    const stdDedHeadroom = Math.max(0, stdDed - currentAGI);
+    if (stdDedHeadroom > 0) {
+        const chunkSize = Math.min(stdDedHeadroom, currentTraditionalBalance - totalConverted);
+        if (chunkSize > 0) {
+            const futureMarginal = futureMarginalAt(totalConverted + chunkSize);
+            const gap = futureMarginal; // currentRate is 0
+            // For free conversions (current rate = 0), gap is just the future rate. Always convert
+            // if future rate is at least the threshold (otherwise we're paying nothing now to
+            // dodge nothing later).
+            if (futureMarginal >= minimumRateGap) {
+                totalConverted += chunkSize;
+                topRate = 0;
+                walk.push({
+                    currentRate: 0,
+                    chunkStart: -stdDedHeadroom,
+                    chunkEnd: 0,
+                    chunkSize,
+                    futureMarginal,
+                    gap,
+                    decision: 'convert',
+                    cumulative: totalConverted,
+                });
+            } else {
+                walk.push({
+                    currentRate: 0,
+                    chunkStart: -stdDedHeadroom,
+                    chunkEnd: 0,
+                    chunkSize,
+                    futureMarginal,
+                    gap,
+                    decision: 'stop',
+                    cumulative: totalConverted,
+                });
+                return {
+                    optimalConversion: totalConverted,
+                    topConversionRate: topRate,
+                    futureMarginalAtStop: futureMarginal,
+                    stopReason: futureMarginal === 0 ? 'no-future-tax' : 'gap-closed',
+                    walk,
+                };
+            }
+        }
+    }
+
+    // Subsequent chunks: walk through federal brackets from current taxable position
+    // upward. Position in the bracket structure = currentAGI - stdDed + (totalConverted - stdDedHeadroom)
+    // — i.e., the post-stdDed taxable income after our conversions so far.
+    const sortedBrackets = [...currentTaxParams.brackets].sort((a, b) => a.threshold - b.threshold);
+
+    for (let i = 0; i < sortedBrackets.length; i++) {
+        if (currentTraditionalBalance - totalConverted <= 0) {
+            return {
+                optimalConversion: totalConverted,
+                topConversionRate: topRate,
+                futureMarginalAtStop: futureMarginalAt(currentTraditionalBalance),
+                stopReason: 'no-balance',
+                walk,
+            };
+        }
+
+        const bracket = sortedBrackets[i];
+        const nextBracket = sortedBrackets[i + 1];
+        const bracketTop = nextBracket ? nextBracket.threshold : Infinity;
+
+        // Current taxable position (post-stdDed) after conversions so far
+        const currentTaxablePos = Math.max(0, currentAGI + totalConverted - stdDed);
+
+        if (currentTaxablePos >= bracketTop) continue; // already past this bracket
+
+        const chunkStart = Math.max(currentTaxablePos, bracket.threshold);
+        const chunkSizeInBracket = bracketTop - chunkStart;
+        if (chunkSizeInBracket <= 0) continue;
+
+        const chunkSize = Math.min(chunkSizeInBracket, currentTraditionalBalance - totalConverted);
+        if (chunkSize <= 0) continue;
+
+        const currentMarginal = bracket.rate;
+        const futureMarginal = futureMarginalAt(totalConverted + chunkSize);
+
+        const gap = futureMarginal - currentMarginal;
+        if (gap < minimumRateGap) {
+            walk.push({
+                currentRate: currentMarginal,
+                chunkStart,
+                chunkEnd: chunkStart + chunkSize,
+                chunkSize,
+                futureMarginal,
+                gap,
+                decision: 'stop',
+                cumulative: totalConverted,
+            });
+            return {
+                optimalConversion: totalConverted,
+                topConversionRate: topRate,
+                futureMarginalAtStop: futureMarginal,
+                stopReason: 'gap-closed',
+                walk,
+            };
+        }
+
+        totalConverted += chunkSize;
+        topRate = currentMarginal;
+        walk.push({
+            currentRate: currentMarginal,
+            chunkStart,
+            chunkEnd: chunkStart + chunkSize,
+            chunkSize,
+            futureMarginal,
+            gap,
+            decision: 'convert',
+            cumulative: totalConverted,
+        });
+    }
+
+    return {
+        optimalConversion: totalConverted,
+        topConversionRate: topRate,
+        futureMarginalAtStop: futureMarginalAt(totalConverted),
+        stopReason: 'no-balance',
+        walk,
+    };
+}
+
+/**
+ * Project what Traditional balance will be at RMD age given a conversion rate.
+ *
+ * For each year: balance = balance × (1 + growthRate) - annualConversionAmount
+ *
+ * @param currentBalance - Current Traditional balance
+ * @param yearsUntilRMD - Years remaining until RMD age
+ * @param annualConversionAmount - Amount to convert each year
+ * @param growthRate - Expected annual growth rate (e.g., 0.07 for 7%)
+ * @returns Projected balance at RMD age (floored at 0)
+ */
+export function projectBalanceAtRMD(
+    currentBalance: number,
+    yearsUntilRMD: number,
+    annualConversionAmount: number,
+    growthRate: number
+): number {
+    // Handle edge cases
+    if (yearsUntilRMD <= 0) {
+        return currentBalance;
+    }
+
+    // Zero growth is a special case - simple subtraction
+    if (growthRate === 0) {
+        const projectedBalance = currentBalance - (yearsUntilRMD * annualConversionAmount);
+        return Math.max(0, projectedBalance);
+    }
+
+    // Use iterative calculation (clearer than closed-form)
+    // For each year: balance grows, then conversion is removed
+    let balance = currentBalance;
+
+    for (let year = 0; year < yearsUntilRMD; year++) {
+        // Growth first
+        balance = balance * (1 + growthRate);
+
+        // Then conversion
+        balance = balance - annualConversionAmount;
+
+        // Floor at 0 - can't go negative
+        if (balance <= 0) {
+            return 0;
+        }
+    }
+
+    return Math.max(0, balance);
+}
+
+/**
+ * Find the optimal bracket ceiling for conversions using a simple three-tier system.
+ *
+ * Algorithm:
+ * 1. Compute baseline projected balance assuming only 12% bracket conversions each year
+ * 2. Determine peak RMD bracket from baseline using mid-retirement divisor (15)
+ * 3. Set ceiling from three-tier table based on peak RMD bracket
+ * 4. Return bracket space at that ceiling for PMT pacing
+ *
+ * Three-tier ceiling table:
+ * - Peak RMD bracket <= 12%: ceiling = 0% (standard deduction only)
+ * - Peak RMD bracket is 22% or 24%: ceiling = 12%
+ * - Peak RMD bracket >= 32%: ceiling = 24%
+ *
+ * Principle: Only convert at a rate that is at least two bracket tiers below
+ * the projected RMD rate. This ensures real savings after accounting for
+ * sequence-of-returns risk.
+ *
+ * @param currentTraditionalBalance - Current Traditional IRA/401k balance
+ * @param yearsUntilRMD - Years remaining until RMD age
+ * @param pensionIncomeAtRMD - Non-SS fixed income at RMD age (pensions, annuities)
+ * @param ssAtRMD - Social Security benefits at RMD age
+ * @param currentAGI - This year's AGI (excluding SS)
+ * @param socialSecurityThisYear - This year's SS benefits
+ * @param ltcgIncome - Long-term capital gains (for bump zone detection)
+ * @param growthRate - Expected annual growth rate
+ * @param rmdStartAge - Age at which RMDs begin (72, 73, or 75 based on birth year)
+ * @param taxParams - Federal tax parameters
+ * @param taxState - Tax state (filing status, etc.)
+ * @returns ConversionCeilingResult with ceiling, bracket space, projections
+ */
+export function calculateDynamicConversionCeiling(
+    currentTraditionalBalance: number,
+    yearsUntilRMD: number,
+    pensionIncomeAtRMD: number,
+    ssAtRMD: number,
+    passiveIncomeAtRMD: number,
+    currentAGI: number,
+    _socialSecurityThisYear: number,
+    _ltcgIncome: number,
+    growthRate: number,
+    rmdStartAge: number,
+    taxParams: TaxParameters,
+    taxState: TaxState,
+    _stateParams: TaxParameters | null = null,
+    _acaOptions?: ACAOptions,
+    baselineProjections?: BaselineProjections,
+    /**
+     * Simulation assumptions. When provided, the peak-RMD bracket lookup uses
+     * tax parameters projected to the RMD year so that RMD-year nominal income
+     * is compared against RMD-year nominal brackets. Without this, the bracket
+     * comparison mixes units (income in RMD-year dollars vs brackets in
+     * current-year dollars), which inflates the apparent peak-RMD bracket at
+     * younger ages. Optional for backwards compatibility — callers that don't
+     * pass it get the legacy (unit-mismatched) behavior.
+     */
+    assumptions?: AssumptionsState,
+    conversionMode: 'rate-match' | 'std-ded-only' = 'rate-match'
+): ConversionCeilingResult {
+    // If already at RMD age, no conversions
+    if (yearsUntilRMD <= 0) {
+        return {
+            conversionCeiling: 0,
+            bracketSpacePerYear: 0,
+            projectedBalanceAtRMD: currentTraditionalBalance,
+            projectedRMDBracket: 0,
+            peakRMD: 0,
+            peakRMDBracket: 0,
+        };
+    }
+
+    // Std-ded-only mode: fill the 0% federal bracket (standard-deduction headroom)
+    // and stop. Used by `runProjectionSubsim` to project a Traditional-balance
+    // trajectory that does only "free" conversions, which feeds the rate-match
+    // baseline for the main sim. Skip rate-match, peak-bracket lookup, ideal-target
+    // computation entirely — none of it is needed when the conversion is bounded
+    // by the standard deduction.
+    if (conversionMode === 'std-ded-only') {
+        const stdDedHeadroom = Math.max(0, taxParams.standardDeduction - currentAGI);
+        const cappedAmount = Math.min(stdDedHeadroom, currentTraditionalBalance);
+        return {
+            conversionCeiling: 0,
+            bracketSpacePerYear: cappedAmount,
+            projectedBalanceAtRMD: currentTraditionalBalance,
+            projectedRMDBracket: 0,
+            peakRMD: 0,
+            peakRMDBracket: 0,
+        };
+    }
+
+    // Use baseline projections if available for fixed income at RMD.
+    // Pass 1 simulates the trajectory to RMD year so these reflect actual portfolio
+    // dynamics (brokerage growth → dividends, etc.); fall back to direct inputs
+    // (which use COLA-only projection or current-year proxies) when not available.
+    const effectiveSsAtRMD = baselineProjections?.ssAtRMD ?? ssAtRMD;
+    const effectivePensionAtRMD = baselineProjections?.pensionAtRMD ?? pensionIncomeAtRMD;
+    const effectivePassiveIncomeAtRMD = baselineProjections?.passiveAtRMD ?? passiveIncomeAtRMD;
+
+    // =========================================================================
+    // STEP 1: Compute projected Trad balance at RMD age
+    // =========================================================================
+    // Prefer baselineProjections.traditionalBalanceAtRMD when available — this
+    // value comes from the iterative two-pass run and reflects the actual
+    // converging conversion trajectory, so peakRMDBracket reflects where RMDs
+    // really land (not "where they'd land if I never converted from this point").
+    //
+    // Without iteration, fall back to naive growth projection from current
+    // balance. This was the original behavior and produces conservative ceilings.
+
+    const baselineBalance = baselineProjections?.traditionalBalanceAtRMD
+        ?? currentTraditionalBalance * Math.pow(1 + growthRate, yearsUntilRMD);
+
+    // =========================================================================
+    // STEP 2: Determine peak RMD bracket from baseline
+    // =========================================================================
+
+    const PEAK_RMD_DIVISOR = 15;  // Approximates age ~87 (mid-retirement)
+    const peakRMD = baselineBalance / PEAK_RMD_DIVISOR;
+
+    // Look up tax parameters for the RMD year, not the current year. peakRMD,
+    // effectiveSsAtRMD, effectivePensionAtRMD, and passiveIncomeAtRMD are all
+    // expressed in RMD-year nominal dollars — they need to be compared against
+    // RMD-year inflation-projected brackets, otherwise the apparent peak-RMD
+    // bracket is inflated by (1 + inflation)^yearsUntilRMD.
+    //
+    // Use birthYear + rmdStartAge for the RMD year — that's the user's actual
+    // RMD year and is invariant across simulation years. (Avoid taxState.year +
+    // yearsUntilRMD: taxState.year is the user's configured tax year, not the
+    // current simulation year, so as yearsUntilRMD shrinks the apparent rmdYear
+    // would walk backwards toward the present.)
+    let peakBracketTaxParams = taxParams;
+    if (assumptions) {
+        const rmdYear = getBirthYear(assumptions.milestones) + rmdStartAge;
+        const rmdYearParams = TaxService.getTaxParameters(
+            rmdYear, taxState.filingStatus, 'federal', undefined, assumptions
+        );
+        if (rmdYearParams) {
+            peakBracketTaxParams = rmdYearParams;
+        }
+    }
+
+    // Calculate taxable SS at peak RMD
+    const peakTaxableSS = TaxService.getTaxableSocialSecurityBenefits(
+        effectiveSsAtRMD,
+        effectivePensionAtRMD + peakRMD + effectivePassiveIncomeAtRMD,
+        0,
+        taxState.filingStatus
+    );
+    const peakTaxableIncome = peakRMD + effectivePensionAtRMD + effectivePassiveIncomeAtRMD + peakTaxableSS - peakBracketTaxParams.standardDeduction;
+    const peakRMDBracket = TaxService.getMarginalTaxRate(Math.max(0, peakTaxableIncome), peakBracketTaxParams).rate;
+
+    // =========================================================================
+    // STEP 3 + 4: Rate-matched conversion via direct bracket walk
+    // =========================================================================
+    //
+    // Rather than computing a single "ceiling" rate and then filling brackets up
+    // to it, walk through the brackets dollar-chunk by dollar-chunk. For each
+    // chunk: compute current marginal (the bracket's rate) and project future
+    // marginal at the remaining Trad balance after the chunk. Convert if the gap
+    // is at least minimumRateGap (default 5pp). Stop otherwise.
+    //
+    // This naturally adapts: in early low-income years with lots of Trad, walk
+    // up through 22%/24% brackets because future is even higher. As Trad shrinks
+    // year by year, future marginal drops, gaps close, and the walk stops sooner.
+    // No discrete ceiling cliff, no iteration needed — convergence is per-year.
+    const minRateGap = assumptions?.investments?.rothConversionMinRateGap ?? 0.05;
+    const rateMatchResult = computeRateMatchedConversion(
+        currentTraditionalBalance,
+        yearsUntilRMD,
+        effectivePensionAtRMD,
+        effectiveSsAtRMD,
+        effectivePassiveIncomeAtRMD,
+        currentAGI,
+        growthRate,
+        taxParams,            // current-year params for the brackets we walk
+        peakBracketTaxParams, // RMD-year params for projecting future marginal
+        taxState,
+        minRateGap,
+        baselineBalance       // sub-sim-derived projection (decoupled from live trad balance)
+    );
+
+    const ceiling = rateMatchResult.topConversionRate;
+    let bracketSpacePerYear = rateMatchResult.optimalConversion;
+
+    // Subsequent SS-torpedo / ACA / LTCG-bump logic (downstream in YearSolver) may
+    // further reduce this; rate-match output is the rate-arbitrage optimum.
+
+    // =========================================================================
+    // Compute projected balance for return
+    // =========================================================================
+
+    // Use baseline projection for projectedBalanceAtRMD if available
+    const effectiveProjectedBalance = baselineProjections?.traditionalBalanceAtRMD
+        ?? projectBalanceAtRMD(currentTraditionalBalance, yearsUntilRMD, 0, growthRate);
+
+    // Compute projected RMD bracket (first-year RMD using standard divisor)
+    const rmdDivisor = getRMDDivisor(rmdStartAge);
+    const projectedRMD = rmdDivisor > 0 ? effectiveProjectedBalance / rmdDivisor : 0;
+    const projectedTaxableSS = TaxService.getTaxableSocialSecurityBenefits(
+        effectiveSsAtRMD,
+        effectivePensionAtRMD + projectedRMD,
+        0,
+        taxState.filingStatus
+    );
+    // Same units fix as peakRMDBracket: projectedRMD/SS/pension are in RMD-year
+    // nominal dollars, so look up brackets in RMD-year params when available.
+    const projectedTaxableIncome = projectedRMD + effectivePensionAtRMD + projectedTaxableSS - peakBracketTaxParams.standardDeduction;
+    const projectedRMDBracket = TaxService.getMarginalTaxRate(Math.max(0, projectedTaxableIncome), peakBracketTaxParams).rate;
+
+    return {
+        conversionCeiling: ceiling,
+        bracketSpacePerYear,
+        projectedBalanceAtRMD: effectiveProjectedBalance,
+        projectedRMDBracket,
+        peakRMD,
+        peakRMDBracket,
+        rateMatchWalk: rateMatchResult.walk,
+    };
+}
+

--- a/src/services/simulation/WithdrawalPlanner.ts
+++ b/src/services/simulation/WithdrawalPlanner.ts
@@ -1,0 +1,1163 @@
+/**
+ * WithdrawalPlanner.ts
+ *
+ * Unified withdrawal planning for the SimulationEngine rewrite.
+ *
+ * Design Principles:
+ * 1. Single code path - both basic and tax-optimized modes use this
+ * 2. Algebraic gross-up - solves single-source withdrawals in 1 pass
+ * 3. Account drain - withdraws entire balance when insufficient
+ * 4. Savings preservation - savings moved to end of non-penalized accounts
+ *
+ * CRITICAL: Uses BASE deficit (expenses + ordinaryTax + FICA - income - RMD).
+ * LTCG tax is NOT included in the deficit before grossing up - that causes double-counting.
+ */
+
+import { AnyAccount, InvestedAccount, SavedAccount, ESPPAccount } from "../../components/Objects/Accounts/models";
+import { TaxState } from "../../components/Objects/Taxes/TaxContext";
+import { AssumptionsState } from "../../components/Objects/Assumptions/AssumptionsContext";
+import {
+    PlannedWithdrawal,
+    AccountBalanceSnapshot,
+    WithdrawalAccountType,
+    DecisionLogEntry,
+} from "./types";
+import * as TaxService from "../../components/Objects/Taxes/TaxService";
+import { getLTCGRate as getLTCGRateForIncome } from "../../components/Objects/Taxes/taxService/capitalGainsTax";
+import { TaxBracket } from "../../data/TaxData";
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const EARLY_WITHDRAWAL_AGE = 59.5;
+const EARLY_WITHDRAWAL_PENALTY_RATE = 0.10;
+
+// BUG #14 FIX: gross-up divides by (1 - effectiveRate). If a combined
+// marginal+penalty rate reaches or exceeds 1, the denominator is <= 0 and the
+// gross-up returns Infinity/NaN, which then propagates into the plan totals.
+// Clamp the divisor to a small positive floor so the output stays finite (and
+// conservatively large) instead of exploding. 0.01 mirrors the ESPP guard below.
+const MIN_GROSSUP_DENOMINATOR = 0.01;
+export function grossUpDivisor(effectiveRate: number): number {
+    return Math.max(MIN_GROSSUP_DENOMINATOR, 1 - effectiveRate);
+}
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface WithdrawalPlanResult {
+    withdrawals: PlannedWithdrawal[];
+    totalGross: number;
+    totalNet: number;
+    totalTax: number;
+    totalPenalties: number;
+    totalLTCG: number;
+    totalSTCG: number;
+    remainingDeficit: number;
+    decisions: DecisionLogEntry[];
+}
+
+// AccountWithdrawalContext interface removed - was unused
+
+// =============================================================================
+// ACCOUNT CLASSIFICATION
+// =============================================================================
+
+/**
+ * Classify an account's tax type for withdrawal ordering.
+ */
+function classifyAccount(account: AnyAccount): WithdrawalAccountType {
+    if (account instanceof SavedAccount) return 'savings';
+    if (account instanceof ESPPAccount) return 'espp';
+    if (account instanceof InvestedAccount) {
+        switch (account.taxType) {
+            case 'Traditional 401k': return 'traditional_401k';
+            case 'Traditional IRA': return 'traditional_ira';
+            case 'Roth 401k': return 'roth_401k';
+            case 'Roth IRA': return 'roth_ira';
+            case 'HSA': return 'hsa';
+            case 'Brokerage':
+            default:
+                return 'brokerage';
+        }
+    }
+    return 'savings';
+}
+
+/**
+ * Check if account type incurs early withdrawal penalty.
+ */
+function hasEarlyWithdrawalPenalty(
+    accountType: WithdrawalAccountType,
+    age: number,
+    isEarnings: boolean = false
+): boolean {
+    // HSA non-medical withdrawals are penalized (20%) until age 65, not 59.5.
+    if (accountType === 'hsa') return age < 65;
+
+    if (age >= EARLY_WITHDRAWAL_AGE) return false;
+
+    switch (accountType) {
+        case 'traditional_401k':
+        case 'traditional_ira':
+            return true;
+        case 'roth_401k':
+        case 'roth_ira':
+            // Only earnings have penalty; contributions are penalty-free
+            return isEarnings;
+        // 'hsa' is handled above (penalized until 65, not 59.5).
+        default:
+            return false;
+    }
+}
+
+// =============================================================================
+// ACCOUNT SNAPSHOTTING
+// =============================================================================
+
+/**
+ * Create a balance snapshot from an account.
+ */
+export function createAccountSnapshot(account: AnyAccount, snapshotDate?: Date): AccountBalanceSnapshot {
+    const accountType = classifyAccount(account);
+
+    let vestedBalance = account.amount;
+    let gainRatio = 0;
+    let rothContributions: number | undefined;
+    let conversionHistory: { year: number; amount: number }[] | undefined;
+    let esppLots: AccountBalanceSnapshot['esppLots'];
+
+    if (account instanceof ESPPAccount) {
+        // ESPP: pre-compute per-lot disposition data using existing functions
+        const saleDate = snapshotDate ?? new Date();
+        const sharePrice = account.currentSharePrice ?? (account.amount / Math.max(1, account.totalShares));
+
+        esppLots = account.lots.map(lot => {
+            const dispositionType = account.calculateDispositionType(lot, saleDate);
+
+            // Use calculateSaleTax to get proper tax breakdown for this lot
+            const taxResult = account.calculateSaleTax(
+                lot.shares,
+                sharePrice,
+                saleDate,
+                'fifo',
+                [lot] // Just this lot
+            );
+
+            const ordinaryIncomePerShare = lot.shares > 0 ? taxResult.ordinaryIncome / lot.shares : 0;
+            const ltcgPerShare = lot.shares > 0 ? taxResult.longTermGains / lot.shares : 0;
+            const totalValue = lot.shares * sharePrice;
+
+            return {
+                lotId: lot.id,
+                shares: lot.shares,
+                currentValuePerShare: sharePrice,
+                purchasePricePerShare: lot.purchasePrice,
+                dispositionType,
+                ordinaryIncomePerShare,
+                ltcgPerShare,
+                totalValue,
+            };
+        });
+
+        // Calculate gain ratio for ESPP using lot data (totalCost may not be set)
+        const totalCostBasis = account.lots.reduce((sum, lot) => {
+            // Use totalCost if available, otherwise compute from purchasePrice × shares
+            const lotCost = lot.totalCost ?? (lot.purchasePrice * lot.shares);
+            return sum + lotCost;
+        }, 0);
+        const unrealizedGains = Math.max(0, account.amount - totalCostBasis);
+        gainRatio = account.amount > 0 ? unrealizedGains / account.amount : 0;
+    } else if (account instanceof InvestedAccount) {
+        vestedBalance = account.vestedAmount;
+
+        // Calculate gain ratio for brokerage accounts
+        if (accountType === 'brokerage') {
+            const unrealizedGains = account.amount - account.costBasis;
+            gainRatio = account.amount > 0 ? Math.max(0, unrealizedGains / account.amount) : 0;
+        }
+
+        // Track Roth contribution basis
+        if (accountType === 'roth_ira' || accountType === 'roth_401k') {
+            rothContributions = account.regularContributions ?? 0;
+            conversionHistory = account.conversionHistory ?? [];
+        }
+    }
+
+    return {
+        accountId: account.id,
+        accountName: account.name,
+        accountType,
+        balance: account.amount,
+        vestedBalance,
+        gainRatio,
+        rothContributions,
+        conversionHistory,
+        esppLots,
+    };
+}
+
+/**
+ * Create snapshots for all accounts in withdrawal order.
+ * Savings is moved to end of non-penalized accounts.
+ */
+export function createOrderedSnapshots(
+    accounts: AnyAccount[],
+    withdrawalOrder: { accountId: string }[],
+    currentAge: number,
+    year?: number
+): AccountBalanceSnapshot[] {
+    const snapshots: AccountBalanceSnapshot[] = [];
+    const savingsSnapshots: AccountBalanceSnapshot[] = [];
+    const penalizedSnapshots: AccountBalanceSnapshot[] = [];
+
+    // Use mid-year date for ESPP disposition calculations
+    const snapshotDate = year ? new Date(year, 5, 15) : undefined;
+
+    // Process in user's configured order
+    for (const bucket of withdrawalOrder) {
+        const account = accounts.find(a => a.id === bucket.accountId);
+        if (!account) continue;
+
+        const snapshot = createAccountSnapshot(account, snapshotDate);
+
+        // Separate into categories
+        if (snapshot.accountType === 'savings') {
+            savingsSnapshots.push(snapshot);
+        } else if (hasEarlyWithdrawalPenalty(snapshot.accountType, currentAge)) {
+            penalizedSnapshots.push(snapshot);
+        } else {
+            snapshots.push(snapshot);
+        }
+    }
+
+    // Final order: non-penalized → savings → penalized
+    return [...snapshots, ...savingsSnapshots, ...penalizedSnapshots];
+}
+
+// =============================================================================
+// GROSS-UP FORMULAS
+// =============================================================================
+
+/**
+ * Calculate gross withdrawal needed for a given net from savings.
+ * No tax, no penalty.
+ */
+function grossUpSavings(netNeeded: number): { gross: number; tax: number; penalty: number } {
+    return { gross: netNeeded, tax: 0, penalty: 0 };
+}
+
+/**
+ * Calculate gross withdrawal needed for a given net from brokerage.
+ * Uses algebraic formula: gross = net / (1 - gainRatio × ltcgRate)
+ */
+function grossUpBrokerage(
+    netNeeded: number,
+    gainRatio: number,
+    ltcgRate: number
+): { gross: number; tax: number; ltcg: number } {
+    if (gainRatio <= 0) {
+        // No gains - no tax
+        return { gross: netNeeded, tax: 0, ltcg: 0 };
+    }
+
+    const effectiveRate = gainRatio * ltcgRate;
+    const gross = netNeeded / (1 - effectiveRate);
+    const ltcg = gross * gainRatio;
+    const tax = ltcg * ltcgRate;
+
+    return { gross, tax, ltcg };
+}
+
+/**
+ * Compute piecewise tax on a known gross Traditional withdrawal.
+ * Walks federal and state brackets stacked on current taxable income positions.
+ */
+function computeTaxOnGross(
+    grossAmount: number,
+    fedTaxableIncome: number,
+    stateTaxableIncome: number,
+    fedBrackets: TaxBracket[],
+    stateBrackets: TaxBracket[] | null,
+    remainingFedStdDedSpace: number,
+    remainingStateStdDedSpace: number
+): { fedTax: number; stateTax: number; totalTax: number } {
+    // Federal: tax applies to amount above std deduction space
+    const fedTaxableWithdrawal = Math.max(0, grossAmount - remainingFedStdDedSpace);
+    let fedTax = 0;
+    if (fedTaxableWithdrawal > 0 && fedBrackets.length > 0) {
+        let remaining = fedTaxableWithdrawal;
+        let incomePos = fedTaxableIncome;
+        for (let i = 0; i < fedBrackets.length && remaining > 0; i++) {
+            const bracket = fedBrackets[i];
+            const nextThreshold = fedBrackets[i + 1]?.threshold ?? Infinity;
+            if (incomePos >= nextThreshold) continue;
+            const floor = Math.max(incomePos, bracket.threshold);
+            const room = nextThreshold - floor;
+            const inBracket = Math.min(remaining, room);
+            fedTax += inBracket * bracket.rate;
+            incomePos += inBracket;
+            remaining -= inBracket;
+        }
+    }
+
+    // State: same approach
+    let stateTax = 0;
+    if (stateBrackets && stateBrackets.length > 0) {
+        const stateTaxableWithdrawal = Math.max(0, grossAmount - remainingStateStdDedSpace);
+        if (stateTaxableWithdrawal > 0) {
+            let remaining = stateTaxableWithdrawal;
+            let incomePos = stateTaxableIncome;
+            for (let i = 0; i < stateBrackets.length && remaining > 0; i++) {
+                const bracket = stateBrackets[i];
+                const nextThreshold = stateBrackets[i + 1]?.threshold ?? Infinity;
+                if (incomePos >= nextThreshold) continue;
+                const floor = Math.max(incomePos, bracket.threshold);
+                const room = nextThreshold - floor;
+                const inBracket = Math.min(remaining, room);
+                stateTax += inBracket * bracket.rate;
+                incomePos += inBracket;
+                remaining -= inBracket;
+            }
+        }
+    }
+
+    return { fedTax, stateTax, totalTax: fedTax + stateTax };
+}
+
+
+/**
+ * Calculate gross withdrawal needed for a given net from Traditional accounts.
+ * Uses binary search over computeTaxOnGross to correctly handle separate
+ * federal and state standard deduction spaces and bracket positions.
+ */
+function grossUpTraditional(
+    netNeeded: number,
+    age: number,
+    fedTaxableIncome: number,
+    stateTaxableIncome: number,
+    fedBrackets: TaxBracket[],
+    stateBrackets: TaxBracket[] | null,
+    remainingFedStdDedSpace: number,
+    remainingStateStdDedSpace: number
+): { gross: number; tax: number; penalty: number } {
+    if (netNeeded <= 0) {
+        return { gross: 0, tax: 0, penalty: 0 };
+    }
+
+    const penaltyRate = age < EARLY_WITHDRAWAL_AGE ? EARLY_WITHDRAWAL_PENALTY_RATE : 0;
+
+    // Helper: net delivered by a given gross withdrawal (tax + penalty subtracted).
+    const netAtGross = (gross: number): number => {
+        const t = computeTaxOnGross(
+            gross, fedTaxableIncome, stateTaxableIncome,
+            fedBrackets, stateBrackets,
+            remainingFedStdDedSpace, remainingStateStdDedSpace
+        );
+        return gross - t.totalTax - gross * penaltyRate;
+    };
+
+    // Binary search: find gross such that gross - tax(gross) - penalty(gross) = netNeeded
+    let lo = netNeeded;
+    let hi = netNeeded * 3;
+
+    // When the combined fed+state+penalty rate exceeds ~66.7%, even gross = 3×netNeeded
+    // nets less than netNeeded, so [lo, hi] never brackets the target and the search
+    // silently under-funds the deficit. Grow hi (capped) until net(hi) >= netNeeded.
+    const maxHi = netNeeded * 20;
+    while (hi < maxHi && netAtGross(hi) < netNeeded) {
+        hi = Math.min(hi * 2, maxHi);
+    }
+
+    let bestGross = netNeeded;
+    let bestTax = 0;
+
+    for (let iter = 0; iter < 60; iter++) {
+        const mid = (lo + hi) / 2;
+        const taxResult = computeTaxOnGross(
+            mid, fedTaxableIncome, stateTaxableIncome,
+            fedBrackets, stateBrackets,
+            remainingFedStdDedSpace, remainingStateStdDedSpace
+        );
+        const penalty = mid * penaltyRate;
+        const net = mid - taxResult.totalTax - penalty;
+
+        bestGross = mid;
+        bestTax = taxResult.totalTax;
+
+        if (Math.abs(net - netNeeded) < 0.0001) break;
+
+        if (net < netNeeded) {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+
+    return { gross: bestGross, tax: bestTax, penalty: bestGross * penaltyRate };
+}
+
+/**
+ * Calculate gross withdrawal needed for Roth accounts.
+ * Follows IRS ordering: contributions → conversions → earnings.
+ */
+function grossUpRoth(
+    netNeeded: number,
+    contributionBasis: number,
+    conversionHistory: { year: number; amount: number }[],
+    currentYear: number,
+    age: number,
+    marginalRate: number,
+    maxGross: number = Infinity
+): { gross: number; tax: number; penalty: number; fromContributions: number; fromConversions: number; fromEarnings: number } {
+    let remaining = netNeeded;
+    let fromContributions = 0;
+    let fromConversions = 0;
+    let fromEarnings = 0;
+    let tax = 0;
+    let penalty = 0;
+    let grossUsed = 0;
+
+    // 1. Contributions first - tax-free, penalty-free
+    if (contributionBasis > 0 && remaining > 0 && grossUsed < maxGross) {
+        const fromContrib = Math.min(remaining, contributionBasis, maxGross - grossUsed);
+        fromContributions = fromContrib;
+        grossUsed += fromContrib;
+        remaining -= fromContrib;
+    }
+
+    // 2. Conversions second - FIFO by year, 5-year rule for penalty.
+    // Caller passes a pre-sorted (oldest first) array; we mutate entry amounts
+    // in place so a shared pool can be drained across multiple withdrawals
+    // within the same year.
+    if (remaining > 0 && grossUsed < maxGross && conversionHistory.length > 0) {
+        for (const conv of conversionHistory) {
+            if (remaining <= 0 || grossUsed >= maxGross) break;
+            if (conv.amount <= 0) continue;
+
+            const yearsHeld = currentYear - conv.year;
+            const penaltyApplies = age < EARLY_WITHDRAWAL_AGE && yearsHeld < 5;
+
+            const fromThisConv = Math.min(remaining, conv.amount, maxGross - grossUsed);
+            fromConversions += fromThisConv;
+            grossUsed += fromThisConv;
+            conv.amount -= fromThisConv;
+
+            if (penaltyApplies) {
+                const penaltyOnConv = fromThisConv * EARLY_WITHDRAWAL_PENALTY_RATE;
+                penalty += penaltyOnConv;
+            }
+
+            remaining -= fromThisConv;
+        }
+    }
+
+    // 3. Earnings last - tax + penalty if under 59.5
+    if (remaining > 0 && grossUsed < maxGross) {
+        const grossRoom = maxGross - grossUsed;
+        if (age < EARLY_WITHDRAWAL_AGE) {
+            // Earnings are taxed as ordinary income + 10% penalty
+            const penaltyRate = EARLY_WITHDRAWAL_PENALTY_RATE;
+            const effectiveRate = marginalRate + penaltyRate;
+
+            // Gross up the remaining need, capped by available room.
+            // BUG #14 FIX: guard the divisor so a >= 1 effective rate (marginal +
+            // 10% penalty) can't produce Infinity/NaN.
+            const grossEarnings = Math.min(remaining / grossUpDivisor(effectiveRate), grossRoom);
+            fromEarnings = grossEarnings;
+            tax = grossEarnings * marginalRate;
+            penalty += grossEarnings * penaltyRate;
+        } else {
+            // After 59.5, earnings are tax-free too (qualified distribution)
+            fromEarnings = Math.min(remaining, grossRoom);
+        }
+    }
+
+    const gross = fromContributions + fromConversions + fromEarnings;
+
+    return { gross, tax, penalty, fromContributions, fromConversions, fromEarnings };
+}
+
+// =============================================================================
+// MAIN PLANNING FUNCTION
+// =============================================================================
+
+/**
+ * Plan withdrawals to cover a net deficit.
+ *
+ * @param netNeeded - Net amount needed after all taxes
+ * @param accountOrder - Ordered list of accounts to tap
+ * @param currentAge - Current age for penalty calculations
+ * @param year - Current simulation year
+ * @param taxState - Tax state for rate lookups
+ * @param currentOrdinaryIncome - Current ordinary income (for marginal rate)
+ * @param assumptions - Simulation assumptions
+ * @param reason - Reason for withdrawal (for logging)
+ * @returns Withdrawal plan with all details
+ */
+export function planWithdrawals(
+    netNeeded: number,
+    accountOrder: AccountBalanceSnapshot[],
+    currentAge: number,
+    year: number,
+    taxState: TaxState,
+    currentOrdinaryIncome: number,
+    assumptions: AssumptionsState | undefined,
+    reason: PlannedWithdrawal['reason'] = 'Spending deficit',
+    acaWithdrawalOptions?: { acaCliffThreshold: number; currentMAGI: number },
+    /** Income included in currentOrdinaryIncome for federal brackets but exempt from state tax
+     *  (e.g., taxable Social Security for DC and most states that exempt SS). */
+    stateExemptIncome: number = 0
+): WithdrawalPlanResult {
+    const withdrawals: PlannedWithdrawal[] = [];
+    const decisions: DecisionLogEntry[] = [];
+
+    let remainingNetNeeded = netNeeded;
+    let totalGross = 0;
+    let totalNet = 0;
+    let totalTax = 0;
+    let totalPenalties = 0;
+    let totalLTCG = 0;
+    // STCG is always 0 today: the planner has no per-lot holding-period data to
+    // split brokerage gains short/long, and YearSolver hardcodes STCG=0 in the
+    // authoritative federal tax. Tracked as a const placeholder until that
+    // cross-file short/long split is wired up (reviewed bug #9, NEEDS-CROSS-FILE).
+    const totalSTCG = 0;
+    let cumulativeLTCG = 0; // Tracks LTCG from brokerage/ESPP for ACA MAGI headroom
+    let runningOrdinaryIncome = currentOrdinaryIncome;
+
+    // ACA cliff: track Roth amounts pre-consumed by look-ahead substitution
+    const acaRothConsumed = new Map<string, number>();
+    const ACA_WITHDRAWAL_BUFFER = 500; // Buffer under cliff for withdrawal LTCG
+
+    // Get tax parameters
+    const fedParams = TaxService.getTaxParameters(year, taxState.filingStatus, 'federal', undefined, assumptions);
+    const stateParams = TaxService.getTaxParameters(year, taxState.filingStatus, 'state', taxState.stateResidency, assumptions);
+
+    // Get LTCG rate based on current ordinary income. Delegates to the shared
+    // getLTCGRate helper (imported as getLTCGRateForIncome), closing over this
+    // year's fedParams.
+    //
+    // NOTE (review #3): passing GROSS runningOrdinaryIncome here is a deliberately
+    // conservative proxy for sizing the gross-up — it never under-states the rate.
+    // A taxable-income lookup (subtracting the standard deduction) returns the 0%
+    // *floor* rate whenever taxable ordinary income is below the 0% LTCG ceiling,
+    // which under-withdraws when the gains themselves spill into the 15% bracket.
+    // The authoritative per-year tax (calculateTotalFederalTax) stacks correctly.
+    const getLTCGRate = (ordinaryIncome: number): number =>
+        getLTCGRateForIncome(ordinaryIncome, fedParams);
+
+    // Get marginal ordinary rate
+    const getMarginalRate = (ordinaryIncome: number): number => {
+        if (!fedParams) return 0.22; // Default to 22%
+
+        const result = TaxService.getMarginalTaxRate(
+            Math.max(0, ordinaryIncome - fedParams.standardDeduction),
+            fedParams
+        );
+        return result.rate;
+    };
+
+    // Get state marginal rate.
+    // BUG #7 FIX: take an income arg and recompute per-iteration (like
+    // getMarginalRate) instead of freezing it at the initial
+    // currentOrdinaryIncome. As traditional/HSA withdrawals raise running
+    // income across state brackets, the state portion of the marginal rate
+    // used for subsequent Roth-earnings / HSA / ESPP gross-ups must update too.
+    const getStateRate = (ordinaryIncome: number): number => {
+        if (!stateParams) return 0;
+        const result = TaxService.getMarginalTaxRate(
+            Math.max(0, ordinaryIncome - stateParams.standardDeduction),
+            stateParams
+        );
+        return result.rate;
+    };
+
+    // IRS Pub 590-B: all Roth IRAs are treated as a single Roth IRA for ordering
+    // rules. Pool contribution basis and conversion history (FIFO across accounts)
+    // across every roth_ira snapshot. The pool is decremented in place as
+    // withdrawals are processed. Roth 401k accounts (pre-retirement only after
+    // the at-retirement rollover) keep per-account treatment.
+    const rothIRASnapshots = accountOrder.filter(s => s.accountType === 'roth_ira');
+    let remainingPoolBasis = rothIRASnapshots.reduce(
+        (sum, s) => sum + Math.max(0, s.rothContributions ?? 0),
+        0,
+    );
+    const pooledRothConversions: { year: number; amount: number }[] = rothIRASnapshots
+        .flatMap(s => s.conversionHistory ?? [])
+        .filter(c => c.amount > 0)
+        .map(c => ({ year: c.year, amount: c.amount }))
+        .sort((a, b) => a.year - b.year);
+
+    // Process each account in order
+    for (const snapshot of accountOrder) {
+        if (remainingNetNeeded <= 0) break;
+
+        // Reduce available balance for Roth accounts already tapped by ACA substitution look-ahead
+        const acaAlreadyConsumed = acaRothConsumed.get(snapshot.accountId) ?? 0;
+        const effectiveVestedBalance = snapshot.vestedBalance - acaAlreadyConsumed;
+        if (effectiveVestedBalance <= 0) continue;
+
+        const ltcgRate = getLTCGRate(runningOrdinaryIncome);
+        const marginalRate = getMarginalRate(runningOrdinaryIncome) + getStateRate(runningOrdinaryIncome);
+
+        let withdrawal: PlannedWithdrawal;
+
+        switch (snapshot.accountType) {
+            case 'savings': {
+                const result = grossUpSavings(remainingNetNeeded);
+                const grossToWithdraw = Math.min(result.gross, effectiveVestedBalance);
+                const netReceived = grossToWithdraw;
+
+                withdrawal = {
+                    source: 'savings',
+                    accountId: snapshot.accountId,
+                    accountName: snapshot.accountName,
+                    gross: grossToWithdraw,
+                    net: netReceived,
+                    penalty: 0,
+                    tax: 0,
+                    reason,
+                };
+
+                remainingNetNeeded -= netReceived;
+                totalNet += netReceived;
+                totalGross += grossToWithdraw;
+                break;
+            }
+
+            case 'brokerage': {
+                const result = grossUpBrokerage(remainingNetNeeded, snapshot.gainRatio, ltcgRate);
+                let grossToWithdraw = Math.min(result.gross, effectiveVestedBalance);
+
+                // Recalculate for actual amount if capped
+                const actualGainRatio = snapshot.gainRatio;
+                let actualLTCG = grossToWithdraw * actualGainRatio;
+                let actualTax = actualLTCG * ltcgRate;
+                let netReceived = grossToWithdraw - actualTax;
+
+                // =================================================================
+                // ACA CLIFF CHECK: Cap brokerage withdrawal if LTCG would breach cliff
+                // Substitute tax-free Roth withdrawals for the remainder
+                // =================================================================
+                if (acaWithdrawalOptions && grossToWithdraw > 0) {
+                    const projectedMAGI = acaWithdrawalOptions.currentMAGI + cumulativeLTCG + actualLTCG;
+
+                    if (projectedMAGI > acaWithdrawalOptions.acaCliffThreshold) {
+                        // Calculate how much LTCG headroom we have
+                        const magiHeadroom = Math.max(0,
+                            acaWithdrawalOptions.acaCliffThreshold - ACA_WITHDRAWAL_BUFFER
+                            - acaWithdrawalOptions.currentMAGI - cumulativeLTCG
+                        );
+
+                        // Convert LTCG headroom to max safe gross withdrawal
+                        // LTCG = gross × gainRatio, so gross = LTCG / gainRatio
+                        let maxSafeGross: number;
+                        if (actualGainRatio > 0) {
+                            const maxSafeLTCG = magiHeadroom;
+                            maxSafeGross = maxSafeLTCG / actualGainRatio;
+                        } else {
+                            maxSafeGross = grossToWithdraw; // No gains, no MAGI impact
+                        }
+
+                        const originalGross = grossToWithdraw;
+                        const originalNet = netReceived;
+                        grossToWithdraw = Math.max(0, Math.min(grossToWithdraw, maxSafeGross));
+
+                        // Recalculate with capped amount
+                        actualLTCG = grossToWithdraw * actualGainRatio;
+                        actualTax = actualLTCG * ltcgRate;
+                        netReceived = grossToWithdraw - actualTax;
+
+                        // Calculate deficit still needing coverage from Roth
+                        const netShortfall = originalNet - netReceived;
+
+                        if (netShortfall > 0) {
+                            // Look-ahead: find Roth accounts in the withdrawal order
+                            let rothSubstitutionNet = 0;
+
+                            for (const rothSnapshot of accountOrder) {
+                                if (rothSubstitutionNet >= netShortfall) break;
+                                if (rothSnapshot.accountType !== 'roth_ira' && rothSnapshot.accountType !== 'roth_401k') continue;
+
+                                const alreadyConsumed = acaRothConsumed.get(rothSnapshot.accountId) ?? 0;
+                                const availableRoth = rothSnapshot.vestedBalance - alreadyConsumed;
+                                if (availableRoth <= 0) continue;
+
+                                const stillNeeded = netShortfall - rothSubstitutionNet;
+
+                                // BUG #9 FIX: consume from the SAME conversion/basis source the
+                                // main loop drains, so a conversion spent here is not available
+                                // again to the main pass (which would double-count the dollars and
+                                // mis-assign the 5-year penalty).
+                                //
+                                // For roth_ira (pooled per IRS Pub 590-B) we pass the shared
+                                // `pooledRothConversions` array (grossUpRoth mutates conv.amount in
+                                // place, so the drain is visible to the main loop) and decrement the
+                                // shared `remainingPoolBasis` by whatever contribution basis is used.
+                                // For roth_401k (per-account) the snapshot's conversionHistory is a
+                                // LIVE reference to the account model's array, and snapshots are reused
+                                // across YearSolver's deficit iterations (and the model persists across
+                                // simulation years). grossUpRoth decrements conv.amount in place, so we
+                                // must pass a deep COPY here (mirroring pooledRothConversions) to avoid
+                                // corrupting the account's conversion basis / 5-year-penalty accounting
+                                // on later iterations and years. Combined with the main loop's
+                                // acaRothConsumed/effectiveVestedBalance guard on balance, this prevents
+                                // double-spend without mutating the model.
+                                const isPooledRoth = rothSnapshot.accountType === 'roth_ira';
+                                const acaContribAvailable = isPooledRoth
+                                    ? Math.max(0, Math.min(remainingPoolBasis, rothSnapshot.vestedBalance) - alreadyConsumed)
+                                    : Math.max(0, (rothSnapshot.rothContributions ?? 0) - alreadyConsumed);
+                                const acaConversionsForCall = isPooledRoth
+                                    ? pooledRothConversions
+                                    : (rothSnapshot.conversionHistory ?? [])
+                                        .map(c => ({ year: c.year, amount: c.amount }))
+                                        .sort((a, b) => a.year - b.year);
+
+                                const rothResult = grossUpRoth(
+                                    Math.min(stillNeeded, availableRoth),
+                                    acaContribAvailable,
+                                    acaConversionsForCall,
+                                    year,
+                                    currentAge,
+                                    marginalRate,
+                                    availableRoth
+                                );
+
+                                if (isPooledRoth) {
+                                    remainingPoolBasis = Math.max(0, remainingPoolBasis - rothResult.fromContributions);
+                                }
+
+                                const rothGross = rothResult.gross;
+                                const rothTax = rothResult.tax;
+                                const rothPenalty = rothResult.penalty;
+                                const rothNet = rothGross - rothTax - rothPenalty;
+
+                                if (rothNet <= 0) continue;
+
+                                // Track consumption
+                                acaRothConsumed.set(rothSnapshot.accountId, alreadyConsumed + rothGross);
+                                rothSubstitutionNet += rothNet;
+
+                                // Record the Roth substitution withdrawal
+                                const rothWithdrawal: PlannedWithdrawal = {
+                                    source: rothSnapshot.accountType,
+                                    accountId: rothSnapshot.accountId,
+                                    accountName: rothSnapshot.accountName,
+                                    gross: rothGross,
+                                    net: rothNet,
+                                    penalty: rothPenalty,
+                                    tax: rothTax,
+                                    reason: 'ACA cliff Roth substitution',
+                                };
+
+                                withdrawals.push(rothWithdrawal);
+                                totalNet += rothNet;
+                                totalGross += rothGross;
+                                totalTax += rothTax;
+                                totalPenalties += rothPenalty;
+
+                                // Roth earnings add to ordinary income if under 59.5
+                                if (rothResult.fromEarnings > 0 && currentAge < 59.5) {
+                                    runningOrdinaryIncome += rothResult.fromEarnings;
+                                }
+
+                                decisions.push({
+                                    category: 'withdrawal',
+                                    account: rothSnapshot.accountName,
+                                    amount: rothGross,
+                                    description: `ACA cliff Roth substitution: $${rothGross.toLocaleString()} from ${rothSnapshot.accountName} (tax-free) replaces brokerage to avoid MAGI breach.`,
+                                });
+                            }
+
+                            // Reduce remainingNetNeeded by what Roth covered
+                            remainingNetNeeded -= rothSubstitutionNet;
+
+                            decisions.push({
+                                category: 'withdrawal',
+                                account: snapshot.accountName,
+                                amount: grossToWithdraw,
+                                description: `ACA cliff: Brokerage capped at $${grossToWithdraw.toLocaleString()} (was $${originalGross.toLocaleString()}). LTCG $${actualLTCG.toLocaleString()} keeps MAGI under cliff $${acaWithdrawalOptions.acaCliffThreshold.toLocaleString()}. Roth substituted $${rothSubstitutionNet.toLocaleString()}.`,
+                            });
+
+                            if (rothSubstitutionNet < netShortfall) {
+                                // Not enough Roth to cover the gap — accept cliff breach for remainder
+                                decisions.push({
+                                    category: 'warning',
+                                    amount: netShortfall - rothSubstitutionNet,
+                                    description: `Insufficient Roth balance for full ACA substitution. Remaining $${(netShortfall - rothSubstitutionNet).toLocaleString()} unfunded by substitution.`,
+                                });
+                            }
+                        }
+                    }
+                }
+
+                withdrawal = {
+                    source: 'brokerage',
+                    accountId: snapshot.accountId,
+                    accountName: snapshot.accountName,
+                    gross: grossToWithdraw,
+                    net: netReceived,
+                    capitalGains: { shortTerm: 0, longTerm: actualLTCG },
+                    penalty: 0,
+                    tax: actualTax,
+                    reason,
+                };
+
+                cumulativeLTCG += actualLTCG;
+                remainingNetNeeded -= netReceived;
+                totalNet += netReceived;
+                totalGross += grossToWithdraw;
+                totalTax += actualTax;
+                totalLTCG += actualLTCG;
+                break;
+            }
+
+            case 'traditional_401k':
+            case 'traditional_ira': {
+                // Compute taxable income positions and remaining std ded space
+                // Federal: uses full runningOrdinaryIncome (includes taxable SS)
+                const fedTaxable = Math.max(0, runningOrdinaryIncome - (fedParams?.standardDeduction ?? 0));
+                // State: excludes stateExemptIncome (e.g., taxable SS for DC)
+                const stateIncomeForBrackets = runningOrdinaryIncome - stateExemptIncome;
+                const stateTaxable = stateParams ? Math.max(0, stateIncomeForBrackets - stateParams.standardDeduction) : 0;
+                const fedStdDedSpace = Math.max(0, (fedParams?.standardDeduction ?? 0) - runningOrdinaryIncome);
+                const stateStdDedSpace = stateParams
+                    ? Math.max(0, stateParams.standardDeduction - stateIncomeForBrackets)
+                    : Infinity;
+
+                const result = grossUpTraditional(
+                    remainingNetNeeded, currentAge,
+                    fedTaxable, stateTaxable,
+                    fedParams?.brackets ?? [], stateParams?.brackets ?? null,
+                    fedStdDedSpace, stateStdDedSpace
+                );
+                const grossToWithdraw = Math.min(result.gross, effectiveVestedBalance);
+
+                // Compute tax: if capped by balance, recompute piecewise; otherwise use gross-up result
+                const penaltyRate = currentAge < EARLY_WITHDRAWAL_AGE ? EARLY_WITHDRAWAL_PENALTY_RATE : 0;
+                let actualTax: number;
+                let actualPenalty: number;
+                let netReceived: number;
+
+                if (grossToWithdraw < result.gross) {
+                    // Capped by account balance — recompute tax piecewise for actual gross
+                    const taxResult = computeTaxOnGross(
+                        grossToWithdraw, fedTaxable, stateTaxable,
+                        fedParams?.brackets ?? [], stateParams?.brackets ?? null,
+                        fedStdDedSpace, stateStdDedSpace
+                    );
+                    actualTax = taxResult.totalTax;
+                    actualPenalty = grossToWithdraw * penaltyRate;
+                    netReceived = grossToWithdraw - actualTax - actualPenalty;
+                } else {
+                    actualTax = result.tax;
+                    actualPenalty = result.penalty;
+                    netReceived = grossToWithdraw - actualTax - actualPenalty;
+                }
+
+                withdrawal = {
+                    source: snapshot.accountType,
+                    accountId: snapshot.accountId,
+                    accountName: snapshot.accountName,
+                    gross: grossToWithdraw,
+                    net: netReceived,
+                    penalty: actualPenalty,
+                    tax: actualTax,
+                    reason,
+                };
+
+                // Traditional withdrawal adds to ordinary income
+                runningOrdinaryIncome += grossToWithdraw;
+
+                remainingNetNeeded -= netReceived;
+                totalNet += netReceived;
+                totalGross += grossToWithdraw;
+                totalTax += actualTax;
+                totalPenalties += actualPenalty;
+
+                if (actualPenalty > 0) {
+                    decisions.push({
+                        category: 'withdrawal',
+                        account: snapshot.accountName,
+                        amount: actualPenalty,
+                        description: `Early withdrawal penalty of $${actualPenalty.toFixed(0)} on Traditional withdrawal.`,
+                    });
+                }
+                break;
+            }
+
+            case 'roth_401k':
+            case 'roth_ira': {
+                // Roth IRA: pool contribution basis and conversion history across all
+                // Roth IRAs (IRS Pub 590-B). Roth 401k: keep per-account treatment.
+                const isPooled = snapshot.accountType === 'roth_ira';
+                const contribAvailable = isPooled
+                    ? Math.max(0, Math.min(remainingPoolBasis, snapshot.vestedBalance) - acaAlreadyConsumed)
+                    : Math.max(0, (snapshot.rothContributions ?? 0) - acaAlreadyConsumed);
+                const conversionsForCall = isPooled
+                    ? pooledRothConversions
+                    : (snapshot.conversionHistory ? snapshot.conversionHistory.map(c => ({ year: c.year, amount: c.amount })).sort((a, b) => a.year - b.year) : []);
+
+                const result = grossUpRoth(
+                    remainingNetNeeded,
+                    contribAvailable,
+                    conversionsForCall,
+                    year,
+                    currentAge,
+                    marginalRate,
+                    effectiveVestedBalance
+                );
+
+                if (isPooled) {
+                    remainingPoolBasis = Math.max(0, remainingPoolBasis - result.fromContributions);
+                }
+                const grossToWithdraw = result.gross;
+                const netReceived = grossToWithdraw - result.tax - result.penalty;
+
+                withdrawal = {
+                    source: snapshot.accountType,
+                    accountId: snapshot.accountId,
+                    accountName: snapshot.accountName,
+                    gross: grossToWithdraw,
+                    net: netReceived,
+                    penalty: result.penalty,
+                    tax: result.tax,
+                    reason,
+                };
+
+                // Roth earnings (if any) add to ordinary income
+                if (result.fromEarnings > 0 && currentAge < EARLY_WITHDRAWAL_AGE) {
+                    runningOrdinaryIncome += result.fromEarnings;
+                }
+
+                remainingNetNeeded -= netReceived;
+                totalNet += netReceived;
+                totalGross += grossToWithdraw;
+                totalTax += result.tax;
+                totalPenalties += result.penalty;
+
+                if (result.penalty > 0) {
+                    decisions.push({
+                        category: 'withdrawal',
+                        account: snapshot.accountName,
+                        amount: result.penalty,
+                        description: `Early withdrawal penalty of $${result.penalty.toFixed(0)} on Roth withdrawal (5-year rule).`,
+                    });
+                }
+                break;
+            }
+
+            case 'hsa': {
+                // HSA withdrawals for non-healthcare are taxed as ordinary + 20% penalty before 65
+                const penaltyRate = currentAge < 65 ? 0.20 : 0;
+                const effectiveRate = marginalRate + penaltyRate;
+                // BUG #14 FIX: guard the divisor so a >= 1 effective rate
+                // (marginal + 20% HSA penalty) can't produce Infinity/NaN.
+                const gross = remainingNetNeeded / grossUpDivisor(effectiveRate);
+                const grossToWithdraw = Math.min(gross, effectiveVestedBalance);
+
+                const actualPenalty = grossToWithdraw * penaltyRate;
+                const actualTax = grossToWithdraw * marginalRate;
+                const netReceived = grossToWithdraw - actualTax - actualPenalty;
+
+                withdrawal = {
+                    source: 'hsa',
+                    accountId: snapshot.accountId,
+                    accountName: snapshot.accountName,
+                    gross: grossToWithdraw,
+                    net: netReceived,
+                    penalty: actualPenalty,
+                    tax: actualTax,
+                    reason,
+                };
+
+                runningOrdinaryIncome += grossToWithdraw;
+                remainingNetNeeded -= netReceived;
+                totalNet += netReceived;
+                totalGross += grossToWithdraw;
+                totalTax += actualTax;
+                totalPenalties += actualPenalty;
+
+                if (actualPenalty > 0) {
+                    decisions.push({
+                        category: 'warning',
+                        account: snapshot.accountName,
+                        amount: actualPenalty,
+                        description: `HSA withdrawal for non-healthcare incurs 20% penalty of $${actualPenalty.toFixed(0)}.`,
+                    });
+                }
+                break;
+            }
+
+            case 'espp': {
+                const esppLots = snapshot.esppLots;
+
+                // Use pre-computed lot data if available
+                if (esppLots && esppLots.length > 0) {
+                    // Blended effective-tax sizing. The bargain element is taxed as
+                    // ordinary income (marginal + state), only the post-bargain
+                    // appreciation is LTCG. Sizing the gross against just
+                    // gainRatio*ltcgRate (as before) ignored the ordinary tax on the
+                    // bargain element AND wrongly applied the lower LTCG rate to the
+                    // ordinary-taxed portion, so the sale under-delivered net cash.
+                    // Derive the pool's tax-per-gross-dollar from the lot data and
+                    // gross up against the blended rate.
+                    const esppMarginalRate = getMarginalRate(runningOrdinaryIncome);
+                    const esppStateRate = getStateRate(runningOrdinaryIncome);
+                    const esppCombinedOrdinaryRate = esppMarginalRate + esppStateRate;
+
+                    let poolValue = 0;
+                    let poolOrdinaryTax = 0;
+                    let poolLtcgTax = 0;
+                    for (const lot of esppLots) {
+                        poolValue += lot.totalValue;
+                        poolOrdinaryTax += lot.shares * lot.ordinaryIncomePerShare * esppCombinedOrdinaryRate;
+                        poolLtcgTax += lot.shares * lot.ltcgPerShare * ltcgRate;
+                    }
+                    const effectiveTaxPerGrossDollar = poolValue > 0
+                        ? (poolOrdinaryTax + poolLtcgTax) / poolValue
+                        : 0;
+
+                    // Estimate gross needed using the blended effective rate.
+                    // Clamp the denominator defensively so a near-100% blended rate
+                    // can't produce a negative/exploding gross.
+                    const esppDenominator = Math.max(0.01, 1 - effectiveTaxPerGrossDollar);
+                    const estimatedGross = Math.min(
+                        remainingNetNeeded / esppDenominator,
+                        effectiveVestedBalance
+                    );
+
+                    // Walk lots in order, consuming shares until we have enough
+                    let grossToWithdraw = 0;
+                    let esppOrdinaryIncome = 0;
+                    let esppLTCG = 0;
+                    let remainingGrossNeeded = estimatedGross;
+
+                    for (const lot of esppLots) {
+                        if (remainingGrossNeeded <= 0) break;
+
+                        const lotValue = lot.totalValue;
+                        const valueToUse = Math.min(lotValue, remainingGrossNeeded);
+                        const shareRatio = lotValue > 0 ? valueToUse / lotValue : 0;
+                        const sharesUsed = lot.shares * shareRatio;
+
+                        grossToWithdraw += valueToUse;
+                        esppOrdinaryIncome += sharesUsed * lot.ordinaryIncomePerShare;
+                        esppLTCG += sharesUsed * lot.ltcgPerShare;
+                        remainingGrossNeeded -= valueToUse;
+                    }
+
+                    if (grossToWithdraw <= 0) {
+                        continue; // Skip to next account if no value to withdraw
+                    }
+
+                    // Calculate taxes: ordinary income at marginal rate, LTCG at cap gains rate.
+                    // Reuse the blended-rate inputs computed above for the gross-up.
+                    const ordinaryTax = esppOrdinaryIncome * esppCombinedOrdinaryRate;
+                    const ltcgTax = esppLTCG * ltcgRate;
+                    const actualTax = ordinaryTax + ltcgTax;
+
+                    const netReceived = grossToWithdraw - actualTax;
+
+                    withdrawal = {
+                        source: 'espp',
+                        accountId: snapshot.accountId,
+                        accountName: snapshot.accountName,
+                        gross: grossToWithdraw,
+                        net: netReceived,
+                        capitalGains: { shortTerm: 0, longTerm: esppLTCG },
+                        penalty: 0,
+                        tax: actualTax,
+                        reason,
+                    };
+
+                    // ESPP ordinary income affects tax bracket
+                    runningOrdinaryIncome += esppOrdinaryIncome;
+
+                    cumulativeLTCG += esppLTCG;
+                    remainingNetNeeded -= netReceived;
+                    totalNet += netReceived;
+                    totalGross += grossToWithdraw;
+                    totalTax += actualTax;
+                    totalLTCG += esppLTCG;
+
+                    // Log ESPP ordinary income decision
+                    if (esppOrdinaryIncome > 0) {
+                        const dispositionTypes = [...new Set(esppLots.map(l => l.dispositionType))].join('/');
+                        decisions.push({
+                            category: 'tax',
+                            account: snapshot.accountName,
+                            amount: esppOrdinaryIncome,
+                            description: `ESPP withdrawal: $${esppOrdinaryIncome.toLocaleString()} ordinary income (${dispositionTypes} disposition), $${esppLTCG.toLocaleString()} LTCG.`,
+                        });
+                    }
+                } else {
+                    // Fallback: treat like brokerage if no ESPP lot data
+                    const result = grossUpBrokerage(remainingNetNeeded, snapshot.gainRatio, ltcgRate);
+                    const grossToWithdraw = Math.min(result.gross, effectiveVestedBalance);
+
+                    const actualLTCG = grossToWithdraw * snapshot.gainRatio;
+                    const actualTax = actualLTCG * ltcgRate;
+                    const netReceived = grossToWithdraw - actualTax;
+
+                    withdrawal = {
+                        source: 'espp',
+                        accountId: snapshot.accountId,
+                        accountName: snapshot.accountName,
+                        gross: grossToWithdraw,
+                        net: netReceived,
+                        capitalGains: { shortTerm: 0, longTerm: actualLTCG },
+                        penalty: 0,
+                        tax: actualTax,
+                        reason,
+                    };
+
+                    cumulativeLTCG += actualLTCG;
+                    remainingNetNeeded -= netReceived;
+                    totalNet += netReceived;
+                    totalGross += grossToWithdraw;
+                    totalTax += actualTax;
+                    totalLTCG += actualLTCG;
+                }
+                break;
+            }
+
+            default:
+                continue;
+        }
+
+        withdrawals.push(withdrawal);
+
+        // Log the withdrawal
+        decisions.push({
+            category: 'withdrawal',
+            account: snapshot.accountName,
+            amount: withdrawal.gross,
+            description: `Withdrew $${withdrawal.gross.toLocaleString()} from ${snapshot.accountName} (net: $${withdrawal.net.toLocaleString()}).`,
+        });
+    }
+
+    // Log if there's remaining deficit
+    if (remainingNetNeeded > 0) {
+        decisions.push({
+            category: 'warning',
+            amount: remainingNetNeeded,
+            description: `Unfunded deficit of $${remainingNetNeeded.toLocaleString()}. All accounts exhausted.`,
+        });
+    }
+
+    return {
+        withdrawals,
+        totalGross,
+        totalNet,
+        totalTax,
+        totalPenalties,
+        totalLTCG,
+        totalSTCG,
+        remainingDeficit: remainingNetNeeded < 0.01 ? 0 : remainingNetNeeded,
+        decisions,
+    };
+}

--- a/src/services/simulation/WithdrawalService.ts
+++ b/src/services/simulation/WithdrawalService.ts
@@ -1,0 +1,51 @@
+import { AnyAccount, DeficitDebtAccount } from "../../components/Objects/Accounts/models";
+
+export interface DeficitDebtResult {
+    existingDeficitDebt: DeficitDebtAccount | undefined;
+    deficitDebtPayment: number;
+    discretionaryCash: number;
+    logs: string[];
+}
+
+/**
+ * Track deficit debt: if there's still an uncovered deficit after all withdrawals.
+ */
+export function processDeficitDebt(
+    discretionaryCash: number,
+    accounts: AnyAccount[],
+    logs: string[]
+): DeficitDebtResult {
+    const DEFICIT_DEBT_ID = 'system-deficit-debt';
+    const DEFICIT_DEBT_NAME = 'Uncovered Deficit';
+    let deficitDebtPayment = 0;
+
+    let existingDeficitDebt = accounts.find(
+        acc => acc instanceof DeficitDebtAccount && acc.id === DEFICIT_DEBT_ID
+    ) as DeficitDebtAccount | undefined;
+
+    // Only create deficit debt for deficits > $0.005 (ignore small rounding errors)
+    if (discretionaryCash < -0.005) {
+        const uncoveredDeficit = Math.abs(discretionaryCash);
+
+        if (existingDeficitDebt) {
+            existingDeficitDebt = new DeficitDebtAccount(
+                DEFICIT_DEBT_ID,
+                DEFICIT_DEBT_NAME,
+                existingDeficitDebt.amount + uncoveredDeficit
+            );
+        } else {
+            existingDeficitDebt = new DeficitDebtAccount(
+                DEFICIT_DEBT_ID,
+                DEFICIT_DEBT_NAME,
+                uncoveredDeficit
+            );
+        }
+
+        logs.push(`[WARN] Uncovered deficit of $${uncoveredDeficit.toLocaleString(undefined, { maximumFractionDigits: 0 })} added to deficit debt`);
+        logs.push(`  Total deficit debt: $${existingDeficitDebt.amount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`);
+
+        discretionaryCash = 0;
+    }
+
+    return { existingDeficitDebt, deficitDebtPayment, discretionaryCash, logs };
+}

--- a/src/services/simulation/YearSolver.ts
+++ b/src/services/simulation/YearSolver.ts
@@ -1,0 +1,2015 @@
+/**
+ * YearSolver.ts
+ *
+ * Phase 2R: Retirement Year Solver
+ *
+ * This is the core convergence solver for retirement years. It handles:
+ * 1. Roth conversion planning (FIRST - determines ordinary income)
+ * 2. Withdrawal planning (SECOND - uses known tax rates)
+ * 3. Convergence loop for bracket crossings
+ *
+ * Design Principles:
+ * - Conversion before withdrawals (conversion affects LTCG rates)
+ * - Algebraic gross-up on BASE deficit (no LTCG in deficit)
+ * - Loop only when bracket crossing occurs (rare)
+ * - Pure functions - no mutations during planning
+ */
+
+import { AnyAccount, InvestedAccount } from "../../components/Objects/Accounts/models";
+import { AnyIncome, FERSPensionIncome } from "../../components/Objects/Income/models";
+// AnyExpense is currently unused but kept for future extension
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { AnyExpense } from "../../components/Objects/Expense/models";
+import { TaxParameters } from "../../data/TaxData";
+import { TaxState } from "../../components/Objects/Taxes/TaxContext";
+import { AssumptionsState } from "../../components/Objects/Assumptions/AssumptionsContext";
+import {
+    YearPlan,
+    PlannedWithdrawal,
+    PlannedConversion,
+    DecisionLogEntry,
+    YearPlanTax,
+    ConversionTaxSource,
+    TaxOptimizationTarget,
+    ConversionConstraints,
+    ConversionLimitingFactor,
+    BaselineProjections,
+} from "./types";
+import { WithdrawalResult } from "../WithdrawalStrategies";
+import { classifyIncome, getTotalSSBenefits } from "./IncomeClassifier";
+import { planWithdrawals, createOrderedSnapshots } from "./WithdrawalPlanner";
+import * as TaxService from "../../components/Objects/Taxes/TaxService";
+import { getLTCGRate } from "../../components/Objects/Taxes/taxService/capitalGainsTax";
+import { calculateEffectiveConversionTax, ACAOptions } from "./helpers";
+import { getRMDStartAge } from "../../data/RMDData";
+import {
+    calculateDynamicConversionCeiling,
+    coarseToFineSearch,
+    getAcaCliffThreshold,
+} from "./TaxOptimizedWithdrawal";
+import { estimateFixedIncomeAtRMD } from "./helpers";
+import { allocateSurplus, SurplusAllocationSettings } from "./SurplusAllocator";
+import { getIRALimit } from "../../data/ContributionLimits";
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const DEFAULT_GROWTH_RATE = 0.07;
+const DEFAULT_EMERGENCY_FUND_TARGET = 30000;
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface YearSolverInput {
+    year: number;
+    currentAge: number;
+    isRetired: boolean;
+
+    // Income & Expenses
+    incomes: AnyIncome[];
+    expenses: AnyExpense[];
+    totalLivingExpenses: number;
+    rmdAmount: number;
+    /**
+     * IRS excise penalty (25% of the RMD shortfall) computed by RMDService when a
+     * required distribution can't be fully satisfied. It's a cash tax with no
+     * matching distribution, so the solver folds it into the year's total tax /
+     * penalties so it reduces cash and shows up in net worth. Defaults to 0.
+     */
+    rmdPenalty?: number;
+
+    // Accounts
+    accounts: AnyAccount[];
+    withdrawalOrder: { accountId: string }[];
+    /**
+     * Accounts reserved for a dedicated purpose (goal sinking funds). The
+     * surplus allocator must never treat these as general savings — without
+     * this, its no-priorities smart-default can pick a goal fund as "the
+     * emergency fund" and stuff surplus into it on top of the committed goal
+     * funding the engine deposits directly.
+     */
+    reservedAccountIds?: string[];
+
+    // Tax state
+    taxState: TaxState;
+    assumptions: AssumptionsState;
+
+    // Strategy
+    strategyResult?: WithdrawalResult;
+
+    // Settings
+    taxOptimizationEnabled: boolean;
+    acaAware: boolean;
+
+    // Prior year data (for GK and conversions)
+    previousSimulation?: { year: number; accounts: AnyAccount[] }[];
+
+    // GK Guardrails (optional - only passed when withdrawal strategy is active)
+    gkBudget?: number;           // The GK-adjusted spending budget
+    fixedExpenses?: number;      // Fixed (non-discretionary) expenses
+    discretionaryExpenses?: number; // Discretionary expenses (may be eliminated)
+
+    // Baseline projections from a per-year forward sub-simulation (std-ded-only
+    // conversions). When provided, the conversion ceiling calculator uses these as
+    // the source of truth for SS/pension/passive/Trad-balance at RMD age — more
+    // accurate than COLA-only fallbacks or naive forward-compounding of today's
+    // Trad balance.
+    baselineProjections?: BaselineProjections;
+
+    // Conversion mode. 'rate-match' (default) runs the full bracket-walking
+    // algorithm. 'std-ded-only' is used by `runProjectionSubsim` to do only
+    // standard-deduction-headroom conversions while projecting the baseline
+    // trajectory for the main sim's rate-match decisions.
+    conversionMode?: 'rate-match' | 'std-ded-only';
+
+    // Precomputed conversion plan keyed by simulation year. Populated only when
+    // `assumptions.investments.rothConversionStrategy === 'dp-precomputed'`. The
+    // DP strategy looks up this year's amount and skips per-year bracket-walking.
+    dpConversionPlan?: Map<number, number>;
+    // Per-year debug-log strings from the DP solver. planConversionDP appends
+    // them to its decisions so they surface in the year inspector. Only set
+    // when the DP strategy is in use.
+    dpDebugByYear?: Map<number, string[]>;
+}
+
+export interface ConversionPlan {
+    conversion: PlannedConversion | null;
+    conversionTax: number;
+    taxSource: ConversionTaxSource;
+    additionalOrdinaryIncome: number;
+    decisions: DecisionLogEntry[];
+    taxOptimizationTarget?: TaxOptimizationTarget;
+    bracketSpaceForSpending: number;  // bracket space reserved for Traditional spending
+}
+
+/**
+ * A conversion-amount-deciding strategy. Implementations decide how much (if any)
+ * Traditional → Roth conversion to do for a single year, given the year's tax
+ * context. The rate-match implementation walks brackets per-year; future DP
+ * implementations precompute a per-year plan and look it up. Both must satisfy
+ * the same input/output contract.
+ */
+export type ConversionStrategy = (
+    input: YearSolverInput,
+    baseOrdinaryIncome: number,
+    socialSecurityBenefits: number,
+    nonSSOrdinaryIncome: number,
+    fedParams: TaxParameters,
+    stateParams: TaxParameters | null,
+    surplus: number,
+    spendingDeficit: number,
+) => ConversionPlan;
+
+/**
+ * Pick the conversion strategy for the current run. The DP path requires a
+ * precomputed plan to be on `input.dpConversionPlan` (built upstream by
+ * `runSimulationWithOptimization`); without it, the DP strategy returns a
+ * no-conversion plan for the year.
+ */
+function selectConversionStrategy(
+    strategyName: 'rate-match' | 'dp-precomputed' | undefined,
+): ConversionStrategy {
+    if (strategyName === 'dp-precomputed') return planConversionDP;
+    return planConversion;
+}
+
+// =============================================================================
+// HELPER FUNCTIONS
+// =============================================================================
+
+function getTotalTraditionalBalance(accounts: AnyAccount[]): number {
+    return accounts
+        .filter(a => a instanceof InvestedAccount &&
+            (a.taxType === 'Traditional 401k' || a.taxType === 'Traditional IRA'))
+        .reduce((sum, a) => sum + (a as InvestedAccount).vestedAmount, 0);
+}
+
+function getTotalBrokerageBalance(accounts: AnyAccount[]): number {
+    return accounts
+        .filter(a => a instanceof InvestedAccount && a.taxType === 'Brokerage')
+        .reduce((sum, a) => sum + (a as InvestedAccount).vestedAmount, 0);
+}
+
+function getFirstTraditionalAccount(accounts: AnyAccount[]): InvestedAccount | null {
+    return accounts.find(a =>
+        a instanceof InvestedAccount &&
+        (a.taxType === 'Traditional 401k' || a.taxType === 'Traditional IRA') &&
+        a.vestedAmount > 0
+    ) as InvestedAccount | null;
+}
+
+function getFirstRothAccount(accounts: AnyAccount[]): InvestedAccount | null {
+    return accounts.find(a =>
+        a instanceof InvestedAccount &&
+        (a.taxType === 'Roth 401k' || a.taxType === 'Roth IRA')
+    ) as InvestedAccount | null;
+}
+
+/**
+ * Get the weighted average gain ratio for brokerage accounts.
+ * Used for estimating LTCG from potential withdrawals.
+ */
+function getBrokerageGainRatio(accounts: AnyAccount[]): number {
+    let totalBalance = 0;
+    let totalGains = 0;
+
+    for (const account of accounts) {
+        if (account instanceof InvestedAccount && account.taxType === 'Brokerage') {
+            const balance = account.vestedAmount;
+            const gains = Math.max(0, balance - account.costBasis);
+            totalBalance += balance;
+            totalGains += gains;
+        }
+    }
+
+    return totalBalance > 0 ? totalGains / totalBalance : 0;
+}
+
+/**
+ * Get LTCG rate based on ordinary income level.
+ * Thin alias over the shared getLTCGRate helper in capitalGainsTax.
+ */
+const getLTCGRateForIncome = getLTCGRate;
+
+/**
+ * Estimate LTCG that would result from covering a deficit via brokerage withdrawal.
+ * Formula: LTCG = grossWithdrawal × gainRatio
+ *          grossWithdrawal = deficit / (1 - gainRatio × ltcgRate)
+ *          When ltcgRate = 0: grossWithdrawal = deficit, LTCG = deficit × gainRatio
+ */
+function estimateLTCGFromDeficit(deficit: number, gainRatio: number, ltcgRate: number = 0): number {
+    if (deficit <= 0 || gainRatio <= 0) return 0;
+
+    const effectiveRate = gainRatio * ltcgRate;
+    const grossWithdrawal = effectiveRate < 1 ? deficit / (1 - effectiveRate) : deficit;
+    return grossWithdrawal * gainRatio;
+}
+
+// =============================================================================
+// CONVERSION PLANNING
+// =============================================================================
+
+/**
+ * Build the inputs for and call calculateDynamicConversionCeiling. Extracted so
+ * both planConversion (rate-match) and planConversionDP can compute the same
+ * ceiling and bracket-space figures — DP uses them only for the spending
+ * reservation gate, rate-match uses them for conversion sizing too.
+ */
+function computeCeilingContext(
+    input: YearSolverInput,
+    baseOrdinaryIncome: number,
+    socialSecurityBenefits: number,
+    fedParams: TaxParameters,
+    stateParams: TaxParameters | null,
+): {
+    ceilingResult: ReturnType<typeof calculateDynamicConversionCeiling>;
+    rmdStartAge: number;
+    yearsUntilRMD: number;
+    fixedIncomeAtRMD: ReturnType<typeof estimateFixedIncomeAtRMD>;
+    passiveIncome: number;
+    growthRate: number;
+    acaOptions?: ACAOptions;
+    traditionalBalance: number;
+} {
+    const traditionalBalance = getTotalTraditionalBalance(input.accounts);
+    const birthYear = input.year - input.currentAge;
+    const rmdStartAge = getRMDStartAge(birthYear);
+    const yearsUntilRMD = Math.max(0, rmdStartAge - input.currentAge);
+
+    // Pension income for the conversion ceiling must include the FERS MRA-to-62
+    // supplement (a bridge payment that ends at 62). FERSPensionIncome exposes it
+    // via getTotalAnnualAmount(); plain getAnnualAmount() drops it. Mirror
+    // IncomeClassifier / CashflowDetailBuilder, which both use the total. Other
+    // pension types (CSRS) have no supplement, so fall back to getAnnualAmount().
+    const pensionIncome = input.incomes
+        .filter(i => i.className?.includes('Pension'))
+        .reduce((sum, i) => sum + (i instanceof FERSPensionIncome
+            ? i.getTotalAnnualAmount(input.year)
+            : i.getAnnualAmount(input.year)), 0);
+
+    const passiveIncome = input.incomes
+        .filter(i => (i as any).className === 'PassiveIncome' && (i as any).sourceType !== 'RMD')
+        .reduce((sum, i) => sum + i.getAnnualAmount(input.year), 0);
+
+    const futureSS = input.incomes.find(i => (i as any).className === 'FutureSocialSecurityIncome') as
+        { calculatedPIA?: number; claimingAge?: number; name?: string; amount?: number; projectedPIA?: number } | undefined;
+    const futureSS_PIA = (futureSS?.projectedPIA && futureSS.projectedPIA > 0)
+        ? futureSS.projectedPIA
+        : (futureSS?.amount ? futureSS.amount / 12 : (futureSS?.calculatedPIA ?? 0));
+    const ssClaimingAge = futureSS?.claimingAge ?? 67;
+
+    const inflationAdjusted = input.assumptions.macro.inflationAdjusted;
+    const ssCola = inflationAdjusted ? 0.02 : 0;
+    const pensionCola = inflationAdjusted ? 0.02 : 0;
+
+    const fixedIncomeAtRMD = estimateFixedIncomeAtRMD(
+        socialSecurityBenefits,
+        futureSS_PIA,
+        pensionIncome,
+        input.currentAge,
+        rmdStartAge,
+        ssClaimingAge,
+        ssCola,
+        pensionCola
+    );
+
+    const grossRoR = input.assumptions.investments.returnRates.ror ?? (DEFAULT_GROWTH_RATE * 100);
+    const tradAccounts = input.accounts.filter(a =>
+        a instanceof InvestedAccount &&
+        (a.taxType === 'Traditional 401k' || a.taxType === 'Traditional IRA')
+    ) as InvestedAccount[];
+    const totalTradBalance = tradAccounts.reduce((sum, a) => sum + a.vestedAmount, 0);
+    const weightedER = totalTradBalance > 0
+        ? tradAccounts.reduce((sum, a) => sum + a.expenseRatio * a.vestedAmount, 0) / totalTradBalance
+        : 0;
+    const growthRate = (grossRoR - weightedER) / 100;
+
+    let acaOptions: ACAOptions | undefined;
+    if (input.acaAware && input.currentAge < 65) {
+        // Use the shared 400% FPL cliff (by year + filing status) rather than hardcoded
+        // values, matching RothConversionDP. The old constants ($125k MFJ / $62.5k single)
+        // diverged from the real thresholds (~$81.8k / $60.2k for 2024).
+        const acaFiling: 'single' | 'married_filing_jointly' =
+            input.taxState.filingStatus === 'Married Filing Jointly' ? 'married_filing_jointly' : 'single';
+        acaOptions = {
+            currentAge: input.currentAge,
+            acaSubsidyAware: true,
+            acaCliffThreshold: getAcaCliffThreshold(acaFiling, input.year),
+            estimatedSubsidyLoss: 12000,
+        };
+    }
+
+    const ceilingResult = calculateDynamicConversionCeiling(
+        traditionalBalance,
+        yearsUntilRMD,
+        fixedIncomeAtRMD.pensionAtRMD,
+        fixedIncomeAtRMD.ssAtRMD,
+        passiveIncome,
+        baseOrdinaryIncome,
+        socialSecurityBenefits,
+        0,
+        growthRate,
+        rmdStartAge,
+        fedParams,
+        input.taxState,
+        stateParams,
+        acaOptions,
+        input.baselineProjections,
+        input.assumptions,
+        input.conversionMode ?? 'rate-match'
+    );
+
+    return {
+        ceilingResult,
+        rmdStartAge,
+        yearsUntilRMD,
+        fixedIncomeAtRMD,
+        passiveIncome,
+        growthRate,
+        acaOptions,
+        traditionalBalance,
+    };
+}
+
+/**
+ * Plan Roth conversion for the year.
+ *
+ * Conversion is planned FIRST because it affects:
+ * 1. Ordinary income (determines marginal rates)
+ * 2. LTCG rate (stacks on top of ordinary income)
+ * 3. SS taxability (provisional income includes conversion)
+ */
+function planConversion(
+    input: YearSolverInput,
+    baseOrdinaryIncome: number, // non-SS ordinary income + taxable SS (federal bracket-positioning base)
+    socialSecurityBenefits: number,
+    nonSSOrdinaryIncome: number, // ordinary income EXCLUDING SS entirely (taxableBase - fullSS)
+    fedParams: TaxParameters,
+    stateParams: TaxParameters | null,
+    surplus: number, // Cash surplus that could pay conversion tax
+    spendingDeficit: number  // pre-tax deficit estimate (expenses + roughTax - spendable - RMD)
+): ConversionPlan {
+    const decisions: DecisionLogEntry[] = [];
+    let bracketSpaceForSpending = 0;
+
+    const traditionalBalance = getTotalTraditionalBalance(input.accounts);
+
+    // Skip conversion if not enabled or not retired
+    if (!input.taxOptimizationEnabled || !input.isRetired) {
+        const limitingFactor: ConversionLimitingFactor = !input.isRetired ? 'NOT_RETIRED' : 'OPTIMIZATION_DISABLED';
+        return {
+            conversion: null,
+            conversionTax: 0,
+            taxSource: 'SURPLUS',
+            additionalOrdinaryIncome: 0,
+            decisions,
+            bracketSpaceForSpending: 0,
+            taxOptimizationTarget: {
+                yearsUntilRMD: 0,
+                rmdStartAge: 73,
+                targetBracketCeiling: 0,
+                bracketSpaceThisYear: 0,
+                ssAtRMD: 0,
+                pensionAtRMD: 0,
+                currentTraditionalBalance: traditionalBalance,
+                limitingFactor,
+                actualConversion: 0,
+            },
+        };
+    }
+
+    if (traditionalBalance <= 0) {
+        decisions.push({
+            category: 'conversion',
+            description: 'Skipped Roth conversion: no Traditional balance available.',
+        });
+        return {
+            conversion: null,
+            conversionTax: 0,
+            taxSource: 'SURPLUS',
+            additionalOrdinaryIncome: 0,
+            decisions,
+            bracketSpaceForSpending: 0,
+            taxOptimizationTarget: {
+                yearsUntilRMD: 0,
+                rmdStartAge: 73,
+                targetBracketCeiling: 0,
+                bracketSpaceThisYear: 0,
+                ssAtRMD: 0,
+                pensionAtRMD: 0,
+                currentTraditionalBalance: 0,
+                limitingFactor: 'TRADITIONAL_DEPLETED',
+                actualConversion: 0,
+            },
+        };
+    }
+
+    const {
+        ceilingResult,
+        rmdStartAge,
+        yearsUntilRMD,
+        fixedIncomeAtRMD,
+        acaOptions,
+    } = computeCeilingContext(input, baseOrdinaryIncome, socialSecurityBenefits, fedParams, stateParams);
+
+    // Log ceiling decision so it's visible in the year inspector
+    decisions.push({
+        category: 'conversion',
+        description:
+            `Ceiling: ${yearsUntilRMD}yr to RMD, ` +
+            `Trad@RMD ~$${Math.round(ceilingResult.projectedBalanceAtRMD).toLocaleString()} ` +
+            `(baseline no-conversion), ` +
+            `peak RMD ~$${Math.round(ceilingResult.peakRMD).toLocaleString()}/yr ` +
+            `→ ${(ceilingResult.peakRMDBracket * 100).toFixed(0)}% bracket ` +
+            `→ ceiling ${ceilingResult.conversionCeiling > 0 ? (ceilingResult.conversionCeiling * 100).toFixed(0) + '%' : 'none (0%)'}.`,
+    });
+
+    // Build constraint details for debugging
+    const constraintDetails: ConversionConstraints = {
+        bracketCeiling: ceilingResult.conversionCeiling,
+        bracketTop: 0, // Will be calculated below
+        currentAGI: baseOrdinaryIncome,
+        rawBracketSpace: ceilingResult.bracketSpacePerYear,
+        ssTorpedoReduction: 0,
+        acaCliffReduction: 0,
+        effectiveBracketSpace: ceilingResult.bracketSpacePerYear,
+        ssTorpedoTriggered: false,
+        acaCliffTriggered: false,
+    };
+
+    // Calculate bracket top based on filing status and target ceiling
+    const bracketThresholds = fedParams.brackets.filter(b => b.rate <= ceilingResult.conversionCeiling);
+    if (bracketThresholds.length > 0) {
+        const topBracket = bracketThresholds[bracketThresholds.length - 1];
+        // Next bracket threshold is the top of current bracket
+        const nextBracketIdx = fedParams.brackets.findIndex(b => b.rate > ceilingResult.conversionCeiling);
+        if (nextBracketIdx > 0) {
+            constraintDetails.bracketTop = fedParams.brackets[nextBracketIdx].threshold + fedParams.standardDeduction;
+        } else {
+            // At highest bracket
+            constraintDetails.bracketTop = topBracket.threshold + fedParams.standardDeduction + 1000000;
+        }
+    }
+
+    // Build the tax optimization target info for UI display
+    const taxOptimizationTarget: TaxOptimizationTarget = {
+        yearsUntilRMD,
+        rmdStartAge,
+        targetBracketCeiling: ceilingResult.conversionCeiling,
+        bracketSpaceThisYear: ceilingResult.bracketSpacePerYear,
+        ssAtRMD: fixedIncomeAtRMD.ssAtRMD,
+        pensionAtRMD: fixedIncomeAtRMD.pensionAtRMD,
+        projectedBalanceAtRMD: ceilingResult.projectedBalanceAtRMD,
+        currentTraditionalBalance: traditionalBalance,
+        constraintDetails,
+        rateMatchWalk: ceilingResult.rateMatchWalk,
+    };
+
+    // Calculate bracket space
+    let bracketSpace = Math.max(0, ceilingResult.bracketSpacePerYear);
+
+    if (bracketSpace <= 0) {
+        decisions.push({
+            category: 'conversion',
+            description: `Skipped Roth conversion: no bracket space (income $${baseOrdinaryIncome.toLocaleString()} at ceiling ${(ceilingResult.conversionCeiling * 100).toFixed(0)}% bracket).`,
+        });
+        taxOptimizationTarget.limitingFactor = 'NO_BRACKET_SPACE';
+        taxOptimizationTarget.actualConversion = 0;
+        return {
+            conversion: null,
+            conversionTax: 0,
+            taxSource: 'SURPLUS',
+            additionalOrdinaryIncome: 0,
+            decisions,
+            bracketSpaceForSpending: 0,
+            taxOptimizationTarget,
+        };
+    }
+
+    // =========================================================================
+    // SPENDING DEFICIT: Reserve bracket space for Traditional withdrawals
+    // =========================================================================
+    // When there's a spending deficit and brokerage can't cover it, the solver
+    // would convert Traditional→Roth then withdraw Roth for spending — a wasteful
+    // roundtrip. Instead, reserve bracket space for direct Traditional withdrawal.
+    //
+    // Two guards:
+    // 1. Age >= 59.5 only. Under 59.5, conversion is strictly cheaper than
+    //    penalized Traditional withdrawal. Spending comes from Roth contribution
+    //    basis (penalty-free FIFO) or brokerage.
+    // 2. Brokerage insufficient. When brokerage covers the deficit, no roundtrip
+    //    exists — conversion fills brackets while brokerage handles spending.
+    //    Only reserve for the shortfall that would spill into Roth.
+    const penaltyApplies = input.currentAge < 59.5;
+    if (spendingDeficit > 0 && traditionalBalance > 0 && bracketSpace > 0 && !penaltyApplies) {
+        // Check how much of the deficit brokerage can cover
+        const brokerageBalance = getTotalBrokerageBalance(input.accounts);
+        const brokerageGainRatio = getBrokerageGainRatio(input.accounts);
+        const ltcgRate = getLTCGRateForIncome(baseOrdinaryIncome, fedParams);
+        // Gross down: brokerage withdrawal of $B yields $B × (1 - gainRatio × ltcgRate) net
+        const brokerageCoverage = brokerageBalance * (1 - brokerageGainRatio * ltcgRate);
+        const rothBoundDeficit = Math.max(0, spendingDeficit - brokerageCoverage);
+
+        if (rothBoundDeficit > 0) {
+            const marginalResult = TaxService.getMarginalTaxRate(
+                Math.max(0, baseOrdinaryIncome - fedParams.standardDeduction),
+                fedParams
+            );
+            const stateRate = stateParams
+                ? TaxService.getMarginalTaxRate(
+                    Math.max(0, baseOrdinaryIncome - stateParams.standardDeduction),
+                    stateParams
+                  ).rate
+                : 0;
+
+            // Only reserve when marginal rate is at or below the ceiling
+            if (marginalResult.rate <= ceilingResult.conversionCeiling + 0.005) {
+                // Gross-up the Roth-bound portion to bracket space terms
+                const totalEffectiveRate = marginalResult.rate + stateRate;
+                const grossForDeficit = rothBoundDeficit / Math.max(0.5, 1 - totalEffectiveRate);
+                bracketSpaceForSpending = Math.min(grossForDeficit, bracketSpace, traditionalBalance);
+
+                // Reduce bracket space available for conversion
+                bracketSpace = Math.max(0, bracketSpace - bracketSpaceForSpending);
+
+                decisions.push({
+                    category: 'conversion',
+                    amount: bracketSpaceForSpending,
+                    description: `Reserved $${Math.round(bracketSpaceForSpending).toLocaleString()} bracket space ` +
+                        `for Traditional spending (Roth-bound deficit $${Math.round(rothBoundDeficit).toLocaleString()} ` +
+                        `of $${Math.round(spendingDeficit).toLocaleString()} total, ` +
+                        `brokerage covers $${Math.round(brokerageCoverage).toLocaleString()}, ` +
+                        `marginal rate ${(marginalResult.rate * 100).toFixed(1)}% ` +
+                        `vs ${(ceilingResult.conversionCeiling * 100).toFixed(0)}% ceiling).`,
+                });
+
+                if (bracketSpace <= 0) {
+                    taxOptimizationTarget.limitingFactor = 'SPENDING_DEFICIT';
+                }
+            }
+        }
+    }
+
+    // Calculate conversion amount: min of bracket space (after spending reservation)
+    // and available Traditional balance. Iterative refinement of baselineProjections
+    // (in runSimulationWithOptimization) handles the "smooth glidepath" behavior
+    // PMT pacing previously aimed for.
+    const availableTraditional = traditionalBalance - bracketSpaceForSpending;
+    let conversionAmount = Math.min(bracketSpace, availableTraditional);
+
+    // Use coarse-to-fine search for optimal amount considering SS torpedo.
+    // Federal-only rates: the ceiling (e.g., 12%) is a federal bracket target.
+    // State tax is still fully accounted for in the actual conversion tax cost.
+    // Adjust base income and available balance for spending reservation.
+    // Base must EXCLUDE SS: the search → getEffectiveConversionRate →
+    // calculateEffectiveConversionTax re-derives taxable SS internally from the
+    // separate socialSecurityBenefits arg. Passing baseOrdinaryIncome (which
+    // already includes taxable SS) double-counts SS. Mirror the direct conversion-
+    // tax call below, which passes nonSSOrdinaryIncome.
+    const adjustedNonSSBaseIncome = nonSSOrdinaryIncome + bracketSpaceForSpending;
+    const searchResult = coarseToFineSearch(
+        ceilingResult.conversionCeiling,
+        traditionalBalance - bracketSpaceForSpending,
+        adjustedNonSSBaseIncome,
+        socialSecurityBenefits,
+        0, // ltcgIncome
+        fedParams,
+        input.taxState,
+        input.year,
+        null, // federal-only: state tax should not reduce conversion amount
+        acaOptions,
+        input.assumptions
+    );
+
+    if (searchResult.amount > 0) {
+        conversionAmount = Math.min(conversionAmount, searchResult.amount);
+    }
+
+    // Log conversion sizing breakdown so the user can see what constrained the amount
+    {
+        const constraints: string[] = [];
+        const rawBracketSpace = ceilingResult.bracketSpacePerYear;
+        const effectiveBracket = bracketSpace; // after spending reservation
+
+        if (bracketSpaceForSpending > 0) {
+            constraints.push(`spending reservation $${Math.round(bracketSpaceForSpending).toLocaleString()}`);
+        }
+        if (availableTraditional < effectiveBracket) {
+            constraints.push(`Traditional balance $${Math.round(availableTraditional).toLocaleString()}`);
+        }
+        if (searchResult.amount > 0 && searchResult.amount < conversionAmount + 100) {
+            constraints.push(`SS torpedo search $${Math.round(searchResult.amount).toLocaleString()}${searchResult.edgeType === 'SS_TORPEDO' ? ' (torpedo)' : ''}`);
+        }
+
+        const limitedBy = constraints.length > 0
+            ? `Limited by: ${constraints.join('; ')}.`
+            : `Using full bracket space.`;
+
+        decisions.push({
+            category: 'conversion',
+            amount: conversionAmount,
+            description: `Conversion sizing: bracket space $${Math.round(rawBracketSpace).toLocaleString()} ` +
+                `(ceiling ${(ceilingResult.conversionCeiling * 100).toFixed(0)}%), ` +
+                `result $${Math.round(conversionAmount).toLocaleString()}. ${limitedBy}`,
+        });
+    }
+
+    // =========================================================================
+    // ACA CLIFF ENFORCEMENT: Account for LTCG in MAGI calculation
+    // =========================================================================
+    // The algebraic approach:
+    //   MAGI = conversion + LTCG
+    //   LTCG comes from brokerage withdrawals to cover deficit
+    //   deficit = expenses + ordinaryTax(conversion) - income
+    // We need to find max conversion where MAGI ≤ cliff
+    if (acaOptions && input.acaAware && input.currentAge < 65 && conversionAmount > 0) {
+        const acaCliff = acaOptions.acaCliffThreshold;
+        const gainRatio = getBrokerageGainRatio(input.accounts);
+
+        // Get the EXACT same values the solver uses
+        const incomeClass = classifyIncome(input.incomes, input.rmdAmount, 0, input.year);
+        const spendableIncome = incomeClass.classified.spendable;
+        const preTaxDeductions = TaxService.getPreTaxExemptions(input.incomes, input.year, input.currentAge, true);
+        const ficaTax = TaxService.calculateFicaTax(input.taxState, input.incomes, input.year, input.assumptions);
+
+        // Function to estimate MAGI for a given conversion - uses EXACT same logic as solver
+        const estimateMAGI = (conversion: number): number => {
+            // 1. Calculate ordinary income with conversion (same as solver line 690)
+            const allOrdinaryIncome = baseOrdinaryIncome + conversion;
+
+            // 2. Calculate federal tax using the SAME function as solver (lines 716-724).
+            // First arg = ordinary income EXCLUDING SS. nonSSOrdinaryIncome already
+            // strips SS; baseOrdinaryIncome - socialSecurityBenefits would mis-net it
+            // (baseOrdinaryIncome holds taxable SS, not full SS).
+            const ordinaryTaxResult = TaxService.calculateTotalFederalTax(
+                nonSSOrdinaryIncome + conversion, // non-SS ordinary income
+                socialSecurityBenefits,
+                0, // STCG
+                0, // LTCG - not known yet
+                preTaxDeductions,
+                input.taxState.filingStatus,
+                fedParams
+            );
+
+            // 3. Calculate state tax (same as solver lines 726-728)
+            const stateTax = stateParams
+                ? TaxService.calculateTax(allOrdinaryIncome, preTaxDeductions, stateParams)
+                : 0;
+
+            // 4. Total ordinary tax (same as solver line 732)
+            const ordinaryTax = ordinaryTaxResult.totalTax + stateTax;
+
+            // 5. Calculate base deficit using SAME formula as solver
+            // Note: ordinaryTax already includes conversion tax (via allOrdinaryIncome),
+            // so no separate adjustment needed for taxSource='BROKERAGE'.
+            const estimatedDeficit = Math.max(0,
+                input.totalLivingExpenses + ordinaryTax + ficaTax - spendableIncome - input.rmdAmount
+            );
+
+            // 6. Calculate LTCG using gross-up formula
+            // Determine LTCG rate based on income level (same logic as WithdrawalPlanner)
+            const ltcgRate = getLTCGRateForIncome(allOrdinaryIncome, fedParams);
+            const estimatedLTCG = estimateLTCGFromDeficit(estimatedDeficit, gainRatio, ltcgRate);
+
+            // ACA MAGI = all gross income including 100% of SS (not just taxable portion)
+            // spendable + reinvested already includes full SS, so no separate SS addition needed.
+            // Previous formula (baseOrdinaryIncome + socialSecurityBenefits) double-counted SS
+            // because baseOrdinaryIncome already contains taxableSS.
+            const grossIncomeBase = incomeClass.classified.spendable + incomeClass.classified.reinvested;
+            return grossIncomeBase + conversion + estimatedLTCG;
+        };
+
+        const originalConversion = conversionAmount;
+        const initialMAGI = estimateMAGI(conversionAmount);
+
+        if (initialMAGI > acaCliff) {
+            // Need to reduce conversion - use binary search
+            const ACA_BUFFER = 1000; // $1k buffer under cliff
+            const targetMAGI = acaCliff - ACA_BUFFER;
+
+            let lo = 0;
+            let hi = conversionAmount;
+            let bestConversion = 0;
+
+            // Binary search for max conversion where MAGI ≤ targetMAGI
+            for (let i = 0; i < 20 && hi - lo > 100; i++) {
+                const mid = (lo + hi) / 2;
+                const magi = estimateMAGI(mid);
+
+                if (magi <= targetMAGI) {
+                    bestConversion = mid;
+                    lo = mid;
+                } else {
+                    hi = mid;
+                }
+            }
+
+            // If buffer was too aggressive (MAGI at conv=0 is between target and cliff),
+            // retry with no buffer to squeeze in a small conversion
+            if (bestConversion === 0 && estimateMAGI(0) < acaCliff) {
+                lo = 0;
+                hi = conversionAmount;
+                for (let i = 0; i < 20 && hi - lo > 100; i++) {
+                    const mid = (lo + hi) / 2;
+                    if (estimateMAGI(mid) <= acaCliff) {
+                        bestConversion = mid;
+                        lo = mid;
+                    } else {
+                        hi = mid;
+                    }
+                }
+            }
+
+            conversionAmount = Math.max(0, Math.floor(bestConversion));
+
+            // Log the reduction
+            if (conversionAmount < originalConversion) {
+                const finalMAGI = estimateMAGI(conversionAmount);
+                const acaReduction = originalConversion - conversionAmount;
+                decisions.push({
+                    category: 'conversion',
+                    amount: acaReduction,
+                    description: `Conversion reduced from $${originalConversion.toLocaleString()} to $${conversionAmount.toLocaleString()}: MAGI ($${Math.round(finalMAGI).toLocaleString()}) would exceed ACA cliff ($${acaCliff.toLocaleString()}) with estimated LTCG.`,
+                });
+                // Update constraint details with ACA info
+                constraintDetails.acaCliffTriggered = true;
+                constraintDetails.acaCliffReduction = acaReduction;
+                constraintDetails.currentMAGI = finalMAGI;
+                constraintDetails.acaCliffThreshold = acaCliff;
+                constraintDetails.brokerageGainRatio = gainRatio;
+                taxOptimizationTarget.limitingFactor = 'ACA_CLIFF';
+            }
+        }
+    }
+
+    // Update constraint details if SS torpedo was detected
+    if (searchResult.edgeType === 'SS_TORPEDO') {
+        constraintDetails.ssTorpedoTriggered = true;
+        // Calculate how much was lost to SS torpedo
+        const torpedoReduction = Math.max(0, bracketSpace - searchResult.amount);
+        constraintDetails.ssTorpedoReduction = torpedoReduction;
+        constraintDetails.effectiveBracketSpace = searchResult.amount;
+        if (!taxOptimizationTarget.limitingFactor) {
+            taxOptimizationTarget.limitingFactor = 'SS_TORPEDO';
+        }
+    }
+
+    if (conversionAmount <= 0) {
+        // Log why conversion was skipped — but don't overwrite limitingFactor if already set (e.g., by ACA cliff)
+        if (!taxOptimizationTarget.limitingFactor) {
+            decisions.push({
+                category: 'conversion',
+                description: `Skipped Roth conversion: no bracket space available.`,
+            });
+            taxOptimizationTarget.limitingFactor = 'NO_BRACKET_SPACE';
+        }
+        taxOptimizationTarget.actualConversion = 0;
+        return {
+            conversion: null,
+            conversionTax: 0,
+            taxSource: 'SURPLUS',
+            additionalOrdinaryIncome: 0,
+            decisions,
+            bracketSpaceForSpending,
+            taxOptimizationTarget,
+        };
+    }
+
+    // Estimate LTCG that the year will realize. Brokerage gets sold for two
+    // reasons: covering this year's spending deficit, and covering the
+    // conversion tax (when taxSource is BROKERAGE). The LTCG bumps the
+    // conversion's tax cost (LTCG rate goes from 0% → 15% / 15% → 20% as
+    // ordinary income rises), so we want it reflected in the displayed
+    // conversionTax. Same formula the ACA-cliff binary-search uses above.
+    const ltcgGainRatio = getBrokerageGainRatio(input.accounts);
+    const ltcgRateAtIncome = getLTCGRateForIncome(baseOrdinaryIncome + conversionAmount, fedParams);
+    const estimatedLTCGForYear = estimateLTCGFromDeficit(
+        Math.max(0, spendingDeficit),
+        ltcgGainRatio,
+        ltcgRateAtIncome,
+    );
+
+    // Calculate conversion tax.
+    // First arg must be ordinary income EXCLUDING SS — the function re-derives
+    // taxable SS internally from the separate socialSecurityBenefits arg. Passing
+    // baseOrdinaryIncome (which already includes taxable SS) double-counts SS.
+    const conversionTaxResult = calculateEffectiveConversionTax(
+        nonSSOrdinaryIncome,
+        socialSecurityBenefits,
+        estimatedLTCGForYear,
+        conversionAmount,
+        input.taxState.filingStatus,
+        fedParams,
+        stateParams,
+        acaOptions
+    );
+
+    const conversionTax = conversionTaxResult.taxIncrease;
+    const conversionFedTax = conversionTaxResult.breakdown.federalOrdinaryTaxCost
+                           + conversionTaxResult.breakdown.ssTorpedoCost
+                           + conversionTaxResult.breakdown.ltcgBumpCost
+                           + conversionTaxResult.breakdown.niitCost;
+    const conversionStateTax = conversionTaxResult.breakdown.stateTaxCost;
+
+    // Determine tax payment source
+    let taxSource: ConversionTaxSource = 'SURPLUS';
+    let netToRoth = conversionAmount;
+
+    const brokerageBalance = getTotalBrokerageBalance(input.accounts);
+
+    if (surplus >= conversionTax) {
+        taxSource = 'SURPLUS';
+    } else if (brokerageBalance >= conversionTax) {
+        taxSource = 'BROKERAGE';
+    } else {
+        // No surplus or brokerage to pay tax — tax is covered by the
+        // spending deficit (which already includes conversion tax via
+        // finalFedResult.totalTax). Full conversion amount reaches Roth.
+        taxSource = 'WITHHOLD';
+    }
+
+    // Find source and target accounts
+    const sourceAccount = getFirstTraditionalAccount(input.accounts);
+    const targetAccount = getFirstRothAccount(input.accounts);
+
+    if (!sourceAccount || !targetAccount) {
+        decisions.push({
+            category: 'conversion',
+            description: 'Skipped Roth conversion: no valid source or target account.',
+        });
+        return {
+            conversion: null,
+            conversionTax: 0,
+            taxSource: 'SURPLUS',
+            additionalOrdinaryIncome: 0,
+            decisions,
+            bracketSpaceForSpending,
+            taxOptimizationTarget,
+        };
+    }
+
+    const conversion: PlannedConversion = {
+        amount: conversionAmount,
+        fromAccountId: sourceAccount.id,
+        toAccountId: targetAccount.id,
+        taxSource,
+        taxAmount: conversionTax,
+        federalTaxCost: conversionFedTax,
+        stateTaxCost: conversionStateTax,
+        netToRoth,
+        reason: `Roth conversion to fill ${(ceilingResult.conversionCeiling * 100).toFixed(0)}% bracket. Tax paid from ${taxSource.toLowerCase()}.`,
+    };
+
+    decisions.push({
+        category: 'conversion',
+        account: sourceAccount.name,
+        amount: conversionAmount,
+        description: `Converted $${conversionAmount.toLocaleString()} from ${sourceAccount.name} to Roth. Tax: $${conversionTax.toLocaleString()} (${taxSource.toLowerCase()}).`,
+    });
+
+    // Update actual conversion amount and determine limiting factor if not already set
+    taxOptimizationTarget.actualConversion = conversionAmount;
+
+    // Determine limiting factor if not already set. Without PMT, the conversion is
+    // either capped by bracket space (most common) or by available Traditional balance.
+    if (!taxOptimizationTarget.limitingFactor) {
+        if (conversionAmount >= availableTraditional - 1) {
+            taxOptimizationTarget.limitingFactor = 'TRADITIONAL_DEPLETED';
+        } else {
+            taxOptimizationTarget.limitingFactor = 'BRACKET_CEILING';
+        }
+    }
+
+    return {
+        conversion,
+        conversionTax,
+        taxSource,
+        additionalOrdinaryIncome: conversionAmount,
+        decisions,
+        bracketSpaceForSpending,
+        taxOptimizationTarget,
+    };
+}
+
+/**
+ * DP-precomputed conversion strategy. Reads `input.dpConversionPlan?.get(year)`
+ * (set upstream by `runSimulationWithOptimization`), clamps to available trad
+ * balance, then runs the same downstream tax-payment / account-selection logic
+ * as the rate-match path.
+ *
+ * Skip cases: not retired, optimization off, no DP plan, no traditional
+ * balance, no source/target account. Falls through with the no-conversion
+ * shape — same as rate-match's skip cases.
+ */
+function planConversionDP(
+    input: YearSolverInput,
+    baseOrdinaryIncome: number, // non-SS ordinary income + taxable SS (federal bracket-positioning base)
+    socialSecurityBenefits: number,
+    nonSSOrdinaryIncome: number, // ordinary income EXCLUDING SS entirely (taxableBase - fullSS)
+    fedParams: TaxParameters,
+    stateParams: TaxParameters | null,
+    surplus: number,
+    spendingDeficit: number,
+): ConversionPlan {
+    const decisions: DecisionLogEntry[] = [];
+    const traditionalBalance = getTotalTraditionalBalance(input.accounts);
+    let bracketSpaceForSpending = 0;
+
+    // Surface DP solver's per-year debug into the year inspector.
+    const dpDebugLines = input.dpDebugByYear?.get(input.year) ?? [];
+    for (const line of dpDebugLines) {
+        decisions.push({ category: 'conversion', description: line });
+    }
+
+    const skipReturn = (limitingFactor: ConversionLimitingFactor, description?: string): ConversionPlan => {
+        if (description) {
+            decisions.push({ category: 'conversion', description });
+        }
+        return {
+            conversion: null,
+            conversionTax: 0,
+            taxSource: 'SURPLUS',
+            additionalOrdinaryIncome: 0,
+            decisions,
+            bracketSpaceForSpending,
+            taxOptimizationTarget: {
+                yearsUntilRMD: Math.max(0, getRMDStartAge(input.year - input.currentAge) - input.currentAge),
+                rmdStartAge: getRMDStartAge(input.year - input.currentAge),
+                targetBracketCeiling: 0,
+                bracketSpaceThisYear: 0,
+                ssAtRMD: 0,
+                pensionAtRMD: 0,
+                currentTraditionalBalance: traditionalBalance,
+                limitingFactor,
+                actualConversion: 0,
+            },
+        };
+    };
+
+    if (!input.taxOptimizationEnabled || !input.isRetired) {
+        return skipReturn('NOT_RETIRED');
+    }
+    if (traditionalBalance <= 0) {
+        return skipReturn('TRADITIONAL_DEPLETED', 'Skipped Roth conversion: no Traditional balance available.');
+    }
+
+    // Spending-deficit reservation. Mirrors planConversion: when there's a
+    // Roth-bound spending deficit (brokerage can't cover it) and we're not
+    // penalized (age >= 59.5), reserve trad bracket space for direct
+    // Traditional withdrawal — avoids the wasteful "convert → withdraw Roth
+    // for spending" round-trip. Downstream in solveRetirementYear, a non-zero
+    // bracketSpaceForSpending puts trad first (capped at the reservation).
+    //
+    // Gate uses the same conversion ceiling as rate-match (computed via
+    // computeCeilingContext). When ceiling=0% (future RMDs land in 12% or
+    // lower, no incentive to convert into a taxable bracket), reservation
+    // only fires if first-dollar marginal is also 0% — preventing the
+    // bracket-crossing $219k withdrawals at 22% marginal that the older
+    // hardcoded-24% gate produced.
+    const penaltyApplies = input.currentAge < 59.5;
+    if (spendingDeficit > 0 && !penaltyApplies) {
+        const { ceilingResult } = computeCeilingContext(
+            input, baseOrdinaryIncome, socialSecurityBenefits, fedParams, stateParams,
+        );
+        const conversionCeiling = ceilingResult.conversionCeiling;
+        const bracketSpacePerYear = Math.max(0, ceilingResult.bracketSpacePerYear);
+
+        const brokerageBalance = getTotalBrokerageBalance(input.accounts);
+        const brokerageGainRatio = getBrokerageGainRatio(input.accounts);
+        const ltcgRate = getLTCGRateForIncome(baseOrdinaryIncome, fedParams);
+        const brokerageCoverage = brokerageBalance * (1 - brokerageGainRatio * ltcgRate);
+        const rothBoundDeficit = Math.max(0, spendingDeficit - brokerageCoverage);
+
+        if (rothBoundDeficit > 0 && bracketSpacePerYear > 0) {
+            const marginalResult = TaxService.getMarginalTaxRate(
+                Math.max(0, baseOrdinaryIncome - fedParams.standardDeduction),
+                fedParams,
+            );
+            const stateRate = stateParams
+                ? TaxService.getMarginalTaxRate(
+                    Math.max(0, baseOrdinaryIncome - stateParams.standardDeduction),
+                    stateParams,
+                  ).rate
+                : 0;
+
+            const gateOk = marginalResult.rate <= conversionCeiling + 0.005;
+            if (gateOk) {
+                const totalEffectiveRate = marginalResult.rate + stateRate;
+                const grossForDeficit = rothBoundDeficit / Math.max(0.5, 1 - totalEffectiveRate);
+                bracketSpaceForSpending = Math.min(grossForDeficit, bracketSpacePerYear, traditionalBalance);
+
+                decisions.push({
+                    category: 'conversion',
+                    amount: bracketSpaceForSpending,
+                    description: `Reserved $${Math.round(bracketSpaceForSpending).toLocaleString()} bracket space ` +
+                        `for Traditional spending (Roth-bound deficit $${Math.round(rothBoundDeficit).toLocaleString()} ` +
+                        `of $${Math.round(spendingDeficit).toLocaleString()} total, ` +
+                        `brokerage covers $${Math.round(brokerageCoverage).toLocaleString()}, ` +
+                        `marginal rate ${(marginalResult.rate * 100).toFixed(1)}% ` +
+                        `vs ${(conversionCeiling * 100).toFixed(0)}% ceiling).`,
+                });
+            } else {
+                decisions.push({
+                    category: 'conversion',
+                    description: `[DEBUG DP exec] year=${input.year}: spending reservation skipped — ` +
+                        `marginal ${(marginalResult.rate * 100).toFixed(1)}% > ceiling ${(conversionCeiling * 100).toFixed(0)}%; ` +
+                        `Roth-bound deficit $${Math.round(rothBoundDeficit).toLocaleString()} stays Roth-funded.`,
+                });
+            }
+        }
+    }
+
+    // Look up the precomputed conversion amount. Clamp to (traditional - reserved
+    // for spending) so the conversion doesn't compete with the spending withdrawal.
+    const availableTradForConversion = Math.max(0, traditionalBalance - bracketSpaceForSpending);
+    const targetConversion = input.dpConversionPlan?.get(input.year) ?? 0;
+    const conversionAmount = Math.max(0, Math.min(targetConversion, availableTradForConversion));
+
+    // Log real-sim balances side-by-side with DP's projection so we can spot
+    // when DP's forward-sweep state diverges from reality.
+    const realRothBalance = input.accounts
+        .filter(a => a instanceof InvestedAccount && a.taxType === 'Roth IRA')
+        .reduce((sum, a) => sum + (a as InvestedAccount).vestedAmount, 0);
+    const realBrokerageBalance = getTotalBrokerageBalance(input.accounts);
+    decisions.push({
+        category: 'conversion',
+        description:
+            `[DEBUG DP exec] year=${input.year}: plan-lookup=${'$' + Math.round(targetConversion).toLocaleString()}, ` +
+            `traditional=${'$' + Math.round(traditionalBalance).toLocaleString()}, ` +
+            `bracketSpaceForSpending=${'$' + Math.round(bracketSpaceForSpending).toLocaleString()}, ` +
+            `availableTrad=${'$' + Math.round(availableTradForConversion).toLocaleString()}, ` +
+            `clampedAmount=${'$' + Math.round(conversionAmount).toLocaleString()}, ` +
+            `dpPlanProvided=${input.dpConversionPlan ? 'yes' : 'no'}`,
+    });
+    decisions.push({
+        category: 'conversion',
+        description:
+            `[DEBUG DP reality] year=${input.year}: ` +
+            `realTrad=${'$' + Math.round(traditionalBalance).toLocaleString()}, ` +
+            `realRoth=${'$' + Math.round(realRothBalance).toLocaleString()}, ` +
+            `realBrokerage=${'$' + Math.round(realBrokerageBalance).toLocaleString()} ` +
+            `— compare against [DEBUG DP solver] tradEntering and [DEBUG DP baseline] for divergence.`,
+    });
+
+    if (conversionAmount <= 0) {
+        // Spending reservation may still be nonzero — preserve it via skipReturn.
+        return skipReturn(
+            bracketSpaceForSpending > 0 ? 'SPENDING_DEFICIT' : 'NO_BRACKET_SPACE',
+            `DP-precomputed conversion for year ${input.year}: $0 (no plan or zero amount).`,
+        );
+    }
+
+    const sourceAccount = getFirstTraditionalAccount(input.accounts);
+    const targetAccount = getFirstRothAccount(input.accounts);
+    if (!sourceAccount || !targetAccount) {
+        return skipReturn('TRADITIONAL_DEPLETED', 'Skipped DP conversion: no valid source or target account.');
+    }
+
+    // ACA options for the tax cost calc (same logic as rate-match path).
+    let acaOptions: ACAOptions | undefined;
+    if (input.acaAware && input.currentAge < 65) {
+        // Use the shared 400% FPL cliff (by year + filing status) rather than hardcoded
+        // values, matching RothConversionDP. The old constants ($125k MFJ / $62.5k single)
+        // diverged from the real thresholds (~$81.8k / $60.2k for 2024).
+        const acaFiling: 'single' | 'married_filing_jointly' =
+            input.taxState.filingStatus === 'Married Filing Jointly' ? 'married_filing_jointly' : 'single';
+        acaOptions = {
+            currentAge: input.currentAge,
+            acaSubsidyAware: true,
+            acaCliffThreshold: getAcaCliffThreshold(acaFiling, input.year),
+            estimatedSubsidyLoss: 12000,
+        };
+    }
+
+    // Estimate this year's LTCG (mirrors the rate-match path) so the
+    // conversion's displayed Tax Cost reflects the LTCG bump.
+    const ltcgGainRatio = getBrokerageGainRatio(input.accounts);
+    const ltcgRateAtIncome = getLTCGRateForIncome(baseOrdinaryIncome + conversionAmount, fedParams);
+    const estimatedLTCGForYear = estimateLTCGFromDeficit(
+        Math.max(0, spendingDeficit),
+        ltcgGainRatio,
+        ltcgRateAtIncome,
+    );
+
+    // First arg must be ordinary income EXCLUDING SS — the function re-derives
+    // taxable SS internally from the separate socialSecurityBenefits arg. Passing
+    // baseOrdinaryIncome (which already includes taxable SS) double-counts SS.
+    const conversionTaxResult = calculateEffectiveConversionTax(
+        nonSSOrdinaryIncome,
+        socialSecurityBenefits,
+        estimatedLTCGForYear,
+        conversionAmount,
+        input.taxState.filingStatus,
+        fedParams,
+        stateParams,
+        acaOptions,
+    );
+    const conversionTax = conversionTaxResult.taxIncrease;
+    const conversionFedTax = conversionTaxResult.breakdown.federalOrdinaryTaxCost
+        + conversionTaxResult.breakdown.ssTorpedoCost
+        + conversionTaxResult.breakdown.ltcgBumpCost
+        + conversionTaxResult.breakdown.niitCost;
+    const conversionStateTax = conversionTaxResult.breakdown.stateTaxCost;
+
+    // Tax payment source selection (same priority as rate-match).
+    const brokerageBalance = getTotalBrokerageBalance(input.accounts);
+    let taxSource: ConversionTaxSource;
+    if (surplus >= conversionTax) {
+        taxSource = 'SURPLUS';
+    } else if (brokerageBalance >= conversionTax) {
+        taxSource = 'BROKERAGE';
+    } else {
+        taxSource = 'WITHHOLD';
+    }
+
+    const conversion: PlannedConversion = {
+        amount: conversionAmount,
+        fromAccountId: sourceAccount.id,
+        toAccountId: targetAccount.id,
+        taxSource,
+        taxAmount: conversionTax,
+        federalTaxCost: conversionFedTax,
+        stateTaxCost: conversionStateTax,
+        netToRoth: conversionAmount,
+        reason: `DP-precomputed conversion of $${Math.round(conversionAmount).toLocaleString()}. Tax paid from ${taxSource.toLowerCase()}.`,
+    };
+
+    decisions.push({
+        category: 'conversion',
+        account: sourceAccount.name,
+        amount: conversionAmount,
+        description: `DP-planned: $${Math.round(conversionAmount).toLocaleString()} from ${sourceAccount.name} to Roth. Tax: $${Math.round(conversionTax).toLocaleString()} (${taxSource.toLowerCase()}).`,
+    });
+
+    const rmdStartAge = getRMDStartAge(input.year - input.currentAge);
+    return {
+        conversion,
+        conversionTax,
+        taxSource,
+        additionalOrdinaryIncome: conversionAmount,
+        decisions,
+        bracketSpaceForSpending,
+        taxOptimizationTarget: {
+            yearsUntilRMD: Math.max(0, rmdStartAge - input.currentAge),
+            rmdStartAge,
+            targetBracketCeiling: 0,
+            bracketSpaceThisYear: conversionAmount,
+            ssAtRMD: 0,
+            pensionAtRMD: 0,
+            currentTraditionalBalance: traditionalBalance,
+            limitingFactor: conversionAmount >= availableTradForConversion - 1
+                ? 'TRADITIONAL_DEPLETED'
+                : 'BRACKET_CEILING',
+            actualConversion: conversionAmount,
+        },
+    };
+}
+
+// =============================================================================
+// MAIN SOLVER
+// =============================================================================
+
+/**
+ * Solve a retirement year.
+ *
+ * Flow:
+ * 1. Classify income (spendable vs reinvested)
+ * 2. Plan Roth conversion FIRST
+ * 3. Calculate ordinary tax (with conversion)
+ * 4. Calculate base deficit
+ * 5. Plan withdrawals with algebraic gross-up
+ * 6. Loop if bracket crossing (rare)
+ * 7. Calculate surplus/deficit
+ */
+export function solveRetirementYear(input: YearSolverInput): YearPlan {
+    const decisions: DecisionLogEntry[] = [];
+
+    // Get tax parameters
+    const fedParams = TaxService.getTaxParameters(
+        input.year,
+        input.taxState.filingStatus,
+        'federal',
+        undefined,
+        input.assumptions
+    );
+    const stateParams = TaxService.getTaxParameters(
+        input.year,
+        input.taxState.filingStatus,
+        'state',
+        input.taxState.stateResidency,
+        input.assumptions
+    );
+
+    if (!fedParams) {
+        throw new Error(`No federal tax parameters for year ${input.year}`);
+    }
+
+    // Step A: Classify income (before conversion)
+    const incomeClassification = classifyIncome(
+        input.incomes,
+        input.rmdAmount,
+        0, // No conversion yet
+        input.year
+    );
+
+    // Get SS benefits for taxability calculation
+    const socialSecurityBenefits = getTotalSSBenefits(input.incomes, input.year);
+
+    // ==========================================================================
+    // GK GUARDRAILS: Determine effective spending target
+    // ==========================================================================
+    // When GK budget is provided, enforce spending caps:
+    // - If fixed expenses > GK budget: use fixed expenses (can't cut fixed costs)
+    // - If fixed expenses <= GK budget: use min(totalLivingExpenses, gkBudget)
+    // - Log appropriate warnings and decisions
+    let effectiveLivingExpenses = input.totalLivingExpenses;
+
+    if (input.gkBudget !== undefined) {
+        const gkBudget = input.gkBudget;
+        const fixedExpenses = input.fixedExpenses ?? input.totalLivingExpenses;
+        const discretionaryExpenses = input.discretionaryExpenses ?? 0;
+
+        if (fixedExpenses > gkBudget) {
+            // Fixed expenses exceed GK budget - eliminate discretionary but cover fixed
+            effectiveLivingExpenses = fixedExpenses;
+
+            // Log warning about fixed expenses exceeding guardrails budget
+            decisions.push({
+                category: 'warning',
+                amount: fixedExpenses - gkBudget,
+                description: `Fixed expenses ($${fixedExpenses.toLocaleString()}) exceed guardrails budget ($${gkBudget.toLocaleString()}). Discretionary spending eliminated.`,
+            });
+
+            // Log decision about discretionary elimination
+            if (discretionaryExpenses > 0) {
+                decisions.push({
+                    category: 'spending',
+                    amount: discretionaryExpenses,
+                    description: `Discretionary expenses ($${discretionaryExpenses.toLocaleString()}) eliminated due to GK guardrails cap.`,
+                });
+            }
+        } else {
+            // GK budget can accommodate fixed expenses
+            // Use the lesser of total requested expenses and GK budget
+            effectiveLivingExpenses = Math.min(input.totalLivingExpenses, gkBudget);
+
+            if (input.totalLivingExpenses > gkBudget) {
+                // Need to trim discretionary
+                const trimAmount = input.totalLivingExpenses - gkBudget;
+                decisions.push({
+                    category: 'spending',
+                    amount: trimAmount,
+                    description: `Discretionary expenses trimmed by $${trimAmount.toLocaleString()} to stay within GK budget of $${gkBudget.toLocaleString()}.`,
+                });
+            }
+        }
+    }
+
+    // Calculate initial ordinary income (without conversion)
+    // Include reinvested income - it's taxable even though it's not spendable
+    const taxableBase = incomeClassification.classified.spendable + incomeClassification.classified.reinvested;
+    const baseOrdinaryIncome =
+        taxableBase -
+        socialSecurityBenefits + // Remove SS, add back taxable portion
+        TaxService.getTaxableSocialSecurityBenefits(
+            socialSecurityBenefits,
+            taxableBase - socialSecurityBenefits,
+            0, // taxExemptInterest
+            input.taxState.filingStatus
+        );
+
+    // Initial surplus estimate (for determining if conversion tax can be paid from surplus).
+    // Note: classifyIncome adds rmdAmount to spendable, so we don't add it again here.
+    const initialSurplusEstimate = Math.max(0,
+        incomeClassification.classified.spendable -
+        effectiveLivingExpenses
+    );
+
+    // Rough tax estimate for preliminary deficit (before conversion is known)
+    const roughPreTaxDeductions = TaxService.getPreTaxExemptions(input.incomes, input.year, input.currentAge, true);
+    const roughFedTax = TaxService.calculateTotalFederalTax(
+        taxableBase - socialSecurityBenefits, // non-SS ordinary income (baseOrdinaryIncome holds taxable SS)
+        socialSecurityBenefits,
+        0, 0, // no STCG/LTCG
+        roughPreTaxDeductions,
+        input.taxState.filingStatus,
+        fedParams
+    ).totalTax;
+    const roughStateTax = stateParams
+        ? TaxService.calculateTax(baseOrdinaryIncome, roughPreTaxDeductions, stateParams)
+        : 0;
+    const roughFica = TaxService.calculateFicaTax(input.taxState, input.incomes, input.year, input.assumptions);
+    const roughTax = roughFedTax + roughStateTax + roughFica;
+
+    // Note: classifyIncome adds rmdAmount to spendable, so we don't subtract it again.
+    const preliminaryDeficit = Math.max(0,
+        effectiveLivingExpenses + roughTax -
+        incomeClassification.classified.spendable
+    );
+
+    // Step B: Plan Roth conversion FIRST
+    const conversionStrategy = selectConversionStrategy(
+        input.assumptions.investments.rothConversionStrategy,
+    );
+    const conversionPlan = conversionStrategy(
+        input,
+        baseOrdinaryIncome,
+        socialSecurityBenefits,
+        // True non-SS ordinary income (excludes SS entirely). baseOrdinaryIncome
+        // already folds in taxable SS, so it must NOT be reused where the federal
+        // tax contract expects SS-free ordinary income (calculateTotalFederalTax /
+        // calculateEffectiveConversionTax re-derive taxable SS internally).
+        taxableBase - socialSecurityBenefits,
+        fedParams,
+        stateParams ?? null, // Convert undefined to null
+        initialSurplusEstimate,
+        preliminaryDeficit
+    );
+    decisions.push(...conversionPlan.decisions);
+
+    // Update income classification with conversion
+    const finalIncomeClassification = classifyIncome(
+        input.incomes,
+        input.rmdAmount,
+        conversionPlan.additionalOrdinaryIncome,
+        input.year
+    );
+
+    // Step C: Calculate ordinary tax (with conversion)
+    //
+    // Income views for tax computation:
+    //   nonSSBaseIncome: all income EXCLUDING Social Security (stable base for iteration)
+    //   allOrdinaryIncome: nonSS + conversion (used for state tax and planner — excludes SS)
+    //   currentSSTaxable: taxable portion of SS, computed externally with Trad withdrawal
+    //                     in combined income. Added to allOrdinaryIncome for federal tax only.
+    //
+    // Why separate? DC (and most states) exempts SS from state tax. The planner also needs
+    // the state starting position without SS. Federal tax needs SS taxable in the income base.
+    const nonSSBaseIncome = taxableBase - socialSecurityBenefits;
+    const conversionAdded = conversionPlan.additionalOrdinaryIncome;
+
+    // Initial SS taxable estimate (no Traditional withdrawal yet)
+    let currentSSTaxable = TaxService.getTaxableSocialSecurityBenefits(
+        socialSecurityBenefits,
+        nonSSBaseIncome + conversionAdded,
+        0,
+        input.taxState.filingStatus
+    );
+
+    // allOrdinaryIncome: includes taxable SS. Used for federal tax and planner's federal bracket
+    // positioning. For state tax (and planner's state brackets), currentSSTaxable is excluded
+    // since DC and most states exempt SS from income tax.
+    let allOrdinaryIncome = nonSSBaseIncome + currentSSTaxable + conversionAdded;
+
+    // Calculate FICA (only on wages)
+    const ficaTax = TaxService.calculateFicaTax(
+        input.taxState,
+        input.incomes,
+        input.year,
+        input.assumptions
+    );
+
+    // We'll calculate final tax after knowing withdrawals (for LTCG)
+
+    // Step D: Calculate base deficit
+    // Start with conservative estimate (no LTCG tax yet)
+    const preTaxDeductions = TaxService.getPreTaxExemptions(input.incomes, input.year, input.currentAge, true);
+
+    // Step D+E: Iterative LTCG-aware deficit and withdrawal planning
+    //
+    // We use calculateTotalFederalTax() with bracket-stacked LTCG as the authoritative
+    // tax source. The planner's flat-rate gross-up is kept as-is for withdrawal sizing.
+    // We iterate because:
+    //   - Total tax (including LTCG) affects the deficit
+    //   - LTCG depends on withdrawal amount (which depends on deficit)
+    //   - Converges in 2-3 iterations since LTCG tax is a fraction of total withdrawal
+
+    let withdrawals: PlannedWithdrawal[] = [];
+    let withdrawalOrdinaryTax = 0;
+    let withdrawalDecisions: DecisionLogEntry[] = [];
+    let totalPenalties = 0;
+    let iterations = 0;
+    let converged = false;
+
+    if (input.rmdAmount > 0) {
+        // Find Traditional accounts for RMD source
+        const tradAccount = getFirstTraditionalAccount(input.accounts);
+        if (tradAccount) {
+            withdrawals.push({
+                source: tradAccount.taxType === 'Traditional 401k' ? 'traditional_401k' : 'traditional_ira',
+                accountId: tradAccount.id,
+                accountName: tradAccount.name,
+                gross: input.rmdAmount,
+                net: input.rmdAmount, // RMD tax is on the income side, not withheld
+                penalty: 0,
+                tax: 0,
+                reason: 'Required Minimum Distribution',
+            });
+
+            decisions.push({
+                category: 'rmd',
+                account: tradAccount.name,
+                amount: input.rmdAmount,
+                description: `RMD of $${input.rmdAmount.toLocaleString()} from ${tradAccount.name}.`,
+            });
+        }
+    }
+
+    // Create account snapshots in withdrawal order (before the loop - these don't change)
+    let accountSnapshots = createOrderedSnapshots(
+        input.accounts, input.withdrawalOrder, input.currentAge, input.year
+    );
+
+    // Reserve the RMD against the Traditional account it draws from. The RMD already
+    // claims `input.rmdAmount` from that account (recorded as a negative userInflow,
+    // applied later by growAccounts), but createOrderedSnapshots reads the raw balance,
+    // so without this the discretionary planner could plan to withdraw dollars the RMD
+    // already took — over-draining the account and surfacing phantom spendable cash.
+    if (input.rmdAmount > 0) {
+        const rmdAccount = getFirstTraditionalAccount(input.accounts);
+        if (rmdAccount) {
+            accountSnapshots = accountSnapshots.map(s =>
+                s.accountId === rmdAccount.id
+                    ? { ...s, vestedBalance: Math.max(0, s.vestedBalance - input.rmdAmount) }
+                    : s
+            );
+        }
+    }
+
+    if (conversionPlan.bracketSpaceForSpending > 0) {
+        // Tax-optimized order: put capped Traditional first, then normal order
+        const allSnapshots = accountSnapshots;
+        const tradSnapshots: typeof allSnapshots = [];
+        const otherSnapshots: typeof allSnapshots = [];
+        let remainingCap = conversionPlan.bracketSpaceForSpending;
+
+        for (const s of allSnapshots) {
+            if ((s.accountType === 'traditional_401k' || s.accountType === 'traditional_ira')
+                && remainingCap > 0) {
+                const capped = Math.min(s.vestedBalance, remainingCap);
+                tradSnapshots.push({ ...s, vestedBalance: capped });
+                remainingCap -= capped;
+                const remainder = s.vestedBalance - capped;
+                if (remainder > 0) {
+                    otherSnapshots.push({ ...s, vestedBalance: remainder });
+                }
+            } else {
+                otherSnapshots.push(s);
+            }
+        }
+
+        accountSnapshots = [...tradSnapshots, ...otherSnapshots];
+
+        decisions.push({
+            category: 'withdrawal',
+            description: `Tax-optimized order: Traditional first ` +
+                `(cap $${Math.round(conversionPlan.bracketSpaceForSpending).toLocaleString()}) ` +
+                `then normal order.`,
+        });
+    }
+
+    // ACA cliff context. The threshold is fixed; the MAGI base is not.
+    //
+    // Bug #10: currentMAGI must reflect ALL income realized this year, but the
+    // Traditional spending withdrawal (ordinary income) and the brokerage LTCG are
+    // both produced by the deficit loop below — they aren't known here. The base
+    // MAGI is therefore everything EXCEPT those loop-produced amounts:
+    //   base = taxableBase (incl. 100% SS) + conversion.
+    // The planner already layers its own brokerage LTCG onto currentMAGI internally
+    // (cumulativeLTCG + actualLTCG), so we must NOT add LTCG here. But the planner
+    // does NOT know about the Traditional withdrawal, so we feed the running
+    // estimatedTradWithdrawal into currentMAGI each iteration. Without it the cliff
+    // guard under-counts MAGI by the Traditional draw and can blow past the cliff.
+    const acaCliffActive = input.acaAware && input.currentAge < 65;
+    const acaCliffThreshold = acaCliffActive
+        ? getAcaCliffThreshold(
+            input.taxState.filingStatus === 'Married Filing Jointly' ? 'married_filing_jointly' : 'single',
+            input.year
+        )
+        : 0;
+    const acaBaseMAGI = taxableBase + conversionPlan.additionalOrdinaryIncome;
+
+    // Iterative deficit loop: converges on LTCG and SS taxability.
+    //
+    // Two circular dependencies resolved by iteration:
+    //   1. LTCG depends on withdrawal → withdrawal depends on deficit → deficit depends on LTCG tax
+    //   2. SS taxable depends on combined income (includes Traditional withdrawal) →
+    //      fed tax depends on SS taxable → deficit depends on fed → withdrawal depends on deficit
+    //
+    // Architecture: calculateTotalFederalTax() computes SS taxable internally from provisional
+    // income. But its ordinaryTax covers ALL income passed in (including Traditional withdrawal),
+    // while withdrawalOrdinaryTax from the planner separately covers the withdrawal tax.
+    // To avoid double-counting, we compute SS taxable EXTERNALLY (with Traditional withdrawal
+    // in combined income) and pass SS=0 to calculateTotalFederalTax(), with the pre-computed
+    // taxable SS baked into allOrdinaryIncome. This way the function computes tax only on
+    // base income + taxable SS, and the planner handles withdrawal tax separately.
+    //
+    // Convergence: SS taxable is piecewise-linear and monotonic, so 2-4 iterations.
+    let estimatedLTCG = 0;
+    let estimatedTradWithdrawal = 0;
+
+    // Initial federal tax: SS taxable computed without Traditional withdrawal
+    // Pass allOrdinaryIncome (which includes taxable SS) with SS=0 to skip internal SS calc
+    let finalFedResult = TaxService.calculateTotalFederalTax(
+        allOrdinaryIncome, // nonSS + taxableSS + conversion (SS pre-computed externally)
+        0, // SS=0: taxable SS already in allOrdinaryIncome
+        0, // STCG
+        0, // LTCG - not known yet
+        preTaxDeductions,
+        input.taxState.filingStatus,
+        fedParams
+    );
+    // State tax: exclude SS taxable (DC and most states exempt SS from income tax)
+    // State tax on the Traditional withdrawal is in withdrawalOrdinaryTax from the planner.
+    let finalStateTax = stateParams
+        ? TaxService.calculateTax(allOrdinaryIncome - currentSSTaxable, preTaxDeductions, stateParams)
+        : 0;
+
+    const MAX_ITERATIONS = 10;
+    for (let iter = 0; iter < MAX_ITERATIONS; iter++) {
+        if (iter > 0) {
+            // Recompute SS taxable with Traditional withdrawal in combined income.
+            // IRS combined income = AGI excluding SS + 50% × SS.
+            // AGI excluding SS includes: base income + conversion + Trad withdrawal + LTCG.
+            const updatedSSTaxable = TaxService.getTaxableSocialSecurityBenefits(
+                socialSecurityBenefits,
+                nonSSBaseIncome + conversionAdded + estimatedTradWithdrawal + estimatedLTCG,
+                0,
+                input.taxState.filingStatus
+            );
+
+            // Update SS taxable and allOrdinaryIncome
+            currentSSTaxable = updatedSSTaxable;
+            allOrdinaryIncome = nonSSBaseIncome + currentSSTaxable + conversionAdded;
+
+            // Federal tax: allOrdinaryIncome includes taxable SS, pass SS=0
+            finalFedResult = TaxService.calculateTotalFederalTax(
+                allOrdinaryIncome,
+                0, // SS=0: taxable SS already in allOrdinaryIncome
+                0, // STCG
+                estimatedLTCG,
+                preTaxDeductions,
+                input.taxState.filingStatus,
+                fedParams
+            );
+
+            // State tax: exclude SS taxable (DC and most states exempt SS)
+            // Include LTCG in base (DC and most states tax gains as ordinary income)
+            finalStateTax = stateParams
+                ? TaxService.calculateTax(allOrdinaryIncome - currentSSTaxable + estimatedLTCG, preTaxDeductions, stateParams)
+                : 0;
+        }
+
+        // Deficit includes authoritative LTCG tax (via finalFedResult.totalTax).
+        // Note: classifyIncome adds rmdAmount to spendable, so we don't subtract it again.
+        const deficit =
+            effectiveLivingExpenses +
+            finalFedResult.totalTax +
+            finalStateTax +
+            ficaTax -
+            incomeClassification.classified.spendable;
+
+        if (deficit <= 0) {
+            // Surplus year: nothing to solve, this is a genuine (converged) outcome.
+            converged = true;
+            break;
+        }
+
+        // Per-iteration ACA options (Bug #10): roll the running Traditional
+        // withdrawal into currentMAGI so the planner's cliff guard sees the
+        // ordinary income this loop realizes. estimatedTradWithdrawal is the prior
+        // iteration's value (0 on the first pass) and converges alongside LTCG.
+        const acaWithdrawalOpts = acaCliffActive
+            ? { acaCliffThreshold, currentMAGI: acaBaseMAGI + estimatedTradWithdrawal }
+            : undefined;
+
+        // Plan withdrawals - planner uses allOrdinaryIncome as starting income position
+        // Pass currentSSTaxable as stateExemptIncome so the planner excludes it from
+        // state bracket positioning (DC and most states exempt SS from income tax)
+        const withdrawalResult = planWithdrawals(
+            deficit,
+            accountSnapshots,
+            input.currentAge,
+            input.year,
+            input.taxState,
+            allOrdinaryIncome,
+            input.assumptions,
+            'Spending deficit',
+            acaWithdrawalOpts,
+            currentSSTaxable
+        );
+
+        // Update tracking variables from this iteration
+        withdrawals = [
+            ...withdrawals.filter(w => w.reason === 'Required Minimum Distribution'), // Keep RMD
+            ...withdrawalResult.withdrawals,
+        ];
+        withdrawalOrdinaryTax = withdrawalResult.withdrawals
+            .filter(w => w.capitalGains === undefined)
+            .reduce((sum, w) => sum + w.tax, 0);
+        totalPenalties = withdrawalResult.totalPenalties;
+        withdrawalDecisions = withdrawalResult.decisions;
+        iterations = iter + 1;
+
+
+        // Extract Traditional spending withdrawal (exclude RMDs — already in nonSSBaseIncome)
+        const newTradWithdrawal = withdrawalResult.withdrawals
+            .filter(w => w.source === 'traditional_401k' || w.source === 'traditional_ira')
+            .reduce((sum, w) => sum + w.gross, 0);
+
+        // Check convergence: both LTCG and Traditional withdrawal (which drives SS taxable) must stabilize
+        const newLTCG = withdrawalResult.totalLTCG;
+        const ltcgDelta = Math.abs(newLTCG - estimatedLTCG);
+        const tradDelta = Math.abs(newTradWithdrawal - estimatedTradWithdrawal);
+        estimatedLTCG = newLTCG;
+        estimatedTradWithdrawal = newTradWithdrawal;
+
+        if (ltcgDelta < 1 && tradDelta < 1) {
+            converged = true;
+            break;
+        }
+    }
+
+    // DO NOT recompute tax after the loop with plan.totalLTCG.
+    // The withdrawal was sized for the deficit computed from finalFedResult/finalStateTax.
+    // Recomputing with the planner's actual LTCG (which differs by up to the convergence
+    // threshold from estimatedLTCG) would create a mismatch between reported taxes and
+    // withdrawal amount, causing Sankey balance leaks.
+
+    decisions.push(...withdrawalDecisions);
+
+    // RMD shortfall excise (Bug #4). When RMDService couldn't fully satisfy a
+    // required distribution, it computed a 25% penalty on the shortfall. It is an
+    // excise paid in cash with no offsetting distribution, so fold it into the
+    // year's penalties: this flows into totalTax (below) → cashOut, reducing the
+    // surplus / increasing the deficit, and surfaces in the tax summary's
+    // penalties line. Without this the computed penalty had zero financial effect.
+    const rmdPenalty = input.rmdPenalty ?? 0;
+    if (rmdPenalty > 0) {
+        totalPenalties += rmdPenalty;
+        decisions.push({
+            category: 'rmd',
+            amount: rmdPenalty,
+            description: `RMD shortfall excise: $${Math.round(rmdPenalty).toLocaleString()} (25% of unmet required distribution).`,
+        });
+    }
+
+    // Step F: Calculate final surplus using authoritative tax values.
+    // Exclude RMD entries from totalGrossWithdrawals — RMD is already in spendable
+    // (classifyIncome puts it there) and including it here would double-count cash in.
+    const totalGrossWithdrawals = withdrawals
+        .filter(w => w.reason !== 'Required Minimum Distribution')
+        .reduce((sum, w) => sum + w.gross, 0);
+
+    // Total tax uses authoritative federal (ordinary + LTCG + NIIT) + state (with LTCG)
+    // + withdrawal ordinary tax (Roth 5-year, Traditional, HSA) + FICA + penalties
+    const totalTax = finalFedResult.totalTax + finalStateTax + withdrawalOrdinaryTax + ficaTax + totalPenalties;
+
+    // Final cash flow.
+    // LTCG tax is a pass-through: brokerage gross-up pays it directly to the government.
+    // The deficit already included LTCG (via finalFedResult.totalTax), so the gross withdrawal
+    // is deficit + ltcgTax. Counting that full gross as spendable cash-in would create a phantom
+    // surplus equal to ltcgTax. Subtract it so only the net (post-tax) portion is cash-in.
+    const actualLTCGTax = withdrawals
+        .filter(w => w.capitalGains !== undefined)
+        .reduce((sum, w) => sum + w.tax, 0);
+
+    const cashIn =
+        incomeClassification.classified.spendable +
+        totalGrossWithdrawals -
+        actualLTCGTax;
+
+    const cashOut =
+        effectiveLivingExpenses +
+        totalTax;
+
+    const surplus = Math.max(0, cashIn - cashOut);
+    const rawDeficit = cashOut - cashIn;
+    const unfundedDeficit = rawDeficit < 0.01 ? 0 : rawDeficit;
+
+    if (unfundedDeficit > 0) {
+        decisions.push({
+            category: 'warning',
+            amount: unfundedDeficit,
+            description: `Unfunded deficit of $${unfundedDeficit.toLocaleString()}. Insufficient account balances.`,
+        });
+    }
+
+    // Build tax summary with authoritative values
+    // federal: ordinaryTax only (LTCG and NIIT are separate line items)
+    // state: includes LTCG in income base (DC and most states tax gains as ordinary)
+    // capitalGainsLT: authoritative bracket-stacked LTCG tax from calculateTotalFederalTax
+    // niit: from calculateTotalFederalTax (3.8% on investment income above threshold)
+    const taxSummary: YearPlanTax = {
+        federal: finalFedResult.ordinaryTax,
+        state: finalStateTax,
+        fica: ficaTax,
+        capitalGainsLT: finalFedResult.ltcgTax,
+        capitalGainsST: 0,
+        withdrawalOrdinaryTax,
+        niit: finalFedResult.niitTax,
+        penalties: totalPenalties,
+        total: totalTax,
+    };
+
+    // Step G: Allocate surplus (if any)
+    let surplusAllocations: YearPlan['surplusAllocations'] = [];
+    let surplusDeficitDebtPayment = 0;
+    if (surplus > 0) {
+        const priorityBuckets = (input.assumptions.priorities || []).map((p, idx) => ({
+            accountId: p.accountId || '',
+            priority: idx,
+            capType: p.capType,
+            capValue: p.capValue,
+        })).filter(p => p.accountId);
+
+        const earnedIncome = TaxService.getEarnedIncome(input.incomes, input.year);
+        const surplusSettings: SurplusAllocationSettings = {
+            emergencyFundTarget: DEFAULT_EMERGENCY_FUND_TARGET,
+            rothIRAContributionEnabled: true,
+            rothIRALimit: getIRALimit(input.year, input.currentAge, input.assumptions.macro.inflationAdjusted),
+            rothIRAContributedThisYear: 0,
+            monthlyExpenses: effectiveLivingExpenses / 12,
+            reservedAccountIds: input.reservedAccountIds ? new Set(input.reservedAccountIds) : undefined,
+        };
+
+        const surplusResult = allocateSurplus(
+            surplus,
+            input.accounts,
+            priorityBuckets,
+            earnedIncome,
+            surplusSettings
+        );
+
+        surplusAllocations = surplusResult.allocations;
+        surplusDeficitDebtPayment = surplusResult.deficitDebtPayment;
+        decisions.push(...surplusResult.decisions);
+    }
+
+    return {
+        year: input.year,
+        isRetired: input.isRetired,
+        income: finalIncomeClassification.classified,
+        withdrawals,
+        conversion: conversionPlan.conversion,
+        contributions: [], // No contributions in retirement
+        surplusAllocations,
+        deficitDebtPayment: surplusDeficitDebtPayment,
+        tax: taxSummary,
+        surplus,
+        unfundedDeficit,
+        totalExpenses: effectiveLivingExpenses,
+        strategyResult: input.strategyResult,
+        iterations,
+        converged,
+        decisions,
+        taxOptimizationTarget: conversionPlan.taxOptimizationTarget,
+    };
+}
+
+/**
+ * Solve a working year (no conversions, but withdrawals occur if income < expenses).
+ */
+export function solveWorkingYear(input: YearSolverInput): YearPlan {
+    const decisions: DecisionLogEntry[] = [];
+
+    // Get tax parameters
+    const fedParams = TaxService.getTaxParameters(
+        input.year,
+        input.taxState.filingStatus,
+        'federal',
+        undefined,
+        input.assumptions
+    );
+    const stateParams = TaxService.getTaxParameters(
+        input.year,
+        input.taxState.filingStatus,
+        'state',
+        input.taxState.stateResidency,
+        input.assumptions
+    );
+
+    if (!fedParams) {
+        throw new Error(`No federal tax parameters for year ${input.year}`);
+    }
+
+    // Classify income
+    const incomeClassification = classifyIncome(
+        input.incomes,
+        0, // No RMD
+        0, // No conversion
+        input.year
+    );
+
+    // Calculate deductions
+    const preTaxDeductions = TaxService.getPreTaxExemptions(input.incomes, input.year, input.currentAge, true);
+    const postTaxDeductions = TaxService.getPostTaxExemptions(input.incomes, input.year, input.currentAge, true);
+    const socialSecurityBenefits = getTotalSSBenefits(input.incomes, input.year);
+
+    // Include reinvested income in tax base - it's taxable even though it's not spendable
+    const taxableOrdinaryBase = incomeClassification.classified.spendable + incomeClassification.classified.reinvested;
+
+    const taxResult = TaxService.calculateTotalFederalTax(
+        taxableOrdinaryBase - socialSecurityBenefits,
+        socialSecurityBenefits,
+        0,
+        0,
+        preTaxDeductions,
+        input.taxState.filingStatus,
+        fedParams
+    );
+
+    const ficaTax = TaxService.calculateFicaTax(
+        input.taxState,
+        input.incomes,
+        input.year,
+        input.assumptions
+    );
+
+    const stateTax = stateParams
+        ? TaxService.calculateTax(
+            taxableOrdinaryBase,  // Include reinvested income in state tax too
+            preTaxDeductions,
+            stateParams
+        )
+        : 0;
+
+    const totalTax = taxResult.totalTax + stateTax + ficaTax;
+
+    // Calculate initial surplus/deficit
+    // IMPORTANT: Must subtract pre-tax deductions (401k, HSA) and post-tax deductions
+    // (Roth 401k, after-tax contributions) from cashIn because they reduce spendable
+    // cash even though they may reduce taxes or be after-tax.
+    // Note: spendable already excludes reinvested income (handled by classifyIncome).
+    const incomeCashIn = incomeClassification.classified.spendable - preTaxDeductions - postTaxDeductions;
+    const incomeCashOut = input.totalLivingExpenses + totalTax;
+    const initialDeficit = Math.max(0, incomeCashOut - incomeCashIn);
+
+    // Plan withdrawals if income doesn't cover expenses
+    let withdrawals: PlannedWithdrawal[] = [];
+    let ltcgTax = 0;
+    let withdrawalOrdinaryTax = 0;
+    let totalPenalties = 0;
+
+    if (initialDeficit > 0) {
+        const accountSnapshots = createOrderedSnapshots(
+            input.accounts, input.withdrawalOrder, input.currentAge, input.year
+        );
+
+        const withdrawalResult = planWithdrawals(
+            initialDeficit,
+            accountSnapshots,
+            input.currentAge,
+            input.year,
+            input.taxState,
+            taxableOrdinaryBase, // ordinary income for LTCG bracket determination
+            input.assumptions,
+            'Spending deficit'
+        );
+
+        withdrawals = withdrawalResult.withdrawals;
+        ltcgTax = withdrawalResult.withdrawals
+            .filter(w => w.capitalGains !== undefined)
+            .reduce((sum, w) => sum + w.tax, 0);
+        withdrawalOrdinaryTax = withdrawalResult.withdrawals
+            .filter(w => w.capitalGains === undefined)
+            .reduce((sum, w) => sum + w.tax, 0);
+        totalPenalties = withdrawalResult.totalPenalties;
+        decisions.push(...withdrawalResult.decisions);
+    }
+
+    // Final cash flow including withdrawals
+    const totalGrossWithdrawals = withdrawals.reduce((sum, w) => sum + w.gross, 0);
+    const finalTotalTax = totalTax + ltcgTax + withdrawalOrdinaryTax + totalPenalties;
+
+    const finalCashIn = incomeCashIn + totalGrossWithdrawals;
+    const finalCashOut = input.totalLivingExpenses + finalTotalTax;
+    const surplus = Math.max(0, finalCashIn - finalCashOut);
+    const unfundedDeficit = Math.max(0, finalCashOut - finalCashIn);
+
+    if (unfundedDeficit > 0) {
+        decisions.push({
+            category: 'warning',
+            amount: unfundedDeficit,
+            description: `Unfunded deficit of $${unfundedDeficit.toLocaleString()}. Insufficient account balances.`,
+        });
+    }
+
+    const taxSummary: YearPlanTax = {
+        federal: taxResult.totalTax,
+        state: stateTax,
+        fica: ficaTax,
+        capitalGainsLT: ltcgTax,
+        capitalGainsST: 0,
+        withdrawalOrdinaryTax,
+        niit: 0,
+        penalties: totalPenalties,
+        total: finalTotalTax,
+    };
+
+    // Allocate surplus (if any)
+    let surplusAllocations: YearPlan['surplusAllocations'] = [];
+    let surplusDeficitDebtPayment = 0;
+    if (surplus > 0) {
+        const priorityBuckets = (input.assumptions.priorities || []).map((p, idx) => ({
+            accountId: p.accountId || '',
+            priority: idx,
+            capType: p.capType,
+            capValue: p.capValue,
+        })).filter(p => p.accountId);
+
+        const earnedIncome = TaxService.getEarnedIncome(input.incomes, input.year);
+        const surplusSettings: SurplusAllocationSettings = {
+            emergencyFundTarget: DEFAULT_EMERGENCY_FUND_TARGET,
+            rothIRAContributionEnabled: true,
+            rothIRALimit: getIRALimit(input.year, input.currentAge, input.assumptions.macro.inflationAdjusted),
+            rothIRAContributedThisYear: 0,
+            monthlyExpenses: input.totalLivingExpenses / 12,
+            reservedAccountIds: input.reservedAccountIds ? new Set(input.reservedAccountIds) : undefined,
+        };
+
+        const surplusResult = allocateSurplus(
+            surplus,
+            input.accounts,
+            priorityBuckets,
+            earnedIncome,
+            surplusSettings
+        );
+
+        surplusAllocations = surplusResult.allocations;
+        surplusDeficitDebtPayment = surplusResult.deficitDebtPayment;
+        decisions.push(...surplusResult.decisions);
+    }
+
+    return {
+        year: input.year,
+        isRetired: false,
+        income: incomeClassification.classified,
+        withdrawals,
+        conversion: null,
+        contributions: [], // Will be filled by contribution planning
+        surplusAllocations,
+        deficitDebtPayment: surplusDeficitDebtPayment,
+        tax: taxSummary,
+        surplus,
+        unfundedDeficit,
+        totalExpenses: input.totalLivingExpenses,
+        strategyResult: input.strategyResult,
+        iterations: 1,
+        converged: true,
+        decisions,
+    };
+}
+
+/**
+ * Main entry point - routes to working or retirement solver.
+ */
+export function solveYear(input: YearSolverInput): YearPlan {
+    if (input.isRetired) {
+        return solveRetirementYear(input);
+    } else {
+        return solveWorkingYear(input);
+    }
+}

--- a/src/services/simulation/helpers.ts
+++ b/src/services/simulation/helpers.ts
@@ -1,0 +1,419 @@
+import { AnyAccount, InvestedAccount, SavedAccount, ESPPAccount } from "../../components/Objects/Accounts/models";
+import { FilingStatus, TaxParameters } from "../../data/TaxData";
+import * as TaxService from "../../components/Objects/Taxes/TaxService";
+
+export type TaxCategory = 'tax-deferred' | 'tax-free' | 'taxable' | 'mixed';
+
+/**
+ * Classify an account by its tax treatment for withdrawal ordering.
+ */
+export function classifyAccountTaxCategory(account: AnyAccount): TaxCategory {
+    if (account instanceof SavedAccount) return 'tax-free';
+    if (account instanceof InvestedAccount) {
+        switch (account.taxType) {
+            case 'Traditional 401k':
+            case 'Traditional IRA':
+                return 'tax-deferred';
+            case 'Roth 401k':
+            case 'Roth IRA':
+            case 'HSA':
+                return 'tax-free';
+            case 'Brokerage':
+            default:
+                return 'taxable';
+        }
+    }
+    if (account instanceof ESPPAccount) return 'mixed';
+    return 'taxable';
+}
+
+export interface ACAOptions {
+    currentAge: number;
+    acaSubsidyAware: boolean;
+    acaCliffThreshold: number;
+    estimatedSubsidyLoss: number;  // What would be lost if cliff crossed
+}
+
+export interface ConversionTaxBreakdown {
+    federalOrdinaryTaxCost: number;
+    ssTorpedoCost: number;
+    ltcgBumpCost: number;
+    niitCost: number;
+    stateTaxCost: number;
+    acaSubsidyLost: number;
+}
+
+export interface EffectiveConversionTaxResult {
+    taxBefore: number;
+    taxAfter: number;
+    taxIncrease: number;
+    effectiveRate: number;
+    breakdown: ConversionTaxBreakdown;
+    crossesACACliff: boolean;
+}
+
+/**
+ * Calculate the effective tax cost of a Roth conversion, including:
+ * - SS "tax torpedo" effect (conversion pushes more SS into taxable territory)
+ * - LTCG bump (conversion can push LTCG from 0% to 15% bracket)
+ * - State tax on the conversion
+ * - ACA subsidy cliff (for early retirees under 65)
+ *
+ * Uses calculateTotalFederalTax for unified tax calculation with proper
+ * SS taxability and LTCG stacking.
+ *
+ * @param nonSSIncome - AGI excluding Social Security benefits
+ * @param totalSSBenefits - Total Social Security benefits received
+ * @param ltcgIncome - Long-term capital gains income (0 if none)
+ * @param conversionAmount - Amount of Roth conversion
+ * @param filingStatus - Tax filing status
+ * @param fedParams - Federal tax parameters
+ * @param stateParams - State tax parameters (null if no state tax)
+ * @param acaOptions - ACA subsidy awareness options (undefined if not applicable)
+ */
+// NOTE: This function's ACA-MAGI check (magiBefore = nonSSIncome + totalSSBenefits)
+// previously double-counted Social Security because callers passed `baseOrdinaryIncome`
+// (= non-SS income + taxableSS) into the `nonSSIncome` slot. The conversion review fixed
+// the call sites to pass true non-SS ordinary income, so `nonSSIncome + totalSSBenefits`
+// now correctly equals actual-non-SS + full SS.
+export function calculateEffectiveConversionTax(
+    nonSSIncome: number,
+    totalSSBenefits: number,
+    ltcgIncome: number,
+    conversionAmount: number,
+    filingStatus: FilingStatus,
+    fedParams: TaxParameters,
+    stateParams: TaxParameters | null,
+    acaOptions?: ACAOptions
+): EffectiveConversionTaxResult {
+    // =========================================================================
+    // CALCULATE FULL TAX BEFORE AND AFTER CONVERSION
+    // =========================================================================
+    // Use calculateTotalFederalTax for unified handling of SS taxability and LTCG stacking
+    // Note: ltcgIncome is passed as longTermCapitalGains (4th param), STCG is 0 (3rd param)
+    const taxResultBefore = TaxService.calculateTotalFederalTax(
+        nonSSIncome,
+        totalSSBenefits,
+        0,          // shortTermCapitalGains
+        ltcgIncome, // longTermCapitalGains
+        0,          // preTaxDeductions - already accounted for in nonSSIncome
+        filingStatus,
+        fedParams
+    );
+
+    const taxResultAfter = TaxService.calculateTotalFederalTax(
+        nonSSIncome + conversionAmount,
+        totalSSBenefits,
+        0,          // shortTermCapitalGains
+        ltcgIncome, // longTermCapitalGains
+        0,          // preTaxDeductions
+        filingStatus,
+        fedParams
+    );
+
+    // =========================================================================
+    // CALCULATE BREAKDOWN COMPONENTS
+    // =========================================================================
+
+    // LTCG bump: direct comparison from unified results
+    const ltcgBumpCost = taxResultAfter.ltcgTax - taxResultBefore.ltcgTax;
+
+    // NIIT cost: 3.8% on investment income above threshold when MAGI exceeds threshold
+    const niitCost = taxResultAfter.niitTax - taxResultBefore.niitTax;
+
+    // -------------------------------------------------------------------------
+    // SS Torpedo Calculation
+    // -------------------------------------------------------------------------
+    // The "torpedo" is specifically about MORE SS becoming taxable due to the
+    // conversion. When SS is already at 85% taxable, there's no torpedo effect.
+    //
+    // We calculate a "frozen SS" scenario: what would the tax be after conversion
+    // if SS taxability stayed the same as before?
+    //
+    // federalOrdinaryTaxCost = marginal tax at current bracket (with existing taxable SS)
+    // ssTorpedoCost = extra tax from the INCREASE in taxable SS
+    // -------------------------------------------------------------------------
+
+    const taxableSS_before = taxResultBefore.taxableSS;
+    // Note: taxResultAfter.taxableSS available for debugging if needed
+
+    // Calculate tax with "frozen" SS (what if SS didn't become more taxable?)
+    // We add taxableSS_before to ordinary income manually (with no SS benefits)
+    // to simulate the conversion without additional SS becoming taxable
+    const taxFrozenSS = TaxService.calculateTotalFederalTax(
+        nonSSIncome + conversionAmount + taxableSS_before,  // use taxableSS_before
+        0,          // no SS benefits (we're adding taxableSS manually to ordinary)
+        0,          // shortTermCapitalGains
+        ltcgIncome, // longTermCapitalGains
+        0,          // preTaxDeductions
+        filingStatus,
+        fedParams
+    );
+
+    // Also need the "before" state with SS added manually for apples-to-apples comparison
+    const taxBeforeManualSS = TaxService.calculateTotalFederalTax(
+        nonSSIncome + taxableSS_before,
+        0,          // no SS benefits
+        0,          // shortTermCapitalGains
+        ltcgIncome, // longTermCapitalGains
+        0,          // preTaxDeductions
+        filingStatus,
+        fedParams
+    );
+
+    // federalOrdinaryTaxCost = marginal tax at current bracket (with existing taxable SS held constant)
+    const federalOrdinaryTaxCost = taxFrozenSS.ordinaryTax - taxBeforeManualSS.ordinaryTax;
+
+    // ssTorpedoCost = extra tax from MORE SS becoming taxable
+    // This is the difference between actual tax after and the "frozen SS" scenario
+    const ssTorpedoCost = taxResultAfter.ordinaryTax - taxFrozenSS.ordinaryTax;
+
+    // =========================================================================
+    // STATE TAX
+    // =========================================================================
+    let stateTaxCost = 0;
+    if (stateParams) {
+        // Most states tax LTCG as ordinary income (no preferential rate).
+        // Include LTCG in state income to get correct marginal rate on conversion.
+        const stateIncome = nonSSIncome + ltcgIncome;
+        const stateTaxBefore = TaxService.calculateTax(stateIncome, 0, stateParams);
+        const stateTaxAfter = TaxService.calculateTax(stateIncome + conversionAmount, 0, stateParams);
+        stateTaxCost = stateTaxAfter - stateTaxBefore;
+    }
+
+    // =========================================================================
+    // ACA SUBSIDY CLIFF
+    // =========================================================================
+    let crossesACACliff = false;
+    let acaSubsidyLost = 0;
+    if (acaOptions && acaOptions.acaSubsidyAware && acaOptions.currentAge < 65) {
+        // MAGI for ACA includes 100% of SS benefits (not just taxable portion) and
+        // capital gains (LTCG is part of AGI), so cliff crossings are detected for
+        // retirees with capital gains.
+        const magiBefore = nonSSIncome + totalSSBenefits + ltcgIncome;
+        const magiAfter = magiBefore + conversionAmount;
+
+        if (magiBefore < acaOptions.acaCliffThreshold && magiAfter >= acaOptions.acaCliffThreshold) {
+            crossesACACliff = true;
+            acaSubsidyLost = acaOptions.estimatedSubsidyLoss;
+        }
+    }
+
+    // =========================================================================
+    // TOTALS
+    // =========================================================================
+    const taxBefore = taxResultBefore.totalTax;
+    const taxAfter = taxResultAfter.totalTax;
+    const taxIncrease = (taxAfter - taxBefore) + stateTaxCost + acaSubsidyLost;
+    const effectiveRate = conversionAmount > 0 ? taxIncrease / conversionAmount : 0;
+
+    return {
+        taxBefore,
+        taxAfter,
+        taxIncrease,
+        effectiveRate,
+        breakdown: {
+            federalOrdinaryTaxCost,
+            ssTorpedoCost,
+            ltcgBumpCost,
+            niitCost,
+            stateTaxCost,
+            acaSubsidyLost
+        },
+        crossesACACliff
+    };
+}
+
+
+// =============================================================================
+// FIXED INCOME AT RMD PROJECTION
+// =============================================================================
+
+/**
+ * Result of projecting fixed income to RMD age
+ */
+export interface FixedIncomeAtRMDResult {
+    /** Projected Social Security income at RMD age (with COLA) */
+    ssAtRMD: number;
+    /** Projected pension income at RMD age (with COLA) */
+    pensionAtRMD: number;
+    /** Projected passive income at RMD age (no growth assumed) */
+    passiveAtRMD: number;
+    /** Years of COLA applied */
+    yearsProjected: number;
+}
+
+/**
+ * Default COLA rate for SS (historical average is ~2.5%, use conservative 2%)
+ */
+export const DEFAULT_SS_COLA = 0.02;
+
+/**
+ * Default COLA rate for FERS pensions (typically CPI-based, ~2%)
+ */
+export const DEFAULT_PENSION_COLA = 0.02;
+
+/**
+ * Estimate fixed income (SS + pensions) at RMD age by projecting with COLA.
+ *
+ * This is the FALLBACK calculation used when baselineProjections is not available.
+ * It projects current SS and pension income forward using COLA rates.
+ *
+ * @param currentSSIncome - Current year's Social Security income (0 if not yet claiming)
+ * @param futureSS_PIA - Monthly PIA from FutureSocialSecurityIncome (if not yet claiming)
+ * @param currentPensionIncome - Current year's pension income
+ * @param currentAge - Current age in simulation
+ * @param rmdStartAge - Age when RMDs begin (72, 73, or 75)
+ * @param ssClaimingAge - Age when SS will be claimed (for projecting PIA forward)
+ * @param ssCola - Annual SS COLA rate (default 2%)
+ * @param pensionCola - Annual pension COLA rate (default 2%)
+ * @param currentPassiveIncome - Current year's passive income (rental, dividends, etc.)
+ * @returns Projected SS, pension, and passive income at RMD age
+ */
+export function estimateFixedIncomeAtRMD(
+    currentSSIncome: number,
+    futureSS_PIA: number,
+    currentPensionIncome: number,
+    currentAge: number,
+    rmdStartAge: number,
+    ssClaimingAge: number = 67,
+    ssCola: number = DEFAULT_SS_COLA,
+    pensionCola: number = DEFAULT_PENSION_COLA,
+    currentPassiveIncome: number = 0
+): FixedIncomeAtRMDResult {
+    // If already at or past RMD age, no projection needed
+    if (currentAge >= rmdStartAge) {
+        return {
+            ssAtRMD: currentSSIncome,
+            pensionAtRMD: currentPensionIncome,
+            passiveAtRMD: currentPassiveIncome,
+            yearsProjected: 0
+        };
+    }
+
+    const yearsUntilRMD = rmdStartAge - currentAge;
+
+    // --- Project SS to RMD age ---
+    let ssAtRMD: number;
+
+    if (currentSSIncome > 0) {
+        // Already receiving SS - project forward with COLA
+        ssAtRMD = currentSSIncome * Math.pow(1 + ssCola, yearsUntilRMD);
+    } else if (futureSS_PIA > 0) {
+        // Not yet receiving SS - use PIA and project with COLA
+        // PIA is monthly, convert to annual
+        const annualSS = futureSS_PIA * 12;
+
+        // Calculate years of COLA from claiming age to RMD age
+        // SS benefits get COLA starting the year after claiming
+        const yearsOfSSCola = Math.max(0, rmdStartAge - ssClaimingAge);
+        ssAtRMD = annualSS * Math.pow(1 + ssCola, yearsOfSSCola);
+    } else {
+        // No SS info available - default to $0
+        // User should add a FutureSocialSecurityIncome object for accurate planning
+        ssAtRMD = 0;
+    }
+
+    // --- Project Pension to RMD age ---
+    let pensionAtRMD: number;
+
+    if (currentPensionIncome > 0) {
+        // Project pension forward with COLA
+        pensionAtRMD = currentPensionIncome * Math.pow(1 + pensionCola, yearsUntilRMD);
+    } else {
+        // No pension or not yet receiving
+        pensionAtRMD = 0;
+    }
+
+    return {
+        ssAtRMD,
+        pensionAtRMD,
+        passiveAtRMD: currentPassiveIncome,
+        yearsProjected: yearsUntilRMD
+    };
+}
+
+// =============================================================================
+// INCOME EXTRACTION FOR RMD PLANNING
+// =============================================================================
+
+/**
+ * Result of extracting income sources for RMD planning
+ */
+export interface ExtractedIncomeForRMD {
+    /** Current Social Security income (0 if not yet claiming) */
+    socialSecurityBenefits: number;
+    /** Monthly PIA from FutureSocialSecurityIncome (0 if not available) */
+    futureSS_PIA: number;
+    /** Age when SS will be claimed */
+    ssClaimingAge: number;
+    /** Current pension income */
+    pensionIncome: number;
+    /** Current passive income (rental, dividends, interest) */
+    passiveIncome: number;
+    /** Social Security COLA rate */
+    ssCola: number;
+    /** Pension COLA rate */
+    pensionCola: number;
+}
+
+/**
+ * Extract Social Security and pension income from income context for RMD planning.
+ *
+ * This helper extracts the necessary income data from plain JSON income objects
+ * (after localStorage deserialization) to feed into estimateFixedIncomeAtRMD().
+ *
+ * Use this when you need to project fixed income to RMD age but only have access
+ * to the income context, not simulation results.
+ *
+ * @param incomes - Array of income objects from IncomeContext (class instances with className property)
+ * @param currentYear - Current calendar year for getAnnualAmount() calls
+ * @param inflationAdjusted - Whether to apply COLA (from state.macro.inflationAdjusted)
+ * @returns Extracted income data ready for estimateFixedIncomeAtRMD()
+ */
+export function extractIncomeForRMDEstimate(
+    incomes: any[], // AnyIncome[] - class instances with className property
+    currentYear: number,
+    inflationAdjusted: boolean
+): ExtractedIncomeForRMD {
+    // Extract current SS income (if already claiming)
+    // Includes both SocialSecurityIncome (legacy) and CurrentSocialSecurityIncome (disability, survivor, already-claimed)
+    const socialSecurityBenefits = incomes
+        .filter(i => i.className === 'SocialSecurityIncome' || i.className === 'CurrentSocialSecurityIncome')
+        .reduce((sum, i) => sum + i.getAnnualAmount(currentYear), 0);
+
+    // Extract future SS (if not yet claiming)
+    const futureSS = incomes.find(i =>
+        i.className === 'FutureSocialSecurityIncome'
+    ) as { calculatedPIA?: number; claimingAge?: number; amount?: number; projectedPIA?: number } | undefined;
+    // Use projectedPIA if > 0, then fall back to amount/12, then calculatedPIA, then 0.
+    // Cannot use ?? because projectedPIA defaults to 0 (not undefined), so ?? treats it as valid.
+    const futureSS_PIA = (futureSS?.projectedPIA && futureSS.projectedPIA > 0)
+        ? futureSS.projectedPIA
+        : (futureSS?.amount ? futureSS.amount / 12 : (futureSS?.calculatedPIA ?? 0));
+    const ssClaimingAge = futureSS?.claimingAge ?? 67;
+
+    // Extract pension income
+    const pensionIncome = incomes
+        .filter(i => i.className && i.className.includes('Pension'))
+        .reduce((sum, i) => sum + i.getAnnualAmount(currentYear), 0);
+
+    // Extract passive income (rental, dividends, interest, etc.)
+    const passiveIncome = incomes
+        .filter(i => i.className === 'PassiveIncome')
+        .reduce((sum, i) => sum + i.getAnnualAmount(currentYear), 0);
+
+    // Get inflation settings
+    const ssCola = inflationAdjusted ? 0.02 : 0;
+    const pensionCola = inflationAdjusted ? 0.02 : 0;
+
+    return {
+        socialSecurityBenefits,
+        futureSS_PIA,
+        ssClaimingAge,
+        pensionIncome,
+        passiveIncome,
+        ssCola,
+        pensionCola
+    };
+}

--- a/src/services/simulation/types.ts
+++ b/src/services/simulation/types.ts
@@ -1,0 +1,654 @@
+import { AnyAccount } from "../../components/Objects/Accounts/models";
+import { AnyExpense } from "../../components/Objects/Expense/models";
+import { AnyIncome } from "../../components/Objects/Income/models";
+import { WithdrawalResult, GuardrailTrigger } from "../WithdrawalStrategies";
+import { RMDCalculation } from "../../data/RMDData";
+
+/**
+ * Per-source income line for cashflow display.
+ * `kind` mirrors what classifyIncome would assign.
+ */
+export type CashflowIncomeKind = 'work' | 'ss' | 'pension' | 'passive' | 'reinvested' | 'rmd';
+
+export interface CashflowIncomeSource {
+    name: string;
+    amount: number;
+    kind: CashflowIncomeKind;
+    /** For reinvested passive income: the account that holds the reinvested cash. */
+    accountName?: string;
+}
+
+/**
+ * Detailed cashflow breakdown the simulation has already computed but
+ * historically wasn't surfaced. The Sankey chart uses these values directly
+ * instead of re-deriving them from raw incomes/expenses (which led to drift).
+ */
+export interface CashflowDetail {
+    /** Per-source income lines (post earnings test, post-classification). */
+    incomeBySource: CashflowIncomeSource[];
+    /** Pre-tax 401k contributions, summed across active work incomes. */
+    userPreTax401k: number;
+    /** Roth 401k contributions, summed across active work incomes. */
+    userRoth401k: number;
+    /** Employer match flowing into Traditional accounts. */
+    employerMatchPreTax: number;
+    /** Employer match flowing into Roth accounts (rare). */
+    employerMatchRoth: number;
+    /** Insurance payroll deduction (mirror of taxDetails.insurance). */
+    insurance: number;
+    /** Mortgage principal portion of total mortgage payment. */
+    mortgagePrincipal: number;
+    /** Mortgage interest + escrow portion of total mortgage payment. */
+    mortgageInterestEscrow: number;
+    /** Living expense totals by category (excludes mortgage; mortgage is split above). */
+    expensesByCategory: Record<string, number>;
+    /**
+     * Long-term capital gains tax that the planner withheld from a brokerage/ESPP
+     * gross-up. Conceptually this dollar amount never reached the user — the
+     * brokerage routes it directly to the government when sizing the gross-up.
+     *
+     * Equals `sum(w.tax)` over withdrawals with `capitalGains` set. The Sankey
+     * chart subtracts this from gross withdrawals on the inflow side so it
+     * doesn't appear as residual "remaining" cash; SimulationEngine subtracts it
+     * from `totalCashAvailable` when computing `trueUserSaved`, mirroring
+     * YearSolver Step F's `actualLTCGTax` subtraction in `cashIn`.
+     *
+     * Zero when planner LTCG rate is 0 (low ordinary income) since no gross-up
+     * was applied; auth LTCG in that case is captured by `unfundedDeficit`.
+     */
+    brokerageLTCGFromGross: number;
+}
+
+// Define the shape of a single year's result
+export interface SimulationYear {
+    year: number;
+    incomes: AnyIncome[];
+    expenses: AnyExpense[];
+    accounts: AnyAccount[];
+    cashflow: {
+        totalIncome: number;
+        totalExpense: number; // Taxes + Living Expenses + Payroll Deductions
+        livingExpenses: number; // Living expenses only (excluding taxes)
+        discretionary: number; // Unspent cash
+        investedUser: number;  // User contributions + Saved Cash
+        investedMatch: number; // Employer Match
+        totalInvested: number; // Sum
+        bucketAllocations: number; // Priority Bucket contributions
+        bucketDetail: Record<string, number>; // Breakdown
+        withdrawals: number; // Total withdrawn from accounts
+        withdrawalDetail: Record<string, number>; // Per-account breakdown
+    };
+    /** Detailed breakdown for the cashflow Sankey chart. */
+    cashflowDetail?: CashflowDetail;
+    taxDetails: {
+        fed: number; // Federal income tax + early-withdrawal penalty (penalty is also broken out in earlyWithdrawalPenalty)
+        state: number;
+        fica: number;
+        preTax: number;
+        insurance: number;
+        postTax: number;
+        capitalGains: number; // Capital gains tax on brokerage/ESPP withdrawals only
+        withdrawalOrdinaryTax: number; // Tax on Roth earnings (5-year rule), Traditional, HSA non-medical
+        niit: number; // Net Investment Income Tax (3.8%)
+        earlyWithdrawalPenalty?: number; // 10% early-withdrawal penalty (Traditional pre-59.5, Roth conversion 5-year rule). Already included in `fed`; surfaced separately for diagnostics.
+        longTermCapitalGains?: number; // LTCG amount realized this year (for AGI-equivalent denominator in effective-rate calcs). Surfaces WithdrawalState.longTermCapitalGains.
+    };
+    logs: string[];
+    // Withdrawal strategy tracking (for multi-year calculations)
+    strategyWithdrawal?: WithdrawalResult;
+    // Guyton-Klinger strategy adjustment tracking
+    strategyAdjustment?: {
+        guardrailTriggered: GuardrailTrigger;
+        requiredAdjustment: number;      // $ amount GK wants to cut/add
+        actualAdjustment: number;        // $ amount actually cut/added
+        discretionaryAvailable: number;  // $ of discretionary expenses available
+        warning?: string;                // Warning if cut couldn't be fully applied
+    };
+    // Auto Roth conversion tracking
+    rothConversion?: {
+        amount: number;                  // Total amount converted
+        taxCost: number;                 // Tax paid on conversion (legacy: fed-only in V1, fed+state in V2 — prefer federalTaxCost/stateTaxCost)
+        federalTaxCost: number;          // Federal-only tax increase from the conversion
+        stateTaxCost: number;            // State-only tax increase from the conversion
+        taxAfter: number;               // Total federal tax after conversion
+        fromAccounts: Record<string, number>;  // Amount from each Traditional account (by name)
+        toAccounts: Record<string, number>;    // Amount to each Roth account (by name)
+        fromAccountIds: Record<string, number>;  // Amount from each Traditional account (by id)
+        toAccountIds: Record<string, number>;    // Amount to each Roth account (by id)
+    };
+    // Required Minimum Distribution tracking
+    rmdDetails?: {
+        totalRMD: number;                         // Total RMD required this year
+        totalWithdrawn: number;                   // Actual amount withdrawn for RMD
+        accountBreakdown: RMDCalculation[];       // Per-account RMD details
+        shortfall: number;                        // Amount not withdrawn (if any)
+        penalty: number;                          // 25% penalty on shortfall
+    };
+    // Milestone tracking
+    milestoneEvents?: MilestoneReachEvent[];      // Milestones reached this year
+    activeMilestones?: string[];                   // All milestone IDs reached so far
+    taxOptimizationTarget?: TaxOptimizationTarget;
+    /**
+     * Per-year trace from the DP-precomputed conversion strategy. Populated only
+     * when `assumptions.investments.rothConversionStrategy === 'dp-precomputed'`
+     * and the year is within the DP horizon (retirement-onward, pre-RMD-end).
+     * Surfaces the structured math behind each year's conversion choice for the
+     * Roth debug screen.
+     */
+    dpTrace?: DPYearTrace;
+    /**
+     * Lifetime sum of (federal + state + FICA + capital gains) tax under the
+     * std-ded-only conversion baseline — i.e., what taxes would be if only
+     * the always-free standard-deduction-headroom conversions ran. Set on
+     * year 0 of the simulation result so the Withdrawal tab's comparison
+     * panel can display "your strategy vs free conversions only" without
+     * re-running an extra sim.
+     */
+    stdDedBaselineLifetimeTax?: number;
+    // Marks a synthetic "projected end of current year" data point inserted between Year 0 and Year 1
+    isEndOfYearProjection?: boolean;
+}
+
+/**
+ * Structured per-year trace of the DP-precomputed Roth conversion solver's
+ * decision-making. Mirrors the data emitted in the [DEBUG DP …] log lines but
+ * in numeric form so the Roth debug screen can render charts/tables instead of
+ * parsing text.
+ */
+export interface DPYearTrace {
+    year: number;
+    age: number;
+
+    // Decision outcome
+    chosenC: number;
+    yearTax: number;
+    conversionMarginal: number;
+    discountedFuture: number;
+    totalCost: number;
+
+    // State entering the year
+    tradEntering: number;
+    rothEntering: number;
+    rmdAtEntering: number;
+    cMax: number;
+    /** Tax at conversion=0, used for marginal-cost diagnostic. */
+    taxBaselineNoConv: number;
+
+    // State at end of year (under chosen plan)
+    tradNext: number;
+    rothNext: number;
+
+    // Waterfall: spendingNeed + yearTax − cashFromOrdinary = gap → sources
+    spendingNeed: number;
+    cashFromOrdinary: number;
+    gap: number;
+    fromBrokerage: number;
+    fromRoth: number;
+    tradSpending: number;
+    unmetNeed: number;
+    baselineBrokerageCap: number;
+
+    /** Cost-curve samples at the conversion values we evaluated. */
+    costCurve: Array<{
+        c: number;
+        yearTax: number;
+        discountedFuture: number;
+        totalCost: number;
+        tradNext: number;
+        rothNext: number;
+    }>;
+
+    // Baseline (std-ded sub-sim) reference values for this year — for divergence checks.
+    baselineTrad?: number;
+    baselineRoth?: number;
+    baselineBrokerage?: number;
+    baselineConversion?: number;
+
+    // Per-year grid scales (for sanity-checking V-table resolution).
+    dB: number;
+    dRoth: number;
+}
+
+// Internal withdrawal tracking state passed between simulation phases
+export interface WithdrawalState {
+    userInflows: Record<string, number>;
+    employerInflows: Record<string, number>;
+    withdrawalTaxes: number;
+    capitalGainsTaxTotal: number; // Capital gains tax from brokerage/ESPP withdrawals only
+    withdrawalOrdinaryTaxTotal: number; // Tax from Roth earnings (5-year rule), Traditional, HSA non-medical
+    strategyWithdrawalExecuted: number;
+    totalWithdrawals: number;
+    withdrawalDetail: Record<string, number>;
+    withdrawalPenalties: number;
+    totalGrossIncome: number;
+    // Capital gains tracking
+    longTermCapitalGains: number;
+    shortTermCapitalGains: number;
+    stateCapitalGainsTax: number;
+    // Traditional withdrawal tracking for tax calculations
+    traditionalWithdrawals: number;
+}
+
+// Milestone-based trigger types
+export type MilestoneOperator = '>=' | '<=' | '=' | '>' | '<';
+
+export type MilestoneConditionType =
+    | 'NET_WORTH'              // Total assets - liabilities
+    | 'LIQUID_NET_WORTH'       // Brokerage + Savings only (not retirement accounts)
+    | 'TOTAL_DEBT'             // All debt accounts + loan balances
+    | 'YEAR'                   // Fixed calendar year
+    | 'AGE';                   // User's age
+
+// What the right side of the condition compares against
+export type MilestoneValueType =
+    | 'FIXED'                  // Just a number (default)
+    | 'EXPENSES'               // value × annual expenses (e.g., 25x for 4% rule) - living expenses only
+    | 'EXPENSES_GROSSED_UP'    // value × (expenses / (1 - tax_rate)) - includes estimated taxes
+    | 'MILESTONE_PLUS';        // milestone year/age + value offset
+
+export interface MilestoneCondition {
+    type: MilestoneConditionType;
+    operator: MilestoneOperator;
+    value: number;
+    valueType?: MilestoneValueType;        // Default 'FIXED' for backwards compatibility
+    referenceMilestoneId?: string;         // For MILESTONE_PLUS - which milestone to reference
+}
+
+export interface CustomMilestone {
+    id: string;
+    name: string;                      // "Coast FIRE", "Debt Free", etc.
+    conditions: MilestoneCondition[];  // All must be met (AND logic)
+    color?: string;                    // For timeline display
+}
+
+export interface MilestoneReachEvent {
+    milestoneId: string;
+    yearReached: number;
+    ageReached: number;
+}
+
+/**
+ * Baseline projections extracted from a deterministic simulation run.
+ * Used to inform Roth conversion ceiling calculations.
+ */
+export interface BaselineProjections {
+    /** Total Traditional balance at RMD start age */
+    traditionalBalanceAtRMD: number;
+    /** Projected Social Security income at RMD age (with COLA) */
+    ssAtRMD: number;
+    /** Projected pension income at RMD age (with COLA) */
+    pensionAtRMD: number;
+    /** Projected passive income at RMD age (rental, dividends, interest, etc. — excludes RMDs) */
+    passiveAtRMD: number;
+    /** The year when RMDs start */
+    rmdYear: number;
+}
+
+// =============================================================================
+// YEAR SOLVER TYPES (v2 Rewrite)
+// =============================================================================
+
+/**
+ * Income classified by spendability for deficit calculation.
+ */
+export interface ClassifiedIncome {
+    /** Cash available for expenses (work, SS, pensions, RMDs, rental) */
+    spendable: number;
+    /** Goes back into accounts, not available for spending (reinvested dividends) */
+    reinvested: number;
+    /** Required distributions - always spendable and taxable */
+    rmdIncome: number;
+    /** Roth conversions - taxable but NOT spendable (it's a transfer) */
+    conversionIncome: number;
+    /** Everything that appears on tax return */
+    taxableTotal: number;
+    /** Breakdown by source for logging/debugging */
+    breakdown: {
+        wages: number;
+        socialSecurity: number;
+        pensions: number;
+        passive: number;
+        rmd: number;
+        reinvested: number;
+    };
+}
+
+/**
+ * Decision log entry for transparency.
+ */
+export interface DecisionLogEntry {
+    category: 'withdrawal' | 'conversion' | 'contribution' | 'surplus' | 'tax' | 'rmd' | 'warning' | 'spending';
+    account?: string;
+    amount?: number;
+    description: string;
+}
+
+/**
+ * Tax payment source for conversions.
+ */
+export type ConversionTaxSource = 'SURPLUS' | 'BROKERAGE' | 'WITHHOLD';
+
+/**
+ * Account type for withdrawals.
+ */
+export type WithdrawalAccountType =
+    | 'savings'
+    | 'brokerage'
+    | 'traditional_401k'
+    | 'traditional_ira'
+    | 'roth_401k'
+    | 'roth_ira'
+    | 'hsa'
+    | 'espp';
+
+/**
+ * Individual planned withdrawal from an account.
+ */
+export interface PlannedWithdrawal {
+    /** Account type for tax treatment */
+    source: WithdrawalAccountType;
+    /** Account ID */
+    accountId: string;
+    /** Account name (for logging) */
+    accountName: string;
+    /** Gross amount withdrawn */
+    gross: number;
+    /** Net amount received after tax/penalty */
+    net: number;
+    /** Capital gains breakdown (for brokerage/ESPP) */
+    capitalGains?: {
+        shortTerm: number;
+        longTerm: number;
+    };
+    /** Early withdrawal penalty (if under 59.5) */
+    penalty: number;
+    /** Tax on this withdrawal */
+    tax: number;
+    /** Reason for withdrawal */
+    reason: 'Required Minimum Distribution' | 'Spending deficit' | 'Conversion tax' | 'Healthcare expense' | 'ACA cliff Roth substitution';
+}
+
+/**
+ * Planned Roth conversion.
+ */
+export interface PlannedConversion {
+    /** Amount converted */
+    amount: number;
+    /** Source Traditional account ID */
+    fromAccountId: string;
+    /** Target Roth account ID */
+    toAccountId: string;
+    /** How the conversion tax is paid */
+    taxSource: ConversionTaxSource;
+    /** Total tax cost of conversion (federal + state + ACA subsidy lost) */
+    taxAmount: number;
+    /** Federal-only portion of the conversion tax (ordinary + SS torpedo + LTCG bump + NIIT) */
+    federalTaxCost: number;
+    /** State-only portion of the conversion tax */
+    stateTaxCost: number;
+    /** Net amount going to Roth (= amount when SURPLUS/BROKERAGE, < amount when WITHHOLD) */
+    netToRoth: number;
+    /** Reason/explanation */
+    reason: string;
+}
+
+/**
+ * Planned contribution (working years).
+ */
+export interface PlannedContribution {
+    /** Account ID */
+    accountId: string;
+    /** Amount contributed */
+    amount: number;
+    /** Contribution type */
+    type: 'employee_pretax' | 'employee_roth' | 'employer_match' | 'espp' | 'roth_ira' | 'savings';
+}
+
+/**
+ * Planned surplus allocation.
+ */
+export interface PlannedSurplusAllocation {
+    /** Account ID */
+    accountId: string;
+    /** Amount allocated */
+    amount: number;
+    /** Reason for allocation */
+    reason: string;
+}
+
+/**
+ * Tax summary for the year.
+ */
+export interface YearPlanTax {
+    federal: number;
+    state: number;
+    fica: number;
+    capitalGainsLT: number;
+    capitalGainsST: number;
+    /** Tax on Roth earnings (5-year rule), Traditional withdrawals, HSA non-medical */
+    withdrawalOrdinaryTax: number;
+    niit: number;
+    penalties: number;
+    total: number;
+}
+
+/**
+ * Detailed breakdown of what's constraining Roth conversions for this year.
+ * Used for debugging why conversions aren't meeting targets.
+ */
+export interface ConversionConstraints {
+    /** Target bracket rate (e.g., 0.22 for 22%) */
+    bracketCeiling: number;
+    /** Dollar amount at top of target bracket */
+    bracketTop: number;
+    /** AGI before any conversion */
+    currentAGI: number;
+    /** Raw bracket space = bracketTop - currentAGI */
+    rawBracketSpace: number;
+    /** Amount lost to SS torpedo effect */
+    ssTorpedoReduction: number;
+    /** Amount lost to ACA cliff avoidance */
+    acaCliffReduction: number;
+    /** Final usable bracket space after all reductions */
+    effectiveBracketSpace: number;
+    /** Whether SS torpedo is affecting conversions */
+    ssTorpedoTriggered: boolean;
+    /** Whether ACA cliff avoidance is affecting conversions */
+    acaCliffTriggered: boolean;
+    /** Current MAGI for ACA calculation (if applicable) */
+    currentMAGI?: number;
+    /** ACA cliff threshold (if applicable) */
+    acaCliffThreshold?: number;
+    /** Brokerage gain ratio (unrealized gains / balance) — drives LTCG component of MAGI */
+    brokerageGainRatio?: number;
+}
+
+/**
+ * What caused the conversion limit to be reached this year.
+ */
+export type ConversionLimitingFactor =
+    | 'BRACKET_CEILING'       // Hit target tax bracket ceiling
+    | 'SS_TORPEDO'            // SS torpedo caused effective rate to spike
+    | 'ACA_CLIFF'             // ACA cliff avoidance limited conversion
+    | 'NO_BRACKET_SPACE'      // Already in or above target bracket
+    | 'TRADITIONAL_DEPLETED'  // No Traditional balance left to convert
+    | 'NOT_RETIRED'           // Not retired yet, no conversions
+    | 'OPTIMIZATION_DISABLED' // Tax optimization disabled in settings
+    | 'AT_RMD_AGE'            // At or past RMD age, no conversions
+    | 'SPENDING_DEFICIT';      // Bracket space shared with Traditional spending withdrawals
+
+/**
+ * One step in the rate-match walk (debug-only).
+ *
+ * The rate-match walk considers each bracket from std-ded headroom upward and
+ * decides whether to fill it. Each row records the inputs and decision so the
+ * Roth Debug page can reproduce the algorithm's reasoning.
+ */
+export interface RateMatchWalkRow {
+    /** Marginal rate of this chunk (0 for std-ded headroom, then bracket rates). */
+    currentRate: number;
+    /** Lower edge of this chunk's taxable-income window (post-stdDed). */
+    chunkStart: number;
+    /** Upper edge of this chunk's taxable-income window (post-stdDed). */
+    chunkEnd: number;
+    /** Dollars available in this chunk before the balance/cap clamp. */
+    chunkSize: number;
+    /** Projected RMD-year marginal rate if we convert up through this chunk. */
+    futureMarginal: number;
+    /** futureMarginal - currentRate (the rate gap). */
+    gap: number;
+    /** Decision: convert or stop. The first 'stop' row is the limiting factor. */
+    decision: 'convert' | 'stop';
+    /** Cumulative dollars converted including this chunk (only when decision='convert'). */
+    cumulative: number;
+}
+
+/**
+ * Tax optimization target information (for UI display).
+ * Calculated by the V2 solver to show the user what the engine is targeting.
+ */
+export interface TaxOptimizationTarget {
+    /** Years until RMD age */
+    yearsUntilRMD: number;
+    /** RMD start age */
+    rmdStartAge: number;
+    /** Top conversion rate the rate-match walk reached this year (e.g., 0.22) */
+    targetBracketCeiling: number;
+    /** Bracket space available this year */
+    bracketSpaceThisYear: number;
+    /** Projected SS at RMD age */
+    ssAtRMD: number;
+    /** Projected pension at RMD age */
+    pensionAtRMD: number;
+    /** Projected Traditional balance at RMD age given current conversion trajectory */
+    projectedBalanceAtRMD?: number;
+    /** What's limiting conversions this year */
+    limitingFactor?: ConversionLimitingFactor;
+    /** Detailed constraint breakdown for debugging */
+    constraintDetails?: ConversionConstraints;
+    /** Current Traditional balance at start of year */
+    currentTraditionalBalance?: number;
+    /** Actual conversion amount executed this year */
+    actualConversion?: number;
+    /** Bracket-by-bracket trace of the rate-match walk (for the Roth Debug page) */
+    rateMatchWalk?: RateMatchWalkRow[];
+}
+
+/**
+ * Complete plan for a simulation year (Phase 2 output).
+ *
+ * This is a PURE DATA STRUCTURE - no mutations, no side effects.
+ * Phase 3 uses this to execute changes on cloned accounts.
+ */
+export interface YearPlan {
+    /** Year being simulated */
+    year: number;
+
+    /** Whether this is a retirement year */
+    isRetired: boolean;
+
+    /** Classified income for the year */
+    income: ClassifiedIncome;
+
+    /** Planned withdrawals (includes RMDs) */
+    withdrawals: PlannedWithdrawal[];
+
+    /** Planned Roth conversion (null if none) */
+    conversion: PlannedConversion | null;
+
+    /** Planned contributions (working years) */
+    contributions: PlannedContribution[];
+
+    /** Planned surplus allocations */
+    surplusAllocations: PlannedSurplusAllocation[];
+
+    /** Amount allocated to pay down deficit debt from surplus */
+    deficitDebtPayment: number;
+
+    /** Tax summary */
+    tax: YearPlanTax;
+
+    /** Net surplus (positive) or unfunded deficit (negative) */
+    surplus: number;
+
+    /** Amount that couldn't be funded (when all accounts exhausted) */
+    unfundedDeficit: number;
+
+    /** Total living expenses for the year */
+    totalExpenses: number;
+
+    /** Spending strategy result (if applicable) */
+    strategyResult?: WithdrawalResult;
+
+    // Metadata
+
+    /** Number of solver iterations */
+    iterations: number;
+
+    /** Whether the solver converged */
+    converged: boolean;
+
+    /** Decision log */
+    decisions: DecisionLogEntry[];
+
+    /** Tax optimization target (for UI display) */
+    taxOptimizationTarget?: TaxOptimizationTarget;
+}
+
+/**
+ * Account balance snapshot for withdrawal planning.
+ */
+export interface AccountBalanceSnapshot {
+    accountId: string;
+    accountName: string;
+    accountType: WithdrawalAccountType;
+    balance: number;
+    vestedBalance: number;
+    /** For brokerage: unrealized gains / balance */
+    gainRatio: number;
+    /** For Roth: contribution basis available for tax-free withdrawal */
+    rothContributions?: number;
+    /** For Roth: conversion history for 5-year rule */
+    conversionHistory?: { year: number; amount: number }[];
+    /** For ESPP: pre-computed per-lot disposition data */
+    esppLots?: {
+        lotId: string;
+        shares: number;
+        currentValuePerShare: number;
+        purchasePricePerShare: number;
+        dispositionType: 'qualifying' | 'disqualifying';
+        ordinaryIncomePerShare: number;
+        ltcgPerShare: number;
+        totalValue: number;
+    }[];
+}
+
+/**
+ * Input for withdrawal planning.
+ */
+export interface WithdrawalPlannerInput {
+    /** Net amount needed after taxes */
+    netNeeded: number;
+    /** Ordered list of accounts to tap (in priority order) */
+    accountOrder: AccountBalanceSnapshot[];
+    /** Current age for penalty calculations */
+    currentAge: number;
+    /** Current year */
+    year: number;
+    /** Current ordinary income (for marginal rate calculation) */
+    currentOrdinaryIncome: number;
+    /** Filing status */
+    filingStatus: 'single' | 'married_filing_jointly' | 'married_filing_separately' | 'head_of_household';
+    /** Federal tax parameters */
+    fedParams: { brackets: { threshold: number; rate: number }[]; standardDeduction: number };
+    /** State tax parameters (null if no state tax) */
+    stateParams: { brackets: { threshold: number; rate: number }[]; standardDeduction: number } | null;
+}
+
+/**
+ * Result from income classification.
+ */
+export interface IncomeClassificationResult {
+    classified: ClassifiedIncome;
+    logs: string[];
+}


### PR DESCRIPTION
Scoped review of the year solver and cash-allocation core. ONLY the source
files added in the diff are under review. The test files in this branch are a
behavioral reference ONLY (not in the diff) and may be wrong or
timezone-dependent: if source and a test disagree, flag it as a question, do
not assume the test.

ADJUDICATIONS: code-review-pr-50.md … code-review-pr-53.md (in this tree, base
commit) record findings already fixed or ruled by-design. Do not resurface
wont-fixes; in particular, from PR #53:
  - Caps are PACING, by design: surplus exceeding every priority cap with no
    uncapped destination is intentionally NOT force-deposited (it surfaces as
    `unallocated`). Force-filling FIXED/MAX buckets broke sinking-fund
    reservations — adjudicated, do not re-flag.
  - The withdrawal planner's 0% LTCG floor rate is accepted behavior, not a
    bug (adjudicated PR #53 finding 3).

Recurring problem areas that have actually bitten us here — extra scrutiny:

  1. Gross-up sizing. Binary-search bounds; omitting a tax component (state,
     NIIT, penalty) from the iteration so the search converges on the wrong
     number; the unguarded `1/(1 - rate)` form (combined marginal >= 90% ->
     Infinity — PR #53 finding 14, still open).
  2. Withdrawal ordering vs tax characterization. Brokerage/ESPP withdrawals
     carry capital gains while pre-tax carries ordinary income; the solver's
     `cashIn` math and the planner's tax estimates must drain the same lists
     in the same order (no double-spend across the ACA look-ahead and the
     main loop).
  3. GK guardrails and deficit handling. Budget-trim paths (totalExpenses vs
     pre-trim living expenses) have caused phantom Sankey imbalances; deficit
     debt is paid before priority buckets — check both ends of that contract.
  4. Goal sinking funds are COMMITTED transfers now (new architecture,
     2026-06): the engine counts the set-aside with living expenses and
     credits the fund directly; goal-fund accounts are RESERVED
     (`reservedAccountIds`) and must never absorb general surplus, including
     via the no-priorities smart-default. Anything in this scope that lets a
     reserved account receive generic surplus is a bug.
  5. Falsy-zero. `|| default` where 0 is a valid value (returnRate=0,
     costBasis, capValue=0, deductions) should be `??`.
  6. REMAINDER bucket semantics. Anything ordered after a REMAINDER bucket can
     never receive surplus — flows that assume otherwise are bugs.

Output: ranked findings, each with a concrete failure scenario
(inputs/state -> wrong output). Findings that can't name a trigger should say
so explicitly.