### PR TITLE
Scope: tax services + tax data tables (source)

### DIFF
--- a/src/components/Objects/Taxes/TaxContext.tsx
+++ b/src/components/Objects/Taxes/TaxContext.tsx
@@ -1,0 +1,70 @@
+import { createContext, ReactNode, useMemo } from 'react';
+import { FilingStatus, max_year } from '../../../data/TaxData';
+import { usePersistedReducer } from '../../../hooks/usePersistedReducer';
+
+export type DeductionMethod = 'Standard' | 'Itemized' | 'Auto';
+
+export interface TaxState {
+  filingStatus: FilingStatus;
+  stateResidency: string;
+  deductionMethod: DeductionMethod;
+  fedOverride: number | null;
+  ficaOverride: number | null;
+  stateOverride: number | null;
+  year: number;
+}
+
+type Action =
+  | { type: 'SET_STATUS'; payload: FilingStatus }
+  | { type: 'SET_STATE'; payload: string }
+  | { type: 'SET_DEDUCTION_METHOD'; payload: DeductionMethod }
+  | { type: 'SET_FED_OVERRIDE'; payload: number | null }
+  | { type: 'SET_FICA_OVERRIDE'; payload: number | null }
+  | { type: 'SET_STATE_OVERRIDE'; payload: number | null }
+  | { type: 'SET_YEAR'; payload: number }
+  | { type: 'SET_BULK_DATA'; payload: TaxState };
+
+export const defaultTaxState: TaxState = {
+  filingStatus: 'Single',
+  stateResidency: 'DC',
+  deductionMethod: 'Auto',
+  fedOverride: null,
+  ficaOverride: null,
+  stateOverride: null,
+  year: max_year,
+};
+
+function taxReducer(state: TaxState, action: Action): TaxState {
+  switch (action.type) {
+    case 'SET_STATUS': return { ...state, filingStatus: action.payload };
+    case 'SET_STATE': return { ...state, stateResidency: action.payload };
+    case 'SET_DEDUCTION_METHOD': return { ...state, deductionMethod: action.payload };
+    case 'SET_FED_OVERRIDE': return { ...state, fedOverride: action.payload };
+    case 'SET_FICA_OVERRIDE': return { ...state, ficaOverride: action.payload };
+    case 'SET_STATE_OVERRIDE': return { ...state, stateOverride: action.payload };
+    case 'SET_YEAR': return { ...state, year: action.payload };
+    case 'SET_BULK_DATA': return { ...action.payload };
+    default: return state;
+  }
+}
+
+interface TaxContextProps {
+  state: TaxState;
+  dispatch: React.Dispatch<Action>;
+}
+
+export const TaxContext = createContext<TaxContextProps>({
+  state: defaultTaxState,
+  dispatch: () => null,
+});
+
+export function TaxProvider({ children }: { children: ReactNode }): React.ReactElement {
+  const [state, dispatch] = usePersistedReducer(taxReducer, defaultTaxState, {
+    storageKey: 'tax_settings',
+    // Merge with defaults to ensure new fields exist even with old saved data
+  });
+
+  const contextValue = useMemo(() => ({ state, dispatch }), [state, dispatch]);
+
+  return <TaxContext.Provider value={contextValue}>{children}</TaxContext.Provider>;
+}

--- a/src/components/Objects/Taxes/TaxService.tsx
+++ b/src/components/Objects/Taxes/TaxService.tsx
@@ -1,0 +1,48 @@
+/**
+ * Barrel re-exporting the focused tax service modules.
+ *
+ * The implementation lives in ./taxService/ — each domain has its own file:
+ *   - parameters.ts       getTaxParameters, getSALTCap
+ *   - incomeAggregation   gross / pre-tax / post-tax / FICA / SS income getters
+ *   - socialSecurity      getTaxableSocialSecurityBenefits
+ *   - deductions          getItemizedDeductions, getYesDeductions
+ *   - bracketTax          calculateTax + calculateTotalFederalTax (core engine)
+ *   - federalTax          calculateFederalTaxFromIncomes (orchestrator)
+ *   - stateTax            calculateStateTax, calculateUnifiedStateTax
+ *   - ficaTax             calculateFicaTax
+ *   - capitalGainsTax     calculateCapitalGainsTax
+ *   - marginalRates       getMarginalTaxRate, getCombinedMarginalRate
+ *   - esppTax             calculateESPPDispositionTax
+ *
+ * Many consumers use `import * as TaxService from '.../TaxService'` (namespace
+ * import), so this barrel must preserve every name that used to live in the
+ * monolithic file. Don't drop re-exports without checking the consumer set.
+ */
+
+export { getSALTCap, getTaxParameters } from "./taxService/parameters";
+export {
+    getGrossIncome,
+    getPreTaxExemptions,
+    getPostTaxEmployerMatch,
+    getPostTaxExemptions,
+    getFicaExemptions,
+    getEarnedIncome,
+    getSocialSecurityBenefits,
+} from "./taxService/incomeAggregation";
+export { getTaxableSocialSecurityBenefits } from "./taxService/socialSecurity";
+export { getItemizedDeductions, getYesDeductions } from "./taxService/deductions";
+export {
+    calculateTotalFederalTax,
+    calculateTax,
+    type TotalFederalTaxResult,
+} from "./taxService/bracketTax";
+export { calculateFederalTaxFromIncomes } from "./taxService/federalTax";
+export { calculateStateTax, calculateUnifiedStateTax } from "./taxService/stateTax";
+export { calculateFicaTax } from "./taxService/ficaTax";
+export { calculateCapitalGainsTax } from "./taxService/capitalGainsTax";
+export {
+    getMarginalTaxRate,
+    getCombinedMarginalRate,
+    type MarginalRateResult,
+} from "./taxService/marginalRates";
+export { calculateESPPDispositionTax } from "./taxService/esppTax";

--- a/src/components/Objects/Taxes/taxService/bracketTax.ts
+++ b/src/components/Objects/Taxes/taxService/bracketTax.ts
@@ -1,0 +1,182 @@
+/**
+ * The core bracket-walking federal tax calculation. Lives here (not in
+ * federalTax.ts) so that stateTax.ts can use `calculateTax` for its
+ * bracket math without creating a circular dependency back to the
+ * federal-from-incomes orchestrator.
+ */
+import { FilingStatus, TaxParameters } from "../../../../data/TaxData";
+import { getTaxableSocialSecurityBenefits } from "./socialSecurity";
+
+/** Result of the unified federal tax calculation */
+export interface TotalFederalTaxResult {
+    taxableSS: number;      // Taxable portion of SS benefits
+    ordinaryTax: number;    // Tax on ordinary income (wages, pensions, withdrawals, taxable SS, STCG)
+    ltcgTax: number;        // Tax on long-term capital gains + qualified dividends
+    niitTax: number;        // Net Investment Income Tax (3.8% on investment income above threshold)
+    totalTax: number;       // ordinaryTax + ltcgTax + niitTax
+}
+
+/** NIIT thresholds by filing status */
+const NIIT_THRESHOLDS: Record<FilingStatus, number> = {
+    'Single': 200000,
+    'Married Filing Jointly': 250000,
+    'Married Filing Separately': 125000,
+};
+
+/** NIIT rate */
+const NIIT_RATE = 0.038;
+
+/**
+ * Unified federal tax calculation that handles all income types and their interactions.
+ *
+ * This function properly handles:
+ * - Social Security taxability (provisional income calculation)
+ * - STCG taxed as ordinary income (but counted as investment income for NIIT)
+ * - LTCG stacking on top of ordinary income for bracket determination
+ * - NIIT (3.8% on investment income above threshold)
+ * - Standard deduction applied to ordinary income only
+ *
+ * Calculation order:
+ * 1. Calculate provisional income for SS taxability
+ * 2. Calculate taxable SS using getTaxableSocialSecurityBenefits
+ * 3. Calculate taxable ordinary income (includes STCG)
+ * 4. Calculate ordinary tax on taxable ordinary income
+ * 5. Calculate LTCG tax where gains "stack" on top of ordinary taxable income
+ * 6. Calculate NIIT on investment income above threshold
+ *
+ * @param ordinaryIncome - Wages, Traditional withdrawals, pensions, Roth conversions (NOT STCG)
+ * @param socialSecurityBenefits - Gross SS benefits (we calculate taxable portion internally)
+ * @param shortTermCapitalGains - STCG (taxed as ordinary income, but is investment income for NIIT)
+ * @param longTermCapitalGains - LTCG + qualified dividends
+ * @param preTaxDeductions - 401k, HSA contributions, etc.
+ * @param filingStatus - Tax filing status
+ * @param params - Federal tax parameters (brackets, standard deduction, LTCG brackets)
+ */
+export function calculateTotalFederalTax(
+    ordinaryIncome: number,
+    socialSecurityBenefits: number,
+    shortTermCapitalGains: number,
+    longTermCapitalGains: number,
+    preTaxDeductions: number,
+    filingStatus: FilingStatus,
+    params: TaxParameters,
+): TotalFederalTaxResult {
+    // STEP 1: Provisional income for SS taxability
+    // IRS formula: Provisional Income = AGI (excluding SS) + tax-exempt interest + 50% of SS
+    // Both STCG and LTCG count toward provisional income.
+    // Pre-tax deductions (401k, HSA, etc.) reduce AGI, so they must also reduce the
+    // AGI-excluding-SS portion of provisional income before adding half of SS benefits.
+    const provisionalIncome = Math.max(0, ordinaryIncome + shortTermCapitalGains + longTermCapitalGains - preTaxDeductions) + (socialSecurityBenefits * 0.5);
+
+    // STEP 2: Taxable portion of Social Security
+    // TODO: Verify all income types are included (LTCG, STCG, dividends, etc.)
+    const taxableSS = getTaxableSocialSecurityBenefits(
+        socialSecurityBenefits,
+        provisionalIncome - (socialSecurityBenefits * 0.5),
+        0, // taxExemptInterest - not currently tracked
+        filingStatus,
+    );
+
+    // STEP 3: Taxable ordinary income (includes STCG).
+    // The standard deduction is applied against ordinary income first, but any UNUSED
+    // portion still offsets LTCG. The IRS 0%/15%/20% LTCG brackets are measured against
+    // TOTAL taxable income (ordinary + LTCG, after the standard deduction), so when
+    // ordinary income is below the deduction the leftover deduction reduces the amount of
+    // LTCG that is taxable. `taxableOrdinary` (floored at 0) is the LTCG stacking floor;
+    // `unusedDeduction` is the leftover deduction that reduces taxable LTCG in STEP 5.
+    const totalOrdinaryIncome = ordinaryIncome + shortTermCapitalGains + taxableSS;
+    const adjustedOrdinary = Math.max(0, totalOrdinaryIncome - preTaxDeductions);
+    const taxableOrdinary = Math.max(0, adjustedOrdinary - params.standardDeduction);
+    const unusedDeduction = Math.max(0, params.standardDeduction - adjustedOrdinary);
+
+    // STEP 4: Ordinary income tax (includes STCG)
+    let ordinaryTax = 0;
+    for (let i = 0; i < params.brackets.length; i++) {
+        const current = params.brackets[i];
+        const next = params.brackets[i + 1];
+        const upperLimit = next ? next.threshold : Infinity;
+
+        if (taxableOrdinary > current.threshold) {
+            const amountInBracket = Math.min(taxableOrdinary, upperLimit) - current.threshold;
+            ordinaryTax += amountInBracket * current.rate;
+        }
+    }
+
+    // STEP 5: LTCG tax (stacks on top of ordinary income)
+    let ltcgTax = 0;
+    if (longTermCapitalGains > 0 && params.capitalGainsBrackets) {
+        const brackets = params.capitalGainsBrackets;
+        // Any standard deduction not consumed by ordinary income offsets LTCG, so only the
+        // LTCG above that unused deduction is taxable. LTCG then stacks on top of taxable
+        // ordinary income for bracket placement.
+        let remainingGains = Math.max(0, longTermCapitalGains - unusedDeduction);
+        let incomeStack = taxableOrdinary;
+
+        for (let i = 0; i < brackets.length && remainingGains > 0; i++) {
+            const bracket = brackets[i];
+            const nextBracket = brackets[i + 1];
+            const upperLimit = nextBracket ? nextBracket.threshold : Infinity;
+
+            if (incomeStack >= upperLimit) continue;
+
+            const bracketFloor = Math.max(incomeStack, bracket.threshold);
+            const roomInBracket = upperLimit - bracketFloor;
+            const gainsInBracket = Math.min(remainingGains, roomInBracket);
+
+            ltcgTax += gainsInBracket * bracket.rate;
+
+            incomeStack += gainsInBracket;
+            remainingGains -= gainsInBracket;
+        }
+    }
+
+    // STEP 6: NIIT (Net Investment Income Tax)
+    // 3.8% on the LESSER of net investment income or MAGI exceeding threshold.
+    let niitTax = 0;
+    const niitThreshold = NIIT_THRESHOLDS[filingStatus];
+    const netInvestmentIncome = shortTermCapitalGains + longTermCapitalGains;
+
+    if (netInvestmentIncome > 0) {
+        // MAGI for NIIT purposes (approximated as AGI here)
+        const magi = ordinaryIncome + shortTermCapitalGains + longTermCapitalGains + taxableSS - preTaxDeductions;
+        const magiExcess = Math.max(0, magi - niitThreshold);
+
+        if (magiExcess > 0) {
+            const niitBase = Math.min(netInvestmentIncome, magiExcess);
+            niitTax = niitBase * NIIT_RATE;
+        }
+    }
+
+    return {
+        taxableSS,
+        ordinaryTax,
+        ltcgTax,
+        niitTax,
+        totalTax: ordinaryTax + ltcgTax + niitTax,
+    };
+}
+
+/**
+ * Legacy tax calculation function for backwards compatibility.
+ * Use calculateTotalFederalTax for new code that needs SS/LTCG/NIIT handling.
+ *
+ * @param grossIncome - Gross income before deductions
+ * @param preTaxDeductions - 401k, HSA, etc.
+ * @param params - Tax parameters
+ * @returns Tax amount (ordinary income tax only, no SS/LTCG/NIIT)
+ */
+export function calculateTax(
+    grossIncome: number,
+    preTaxDeductions: number,
+    params: TaxParameters,
+): number {
+    return calculateTotalFederalTax(
+        grossIncome,
+        0,
+        0,
+        0,
+        preTaxDeductions,
+        'Single', // filing status doesn't matter when SS=0 and no investment income
+        params,
+    ).ordinaryTax;
+}

--- a/src/components/Objects/Taxes/taxService/capitalGainsTax.ts
+++ b/src/components/Objects/Taxes/taxService/capitalGainsTax.ts
@@ -1,0 +1,79 @@
+import { TaxState } from "../TaxContext";
+import { AssumptionsState } from "../../Assumptions/AssumptionsContext";
+import { getTaxParameters } from "./parameters";
+import { TaxParameters } from "../../../../data/TaxData";
+
+/**
+ * Get the long-term capital gains rate that applies at a given ordinary income
+ * level. LTCG stack on top of ordinary income, so the applicable rate is the
+ * highest capital-gains bracket whose threshold the ordinary income reaches.
+ *
+ * Walks brackets high→low and returns the first whose threshold is met
+ * (>=). Falls back to a flat 15% when no capital-gains brackets are available,
+ * and to 0% when the bracket array is empty.
+ *
+ * @param ordinaryIncome - Ordinary income that positions the gains in a bracket
+ * @param fedParams - Federal tax parameters (supplying capitalGainsBrackets)
+ * @returns The applicable LTCG rate (decimal)
+ */
+export function getLTCGRate(ordinaryIncome: number, fedParams: TaxParameters | null | undefined): number {
+    if (!fedParams?.capitalGainsBrackets) return 0.15;
+
+    const brackets = fedParams.capitalGainsBrackets;
+    for (let i = brackets.length - 1; i >= 0; i--) {
+        if (ordinaryIncome >= brackets[i].threshold) {
+            return brackets[i].rate;
+        }
+    }
+    return brackets[0]?.rate ?? 0;
+}
+
+/**
+ * Calculate capital gains tax on long-term gains.
+ * Capital gains are taxed based on your total taxable income bracket.
+ * The gains "stack on top" of ordinary income to determine the applicable rate.
+ *
+ * @param gains - Amount of long-term capital gains
+ * @param ordinaryTaxableIncome - Taxable income from ordinary sources (after deductions)
+ * @param taxState - Filing status and other tax state
+ * @param year - Tax year
+ * @param assumptions - Assumptions for inflation adjustments
+ * @returns The tax owed on the capital gains
+ */
+export function calculateCapitalGainsTax(
+    gains: number,
+    ordinaryTaxableIncome: number,
+    taxState: TaxState,
+    year: number,
+    assumptions?: AssumptionsState,
+): number {
+    if (gains <= 0) return 0;
+
+    const fedParams = getTaxParameters(year, taxState.filingStatus, 'federal', undefined, assumptions);
+    if (!fedParams || !fedParams.capitalGainsBrackets) {
+        // Fallback to flat 15% if no brackets available
+        return gains * 0.15;
+    }
+
+    const brackets = fedParams.capitalGainsBrackets;
+    let remainingGains = gains;
+    let totalTax = 0;
+    let incomeLevel = Math.max(0, ordinaryTaxableIncome);
+
+    for (let i = 0; i < brackets.length && remainingGains > 0; i++) {
+        const currentBracket = brackets[i];
+        const nextBracket = brackets[i + 1];
+        const upperLimit = nextBracket ? nextBracket.threshold : Infinity;
+
+        if (incomeLevel >= upperLimit) continue;
+
+        const roomInBracket = upperLimit - incomeLevel;
+        const gainsInBracket = Math.min(remainingGains, roomInBracket);
+        totalTax += gainsInBracket * currentBracket.rate;
+
+        incomeLevel += gainsInBracket;
+        remainingGains -= gainsInBracket;
+    }
+
+    return totalTax;
+}

--- a/src/components/Objects/Taxes/taxService/deductions.ts
+++ b/src/components/Objects/Taxes/taxService/deductions.ts
@@ -1,0 +1,33 @@
+import { AnyExpense, MortgageExpense, getExpenseActiveMultiplier } from "../../Expense/models";
+
+export function getItemizedDeductions(expenses: AnyExpense[], year: number): number {
+    return expenses
+        .filter(
+            (exp) =>
+                "is_tax_deductible" in exp &&
+                exp.is_tax_deductible === "Itemized" &&
+                getExpenseActiveMultiplier(exp, year) > 0,
+        )
+        .reduce((val, exp) => {
+            if (exp instanceof MortgageExpense) {
+                return val + exp.calculateAnnualAmortization(year).totalInterest;
+            }
+            return val + exp.getProratedAnnual((exp as any).tax_deductible || 0, year);
+        }, 0);
+}
+
+export function getYesDeductions(expenses: AnyExpense[], year: number): number {
+    return expenses
+        .filter(
+            (exp) =>
+                "is_tax_deductible" in exp &&
+                exp.is_tax_deductible === "Yes" &&
+                getExpenseActiveMultiplier(exp, year) > 0,
+        )
+        .reduce((val, exp) => {
+            if (exp instanceof MortgageExpense) {
+                return val + exp.calculateAnnualAmortization(year).totalInterest;
+            }
+            return val + exp.getProratedAnnual((exp as any).tax_deductible || 0, year);
+        }, 0);
+}

--- a/src/components/Objects/Taxes/taxService/esppTax.ts
+++ b/src/components/Objects/Taxes/taxService/esppTax.ts
@@ -1,0 +1,80 @@
+/**
+ * Calculate ESPP disposition tax breakdown.
+ *
+ * ESPP shares have special tax treatment based on holding periods:
+ *
+ * **Qualifying Disposition** (held 2 years from grant AND 1 year from purchase):
+ * - Ordinary income = lesser of: (1) discount at grant price, or (2) actual gain
+ * - Capital gains = remainder (long-term)
+ *
+ * **Disqualifying Disposition** (sold before meeting both holding periods):
+ * - Ordinary income = FMV at purchase - purchase price (the "bargain element")
+ * - Capital gains = sale price - FMV at purchase (can be short or long term)
+ *
+ * TODO: This function is exported and tested but not used in the app.
+ * Either wire it up to the ESPP account UI (e.g., lot sale preview) or delete it.
+ *
+ * @param sharesToSell - Number of shares being sold
+ * @param salePrice - Sale price per share
+ * @param purchasePrice - Original purchase price per share
+ * @param fmvAtGrant - Fair market value at grant date
+ * @param fmvAtPurchase - Fair market value at purchase date
+ * @param isQualifying - Whether this is a qualifying disposition
+ * @param isLongTermCG - Whether capital gains portion qualifies as long-term
+ * @returns Tax breakdown with ordinary income and capital gains amounts
+ */
+export function calculateESPPDispositionTax(
+    sharesToSell: number,
+    salePrice: number,
+    purchasePrice: number,
+    fmvAtGrant: number,
+    fmvAtPurchase: number,
+    isQualifying: boolean,
+    isLongTermCG: boolean,
+): {
+    ordinaryIncome: number;
+    shortTermCapitalGains: number;
+    longTermCapitalGains: number;
+    totalTaxableGain: number;
+} {
+    const totalSaleProceeds = sharesToSell * salePrice;
+    const totalCostBasis = sharesToSell * purchasePrice;
+    const totalGain = totalSaleProceeds - totalCostBasis;
+
+    let ordinaryIncome = 0;
+    let shortTermCapitalGains = 0;
+    let longTermCapitalGains = 0;
+
+    if (totalGain <= 0) {
+        // Loss scenario - all goes to capital gains (loss)
+        if (isLongTermCG) {
+            longTermCapitalGains = totalGain;
+        } else {
+            shortTermCapitalGains = totalGain;
+        }
+    } else if (isQualifying) {
+        // Qualifying disposition
+        // Ordinary income = lesser of grant discount or actual gain
+        const grantDiscount = fmvAtGrant * 0.15 * sharesToSell; // Typical 15% discount
+        ordinaryIncome = Math.min(grantDiscount, totalGain);
+        longTermCapitalGains = totalGain - ordinaryIncome;
+    } else {
+        // Disqualifying disposition
+        const bargainElement = (fmvAtPurchase - purchasePrice) * sharesToSell;
+        ordinaryIncome = Math.max(0, bargainElement);
+
+        const capitalGain = totalGain - bargainElement;
+        if (isLongTermCG) {
+            longTermCapitalGains = capitalGain;
+        } else {
+            shortTermCapitalGains = capitalGain;
+        }
+    }
+
+    return {
+        ordinaryIncome,
+        shortTermCapitalGains,
+        longTermCapitalGains,
+        totalTaxableGain: ordinaryIncome + shortTermCapitalGains + longTermCapitalGains,
+    };
+}

--- a/src/components/Objects/Taxes/taxService/federalTax.ts
+++ b/src/components/Objects/Taxes/taxService/federalTax.ts
@@ -1,0 +1,98 @@
+import { AnyExpense } from "../../Expense/models";
+import { AnyIncome } from "../../Income/models";
+import { TaxState } from "../TaxContext";
+import { AssumptionsState, getBirthYear } from "../../Assumptions/AssumptionsContext";
+import { getTaxParameters, getSALTCap } from "./parameters";
+import {
+    getGrossIncome,
+    getPreTaxExemptions,
+    getSocialSecurityBenefits,
+} from "./incomeAggregation";
+import { getItemizedDeductions, getYesDeductions } from "./deductions";
+import { calculateTotalFederalTax } from "./bracketTax";
+import { calculateStateTax, calculateUnifiedStateTax } from "./stateTax";
+
+/**
+ * Calculate federal tax from income/expense objects using calculateTotalFederalTax.
+ *
+ * Orchestrates the full federal tax computation: extracts values from incomes
+ * + expenses, threads them through `calculateTotalFederalTax`, handles SALT
+ * cap interaction with state tax, and picks the best of Standard / Itemized
+ * deduction when `deductionMethod === 'Auto'`.
+ *
+ * @param state - Tax state (filing status, overrides, deduction method)
+ * @param incomes - Income objects (SS, pensions, work income)
+ * @param expenses - Expense objects (for itemized deductions)
+ * @param additionalOrdinaryIncome - Traditional withdrawals + Roth conversions + RMDs (default 0)
+ * @param year - Tax year
+ * @param assumptions - Assumptions for inflation adjustments
+ * @param stcg - Short-term capital gains (default 0)
+ * @param ltcg - Long-term capital gains (default 0)
+ * @returns Federal tax amount
+ */
+export function calculateFederalTaxFromIncomes(
+    state: TaxState,
+    incomes: AnyIncome[],
+    expenses: AnyExpense[],
+    additionalOrdinaryIncome: number = 0,
+    year: number,
+    assumptions?: AssumptionsState,
+    stcg: number = 0,
+    ltcg: number = 0,
+): number {
+    if (state.fedOverride !== null) {
+        return state.fedOverride;
+    }
+
+    const incomeGross = getGrossIncome(incomes, year);
+    const age = assumptions?.milestones ? year - getBirthYear(assumptions.milestones) : undefined;
+
+    const incomePreTaxDeductions = getPreTaxExemptions(incomes, year, age);
+    const expenseAboveLineDeductions = getYesDeductions(expenses, year);
+    const totalPreTaxDeductions = incomePreTaxDeductions + expenseAboveLineDeductions;
+
+    const totalSSBenefits = getSocialSecurityBenefits(incomes, year);
+    const nonSSGross = incomeGross - totalSSBenefits;
+    const ordinaryIncome = nonSSGross + additionalOrdinaryIncome;
+
+    const fedParams = getTaxParameters(year, state.filingStatus, "federal", undefined, assumptions);
+    if (!fedParams) return 0;
+
+    // SALT cap interaction with state tax
+    const stateTax = additionalOrdinaryIncome > 0
+        ? calculateUnifiedStateTax(state, incomes, expenses, additionalOrdinaryIncome, year, assumptions)
+        : calculateStateTax(state, incomes, expenses, year, assumptions);
+
+    const saltCap = getSALTCap(year, state.filingStatus);
+    const cappedStateTax = Math.min(stateTax, saltCap);
+
+    const itemizedTotal = getItemizedDeductions(expenses, year) + cappedStateTax;
+
+    const calcTaxWithDeduction = (deductionAmount: number): number => {
+        const paramsWithDeduction = {
+            ...fedParams,
+            standardDeduction: deductionAmount,
+        };
+        return calculateTotalFederalTax(
+            ordinaryIncome,
+            totalSSBenefits,
+            stcg,
+            ltcg,
+            totalPreTaxDeductions,
+            state.filingStatus,
+            paramsWithDeduction,
+        ).totalTax;
+    };
+
+    if (state.deductionMethod === "Auto") {
+        const taxWithStandard = calcTaxWithDeduction(fedParams.standardDeduction);
+        const taxWithItemized = calcTaxWithDeduction(itemizedTotal);
+        return Math.min(taxWithStandard, taxWithItemized);
+    }
+
+    const appliedDeduction = state.deductionMethod === "Standard"
+        ? fedParams.standardDeduction
+        : itemizedTotal;
+
+    return calcTaxWithDeduction(appliedDeduction);
+}

--- a/src/components/Objects/Taxes/taxService/ficaTax.ts
+++ b/src/components/Objects/Taxes/taxService/ficaTax.ts
@@ -1,0 +1,35 @@
+import { AnyIncome } from "../../Income/models";
+import { TaxState } from "../TaxContext";
+import { AssumptionsState } from "../../Assumptions/AssumptionsContext";
+import { getTaxParameters } from "./parameters";
+import { getEarnedIncome, getFicaExemptions } from "./incomeAggregation";
+
+export function calculateFicaTax(
+    state: TaxState,
+    incomes: AnyIncome[],
+    year: number,
+    assumptions?: AssumptionsState,
+): number {
+    if (state.ficaOverride !== null) {
+        return state.ficaOverride;
+    }
+
+    const earnedGross = getEarnedIncome(incomes, year);
+    const ficaExemptions = getFicaExemptions(incomes, year);
+    const fedParams = getTaxParameters(year, state.filingStatus, "federal", undefined, assumptions);
+
+    if (!fedParams) return 0;
+
+    const taxableBase = Math.max(0, earnedGross - ficaExemptions);
+    const ssTax =
+        Math.min(taxableBase, fedParams.socialSecurityWageBase) *
+        fedParams.socialSecurityTaxRate;
+    const medicareTax = taxableBase * fedParams.medicareTaxRate;
+
+    const additionalMedicareThreshold =
+        state.filingStatus === 'Married Filing Jointly' ? 250000 :
+        state.filingStatus === 'Married Filing Separately' ? 125000 : 200000;
+    const additionalMedicareTax = Math.max(0, taxableBase - additionalMedicareThreshold) * 0.009;
+
+    return ssTax + medicareTax + additionalMedicareTax;
+}

--- a/src/components/Objects/Taxes/taxService/incomeAggregation.ts
+++ b/src/components/Objects/Taxes/taxService/incomeAggregation.ts
@@ -1,0 +1,108 @@
+import {
+    AnyIncome,
+    WorkIncome,
+    SocialSecurityIncome,
+    CurrentSocialSecurityIncome,
+    FutureSocialSecurityIncome,
+} from "../../Income/models";
+
+export function getGrossIncome(incomes: AnyIncome[], year: number): number {
+    return incomes.reduce((acc, inc) => {
+        let currentIncome = inc.amount;
+        if (inc instanceof WorkIncome && inc.taxType === "Roth 401k") {
+            currentIncome += inc.employerMatch;
+        }
+        return acc + inc.getProratedAnnual(currentIncome, year);
+    }, 0);
+}
+
+/**
+ * Get pre-tax exemptions (401k, insurance, HSA) from work incomes.
+ * @param useStoredValue - If true, reads stored preTax401k directly instead of calling getEffective401k().
+ *                         Use true in simulation (after increment() has run), false for UI preview.
+ */
+export function getPreTaxExemptions(
+    incomes: AnyIncome[],
+    year: number,
+    age?: number,
+    useStoredValue: boolean = false,
+): number {
+    return incomes
+        .filter((inc) => inc instanceof WorkIncome)
+        .reduce((acc, inc) => {
+            const preTax401k = useStoredValue
+                ? inc.preTax401k
+                : (age !== undefined ? inc.getEffective401k(year, age).preTax : inc.preTax401k);
+            return (
+                acc +
+                inc.getProratedAnnual(preTax401k, year) +
+                inc.getProratedAnnual(inc.insurance, year) +
+                inc.getProratedAnnual(inc.hsaContribution, year)
+            );
+        }, 0);
+}
+
+export function getPostTaxEmployerMatch(incomes: AnyIncome[], year: number): number {
+    return incomes.reduce((acc, inc) => {
+        if (inc instanceof WorkIncome && inc.taxType === "Roth 401k") {
+            return acc + inc.getEffectiveAnnualEmployerMatch(year);
+        }
+        return acc;
+    }, 0);
+}
+
+/**
+ * Get post-tax exemptions (Roth 401k) from work incomes.
+ * @param useStoredValue - If true, reads stored roth401k directly instead of calling getEffective401k().
+ *                         Use true in simulation (after increment() has run), false for UI preview.
+ */
+export function getPostTaxExemptions(
+    incomes: AnyIncome[],
+    year: number,
+    age?: number,
+    useStoredValue: boolean = false,
+): number {
+    return incomes
+        .filter((inc) => inc instanceof WorkIncome)
+        .reduce((acc, inc) => {
+            const roth401k = useStoredValue
+                ? inc.roth401k
+                : (age !== undefined ? inc.getEffective401k(year, age).roth : inc.roth401k);
+            return acc + inc.getProratedAnnual(roth401k, year);
+        }, 0);
+}
+
+export function getFicaExemptions(incomes: AnyIncome[], year: number): number {
+    return incomes
+        .filter((inc) => inc instanceof WorkIncome)
+        .reduce((acc, inc) => {
+            return (
+                acc +
+                inc.getProratedAnnual(inc.insurance, year) +
+                inc.getProratedAnnual(inc.hsaContribution, year)
+            );
+        }, 0);
+}
+
+export function getEarnedIncome(incomes: AnyIncome[], year: number): number {
+    return incomes
+        .filter((inc) => inc.earned_income === "Yes")
+        .reduce((acc, inc) => {
+            return acc + inc.getProratedAnnual(inc.amount, year);
+        }, 0);
+}
+
+/**
+ * Get total Social Security benefits received in the year.
+ */
+export function getSocialSecurityBenefits(incomes: AnyIncome[], year: number): number {
+    return incomes
+        .filter((inc) =>
+            inc instanceof SocialSecurityIncome ||
+            inc instanceof CurrentSocialSecurityIncome ||
+            inc instanceof FutureSocialSecurityIncome,
+        )
+        .reduce((acc, inc) => {
+            return acc + inc.getProratedAnnual(inc.amount, year);
+        }, 0);
+}

--- a/src/components/Objects/Taxes/taxService/marginalRates.ts
+++ b/src/components/Objects/Taxes/taxService/marginalRates.ts
@@ -1,0 +1,123 @@
+import { TaxParameters } from "../../../../data/TaxData";
+import { TaxState } from "../TaxContext";
+import { AssumptionsState } from "../../Assumptions/AssumptionsContext";
+import { getTaxParameters } from "./parameters";
+
+/** Result of marginal tax rate calculation */
+export interface MarginalRateResult {
+    rate: number;           // Decimal rate (e.g., 0.22 for 22%)
+    bracketStart: number;   // Taxable income where this bracket starts
+    bracketEnd: number;     // Taxable income where this bracket ends (Infinity for top)
+    headroom: number;       // $ remaining until next bracket
+}
+
+/**
+ * Get the marginal tax rate for a given taxable income.
+ *
+ * @param taxableIncome - Income after deductions (not gross income)
+ * @param params - Tax parameters containing brackets
+ * @returns Marginal rate info including headroom to next bracket
+ */
+export function getMarginalTaxRate(
+    taxableIncome: number,
+    params: TaxParameters,
+): MarginalRateResult {
+    // Defensive guard: an authority with no brackets (e.g. a sparsely-populated
+    // future-year fallback) would otherwise dereference `undefined`. Treat the
+    // absence of any bracket as a flat 0% rate with unbounded headroom.
+    if (params.brackets.length === 0) {
+        return { rate: 0, bracketStart: 0, bracketEnd: Infinity, headroom: Infinity };
+    }
+
+    if (taxableIncome <= 0) {
+        const first = params.brackets[0];
+        const second = params.brackets[1];
+        return {
+            rate: first.rate,
+            bracketStart: first.threshold,
+            bracketEnd: second ? second.threshold : Infinity,
+            headroom: second ? second.threshold : Infinity,
+        };
+    }
+
+    for (let i = 0; i < params.brackets.length; i++) {
+        const current = params.brackets[i];
+        const next = params.brackets[i + 1];
+        const upperLimit = next ? next.threshold : Infinity;
+
+        if (taxableIncome >= current.threshold && taxableIncome < upperLimit) {
+            return {
+                rate: current.rate,
+                bracketStart: current.threshold,
+                bracketEnd: upperLimit,
+                headroom: upperLimit === Infinity ? Infinity : upperLimit - taxableIncome,
+            };
+        }
+    }
+
+    const top = params.brackets[params.brackets.length - 1];
+    return {
+        rate: top.rate,
+        bracketStart: top.threshold,
+        bracketEnd: Infinity,
+        headroom: Infinity,
+    };
+}
+
+/**
+ * Get combined marginal tax rate (federal + state + FICA if applicable).
+ *
+ * @param grossIncome - Gross income before deductions
+ * @param preTaxDeductions - 401k, HSA, etc.
+ * @param taxState - Tax configuration
+ * @param year - Tax year
+ * @param assumptions - Assumptions for inflation adjustment
+ * @param includesFICA - Whether to include FICA taxes (true for earned income)
+ * @returns Combined marginal rate breakdown
+ */
+export function getCombinedMarginalRate(
+    grossIncome: number,
+    preTaxDeductions: number,
+    taxState: TaxState,
+    year: number,
+    assumptions: AssumptionsState,
+    includesFICA: boolean = true,
+): {
+    federal: number;
+    state: number;
+    fica: number;
+    combined: number;
+    federalHeadroom: number;
+} {
+    const fedParams = getTaxParameters(year, taxState.filingStatus, 'federal', undefined, assumptions);
+    const stateParams = getTaxParameters(year, taxState.filingStatus, 'state', taxState.stateResidency, assumptions);
+
+    const adjustedGross = Math.max(0, grossIncome - preTaxDeductions);
+    const fedStdDed = fedParams?.standardDeduction || 14600;
+    const stateStdDed = stateParams?.standardDeduction || 0;
+
+    const fedTaxableIncome = Math.max(0, adjustedGross - fedStdDed);
+    const stateTaxableIncome = Math.max(0, adjustedGross - stateStdDed);
+
+    const fedMarginal = fedParams ? getMarginalTaxRate(fedTaxableIncome, fedParams) : { rate: 0, headroom: Infinity };
+    const stateMarginal = stateParams ? getMarginalTaxRate(stateTaxableIncome, stateParams) : { rate: 0, headroom: Infinity };
+
+    // FICA: 6.2% SS (up to wage base) + 1.45% Medicare
+    let ficaRate = 0;
+    if (includesFICA && fedParams) {
+        const ssWageBase = fedParams.socialSecurityWageBase || 168600;
+        if (grossIncome < ssWageBase) {
+            ficaRate = fedParams.socialSecurityTaxRate + fedParams.medicareTaxRate;
+        } else {
+            ficaRate = fedParams.medicareTaxRate;
+        }
+    }
+
+    return {
+        federal: fedMarginal.rate,
+        state: stateMarginal.rate,
+        fica: ficaRate,
+        combined: fedMarginal.rate + stateMarginal.rate + ficaRate,
+        federalHeadroom: fedMarginal.headroom,
+    };
+}

--- a/src/components/Objects/Taxes/taxService/parameters.ts
+++ b/src/components/Objects/Taxes/taxService/parameters.ts
@@ -1,0 +1,148 @@
+import {
+    TaxParameters,
+    TAX_DATABASE,
+    getClosestTaxYear,
+    max_year,
+    FilingStatus,
+    AuthorityData,
+} from "../../../../data/TaxData";
+import {
+    AssumptionsState,
+    defaultAssumptions,
+} from "../../Assumptions/AssumptionsContext";
+
+/** Tax years when TCJA SALT cap was in effect ($10k/$5k MFS) */
+const TCJA_SALT_START_YEAR = 2018;
+const TCJA_SALT_END_YEAR = 2024;
+
+/** Tax years when OBBBA raised SALT cap ($40k/$20k MFS with 1% annual inflation) */
+const OBBBA_SALT_START_YEAR = 2025;
+const OBBBA_SALT_END_YEAR = 2029;
+
+/** SALT cap amounts */
+const SALT_CAP_TCJA_JOINT = 10000;
+const SALT_CAP_TCJA_MFS = 5000;
+const SALT_CAP_OBBBA_JOINT = 40000;
+const SALT_CAP_OBBBA_MFS = 20000;
+const SALT_CAP_ANNUAL_INCREASE = 0.01; // 1% annual increase under OBBBA
+
+/**
+ * SALT (State and Local Tax) deduction cap.
+ *
+ * History:
+ * - TCJA 2017 (effective 2018-2024): $10,000 cap ($5,000 MFS)
+ * - One Big Beautiful Bill Act 2025 (effective 2025-2029): $40,000 cap ($20,000 MFS)
+ *   with 1% annual increase starting 2026
+ * - 2030+: Reverts to $10,000
+ *
+ * Note: The 2025 law includes income phase-outs starting at $500k MAGI, but we don't
+ * implement those here for simplicity. The cap still provides a minimum of $10,000.
+ */
+export function getSALTCap(year: number, filingStatus: FilingStatus): number {
+    const isMFS = filingStatus === 'Married Filing Separately';
+
+    // Pre-TCJA: No cap
+    if (year < TCJA_SALT_START_YEAR) {
+        return Infinity;
+    }
+
+    // TCJA cap period (2018-2024)
+    if (year >= TCJA_SALT_START_YEAR && year <= TCJA_SALT_END_YEAR) {
+        return isMFS ? SALT_CAP_TCJA_MFS : SALT_CAP_TCJA_JOINT;
+    }
+
+    // OBBBA raised cap period (2025-2029) with 1% annual increase starting 2026
+    if (year >= OBBBA_SALT_START_YEAR && year <= OBBBA_SALT_END_YEAR) {
+        const yearsOfIncrease = Math.max(0, year - OBBBA_SALT_START_YEAR);
+        const inflationFactor = Math.pow(1 + SALT_CAP_ANNUAL_INCREASE, yearsOfIncrease);
+        const baseCap = isMFS ? SALT_CAP_OBBBA_MFS : SALT_CAP_OBBBA_JOINT;
+        return Math.round(baseCap * inflationFactor);
+    }
+
+    // 2030+: Reverts to original TCJA cap
+    return isMFS ? SALT_CAP_TCJA_MFS : SALT_CAP_TCJA_JOINT;
+}
+
+export function getTaxParameters(
+    year: number,
+    filingStatus: FilingStatus,
+    authority: "federal" | "state",
+    stateResidency?: string,
+    assumptions: AssumptionsState = {
+        ...defaultAssumptions,
+        macro: { ...defaultAssumptions.macro, inflationAdjusted: false },
+    }
+): TaxParameters | undefined {
+    const inflation = assumptions.macro.inflationRate / 100;
+    const inflationAdjusted = assumptions.macro.inflationAdjusted;
+
+    let sourceData: AuthorityData;
+    if (authority === "federal") {
+        sourceData = TAX_DATABASE.federal;
+    } else if (stateResidency && TAX_DATABASE.states[stateResidency]) {
+        sourceData = TAX_DATABASE.states[stateResidency];
+    } else {
+        return undefined;
+    }
+
+    const closestYear = getClosestTaxYear(year);
+
+    if (inflationAdjusted && year > max_year) {
+        // A state's table may not include the federal max_year row. Resolve the
+        // nearest year actually present and inflate from there (same nearest-year
+        // logic used by the non-inflation path below) instead of throwing.
+        let baseYear = max_year;
+        if (!sourceData[max_year]) {
+            const availableYears = Object.keys(sourceData)
+                .map(Number)
+                .filter((y) => !Number.isNaN(y));
+            if (availableYears.length === 0) return undefined;
+            baseYear = availableYears.reduce((best, y) =>
+                Math.abs(y - max_year) < Math.abs(best - max_year) ? y : best
+            );
+        }
+
+        const baseYearParams = sourceData[baseYear][filingStatus];
+        if (!baseYearParams) return undefined;
+
+        const yearsToCompound = year - baseYear;
+        const inflationMultiplier = Math.pow(1 + inflation, yearsToCompound);
+
+        const inflatedBrackets = baseYearParams.brackets.map((bracket) => ({
+            ...bracket,
+            threshold: Math.round(bracket.threshold * inflationMultiplier),
+        }));
+
+        return {
+            ...baseYearParams,
+            standardDeduction: Math.round(
+                baseYearParams.standardDeduction * inflationMultiplier
+            ),
+            socialSecurityWageBase: Math.round(
+                baseYearParams.socialSecurityWageBase * inflationMultiplier
+            ),
+            brackets: inflatedBrackets,
+            capitalGainsBrackets: baseYearParams.capitalGainsBrackets?.map((bracket) => ({
+                ...bracket,
+                threshold: Math.round(bracket.threshold * inflationMultiplier),
+            })),
+        };
+    }
+
+    if (sourceData[closestYear]) {
+        return sourceData[closestYear][filingStatus];
+    }
+
+    // State tables may not cover every federal year (e.g. California has no 2024
+    // entry), so getClosestTaxYear — which only knows federal years — can resolve
+    // to a year missing from this authority's table. Fall back to the nearest year
+    // actually present so the gap doesn't return undefined → $0 tax.
+    const availableYears = Object.keys(sourceData)
+        .map(Number)
+        .filter((y) => !Number.isNaN(y));
+    if (availableYears.length === 0) return undefined;
+    const nearestYear = availableYears.reduce((best, y) =>
+        Math.abs(y - year) < Math.abs(best - year) ? y : best
+    );
+    return sourceData[nearestYear]?.[filingStatus];
+}

--- a/src/components/Objects/Taxes/taxService/socialSecurity.ts
+++ b/src/components/Objects/Taxes/taxService/socialSecurity.ts
@@ -1,0 +1,85 @@
+import { FilingStatus } from "../../../../data/TaxData";
+
+/** Social Security combined income thresholds for benefit taxation */
+const SS_THRESHOLDS_SINGLE = { first: 25000, second: 34000 };
+const SS_THRESHOLDS_JOINT = { first: 32000, second: 44000 };
+
+/** Social Security taxation rates */
+const SS_TIER1_TAXABLE_RATE = 0.5;  // 50% of excess taxable in tier 1
+const SS_TIER2_TAXABLE_RATE = 0.85; // 85% of excess taxable in tier 2
+const SS_MAX_TAXABLE_RATE = 0.85;   // Maximum 85% of benefits can be taxed
+
+/**
+ * Calculate taxable portion of Social Security benefits.
+ *
+ * Combined Income = otherIncome + taxExemptInterest + 50% of SS Benefits
+ *
+ * Thresholds (not inflation-adjusted since 1984/1993):
+ * Single/MFS:
+ *   < $25,000: 0% taxable
+ *   $25,000-$34,000: Up to 50% taxable
+ *   > $34,000: Up to 85% taxable
+ *
+ * Married Filing Jointly:
+ *   < $32,000: 0% taxable
+ *   $32,000-$44,000: Up to 50% taxable
+ *   > $44,000: Up to 85% taxable
+ *
+ * @param totalSSBenefits - Gross Social Security benefits received
+ * @param otherIncome - All taxable income EXCEPT SS. Must include:
+ *                      - Wages and salaries
+ *                      - Pension income
+ *                      - Traditional IRA/401k withdrawals
+ *                      - Roth conversions
+ *                      - Long-term capital gains
+ *                      - Short-term capital gains
+ *                      - Qualified dividends
+ *                      - Ordinary dividends
+ *                      - Interest income
+ *                      - Rental income
+ *                      - Any other taxable income
+ * @param taxExemptInterest - Municipal bond interest. Not taxed federally, but DOES count
+ *                            toward SS combined income calculation. Pass 0 if not tracking.
+ *                            TODO: System does not currently track tax-exempt interest separately.
+ * @param filingStatus - Tax filing status (Single, MFJ, MFS)
+ * @returns Taxable portion of SS benefits (0 to 85% of totalSSBenefits)
+ */
+export function getTaxableSocialSecurityBenefits(
+    totalSSBenefits: number,
+    otherIncome: number,
+    taxExemptInterest: number,
+    filingStatus: FilingStatus,
+): number {
+    if (totalSSBenefits === 0) return 0;
+
+    // Combined income = otherIncome + taxExemptInterest + 50% of SS Benefits
+    const combinedIncome = otherIncome + taxExemptInterest + (totalSSBenefits * SS_TIER1_TAXABLE_RATE);
+
+    // Select thresholds based on filing status
+    const useSingleThresholds = filingStatus === 'Single' || filingStatus === 'Married Filing Separately';
+    const thresholds = useSingleThresholds ? SS_THRESHOLDS_SINGLE : SS_THRESHOLDS_JOINT;
+
+    // No SS benefits are taxable below first threshold
+    if (combinedIncome < thresholds.first) {
+        return 0;
+    }
+
+    // Up to 50% of SS benefits are taxable between first and second threshold
+    if (combinedIncome < thresholds.second) {
+        const excessAboveFirst = combinedIncome - thresholds.first;
+        const taxable50Percent = Math.min(
+            excessAboveFirst * SS_TIER1_TAXABLE_RATE,
+            totalSSBenefits * SS_TIER1_TAXABLE_RATE,
+        );
+        return Math.min(taxable50Percent, totalSSBenefits);
+    }
+
+    // Up to 85% of SS benefits are taxable above second threshold
+    const excessAboveSecond = combinedIncome - thresholds.second;
+    const tier1Amount = Math.min((thresholds.second - thresholds.first) * SS_TIER1_TAXABLE_RATE, totalSSBenefits * SS_TIER1_TAXABLE_RATE);
+    const tier2Amount = excessAboveSecond * SS_TIER2_TAXABLE_RATE;
+    const totalTaxable = tier1Amount + tier2Amount;
+
+    // Cap at 85% of total benefits
+    return Math.min(totalTaxable, totalSSBenefits * SS_MAX_TAXABLE_RATE);
+}

--- a/src/components/Objects/Taxes/taxService/stateTax.ts
+++ b/src/components/Objects/Taxes/taxService/stateTax.ts
@@ -1,0 +1,207 @@
+import { AnyExpense } from "../../Expense/models";
+import { AnyIncome } from "../../Income/models";
+import { TaxState } from "../TaxContext";
+import { AssumptionsState, getBirthYear } from "../../Assumptions/AssumptionsContext";
+import { getTaxParameters } from "./parameters";
+import {
+    getGrossIncome,
+    getPreTaxExemptions,
+    getSocialSecurityBenefits,
+} from "./incomeAggregation";
+import { getTaxableSocialSecurityBenefits } from "./socialSecurity";
+import { getItemizedDeductions, getYesDeductions } from "./deductions";
+import { calculateTax } from "./bracketTax";
+
+export function calculateStateTax(
+    state: TaxState,
+    incomes: AnyIncome[],
+    expenses: AnyExpense[],
+    year: number,
+    assumptions?: AssumptionsState,
+) {
+    if (state.stateOverride !== null) {
+        return state.stateOverride;
+    }
+
+    const annualGross = getGrossIncome(incomes, year);
+    const age = assumptions?.milestones ? year - getBirthYear(assumptions.milestones) : undefined;
+    const incomePreTaxDeductions = getPreTaxExemptions(incomes, year, age);
+    const expenseAboveLineDeductions = getYesDeductions(expenses, year);
+    const totalPreTaxDeductions = incomePreTaxDeductions + expenseAboveLineDeductions;
+
+    const itemizedTotal = getItemizedDeductions(expenses, year);
+    const stateParams = getTaxParameters(
+        year,
+        state.filingStatus,
+        "state",
+        state.stateResidency,
+        assumptions,
+    );
+
+    if (!stateParams) return 0;
+
+    // Social Security handling — data-driven `socialSecurityTreatment` defaults to 'exempt'.
+    const ssTreatment = stateParams.socialSecurityTreatment ?? 'exempt';
+    const totalSSBenefits = getSocialSecurityBenefits(incomes, year);
+    let adjustedGrossForState = annualGross;
+
+    if (totalSSBenefits > 0) {
+        if (ssTreatment === 'taxable') {
+            // States that tax SS: use only the taxable portion (like federal)
+            const nonSSGross = annualGross - totalSSBenefits;
+            const agiExcludingSS = nonSSGross - totalPreTaxDeductions;
+            // TODO: Verify all income types are included (LTCG, STCG, dividends, etc.)
+            const taxableSSBenefits = getTaxableSocialSecurityBenefits(
+                totalSSBenefits,
+                agiExcludingSS,
+                0,
+                state.filingStatus,
+            );
+            adjustedGrossForState = annualGross - totalSSBenefits + taxableSSBenefits;
+        } else if (ssTreatment === 'income-based') {
+            // TODO: Implement income-based SS exemption for states like CO, CT, etc.
+            // For now, treat as exempt (conservative).
+            adjustedGrossForState = annualGross - totalSSBenefits;
+        } else {
+            // 'exempt' — exclude SS benefits entirely
+            adjustedGrossForState = annualGross - totalSSBenefits;
+        }
+    }
+
+    // Senior deduction: per-person variants (e.g., Virginia) get doubled for MFJ
+    // (assumes both spouses meet the age threshold).
+    let seniorDeductionAmount = 0;
+    if (stateParams.seniorDeduction && age !== undefined) {
+        const seniorAge = stateParams.seniorAge ?? 65;
+        if (age >= seniorAge) {
+            seniorDeductionAmount = stateParams.seniorDeduction;
+            if (stateParams.seniorDeductionPerPerson && state.filingStatus === 'Married Filing Jointly') {
+                seniorDeductionAmount *= 2;
+            }
+        }
+    }
+
+    const stateStandardDeduction = (stateParams.standardDeduction || 0) + seniorDeductionAmount;
+
+    if (state.deductionMethod === "Auto") {
+        const taxWithStandard = calculateTax(adjustedGrossForState, totalPreTaxDeductions, {
+            ...stateParams,
+            standardDeduction: stateStandardDeduction,
+        });
+        const taxWithItemized = calculateTax(adjustedGrossForState, totalPreTaxDeductions, {
+            ...stateParams,
+            standardDeduction: itemizedTotal + seniorDeductionAmount,
+        });
+        return Math.min(taxWithStandard, taxWithItemized);
+    }
+
+    const stateAppliedMainDeduction =
+        state.deductionMethod === "Standard"
+            ? stateStandardDeduction
+            : itemizedTotal + seniorDeductionAmount;
+
+    return calculateTax(adjustedGrossForState, totalPreTaxDeductions, {
+        ...stateParams,
+        standardDeduction: stateAppliedMainDeduction,
+    });
+}
+
+/**
+ * Calculate state tax including additional ordinary income from withdrawals.
+ *
+ * @param state - Tax state
+ * @param incomes - Original income objects
+ * @param expenses - Expenses (for deductions)
+ * @param additionalOrdinaryIncome - Traditional withdrawals + Roth conversions + RMDs
+ * @param year - Tax year
+ * @param assumptions - Assumptions for inflation adjustments
+ * @returns State tax including all income sources
+ */
+export function calculateUnifiedStateTax(
+    state: TaxState,
+    incomes: AnyIncome[],
+    expenses: AnyExpense[],
+    additionalOrdinaryIncome: number,
+    year: number,
+    assumptions?: AssumptionsState,
+): number {
+    if (state.stateOverride !== null) {
+        return state.stateOverride;
+    }
+
+    const stateParams = getTaxParameters(
+        year,
+        state.filingStatus,
+        "state",
+        state.stateResidency,
+        assumptions,
+    );
+
+    if (!stateParams) return 0;
+
+    const incomeGross = getGrossIncome(incomes, year);
+    const annualGross = incomeGross + additionalOrdinaryIncome;
+
+    const age = assumptions?.milestones ? year - getBirthYear(assumptions.milestones) : undefined;
+    const incomePreTaxDeductions = getPreTaxExemptions(incomes, year, age);
+    const expenseAboveLineDeductions = getYesDeductions(expenses, year);
+    const totalPreTaxDeductions = incomePreTaxDeductions + expenseAboveLineDeductions;
+
+    const ssTreatment = stateParams.socialSecurityTreatment ?? 'exempt';
+    const totalSSBenefits = getSocialSecurityBenefits(incomes, year);
+    let adjustedGross = annualGross;
+
+    if (totalSSBenefits > 0) {
+        if (ssTreatment === 'taxable') {
+            const nonSSGross = annualGross - totalSSBenefits;
+            const agiExcludingSS = nonSSGross - totalPreTaxDeductions;
+            // TODO: Verify all income types are included (LTCG, STCG, dividends, etc.)
+            const taxableSSBenefits = getTaxableSocialSecurityBenefits(
+                totalSSBenefits,
+                agiExcludingSS,
+                0,
+                state.filingStatus,
+            );
+            adjustedGross = annualGross - totalSSBenefits + taxableSSBenefits;
+        } else if (ssTreatment === 'income-based') {
+            // TODO: Implement income-based SS exemption (CO, CT, etc.)
+            adjustedGross = annualGross - totalSSBenefits;
+        } else {
+            adjustedGross = annualGross - totalSSBenefits;
+        }
+    }
+
+    let seniorDeductionAmount = 0;
+    if (stateParams.seniorDeduction && age !== undefined) {
+        const seniorAge = stateParams.seniorAge ?? 65;
+        if (age >= seniorAge) {
+            seniorDeductionAmount = stateParams.seniorDeduction;
+            if (stateParams.seniorDeductionPerPerson && state.filingStatus === 'Married Filing Jointly') {
+                seniorDeductionAmount *= 2;
+            }
+        }
+    }
+
+    const itemizedTotal = getItemizedDeductions(expenses, year);
+    const stateStandardDeduction = (stateParams.standardDeduction || 0) + seniorDeductionAmount;
+
+    if (state.deductionMethod === "Auto") {
+        const taxWithStandard = calculateTax(adjustedGross, totalPreTaxDeductions, {
+            ...stateParams,
+            standardDeduction: stateStandardDeduction,
+        });
+        const taxWithItemized = calculateTax(adjustedGross, totalPreTaxDeductions, {
+            ...stateParams,
+            standardDeduction: itemizedTotal + seniorDeductionAmount,
+        });
+        return Math.min(taxWithStandard, taxWithItemized);
+    }
+
+    const stateAppliedMainDeduction =
+        state.deductionMethod === "Standard" ? stateStandardDeduction : itemizedTotal + seniorDeductionAmount;
+
+    return calculateTax(adjustedGross, totalPreTaxDeductions, {
+        ...stateParams,
+        standardDeduction: stateAppliedMainDeduction,
+    });
+}

--- a/src/data/TaxData.tsx
+++ b/src/data/TaxData.tsx
@@ -1,0 +1,873 @@
+export type FilingStatus = 'Single' | 'Married Filing Jointly' | 'Married Filing Separately';
+
+export interface TaxBracket {
+  threshold: number; // The income level where this rate begins
+  rate: number;      // Decimal (0.10 for 10%)
+}
+
+// State-specific Social Security treatment
+export type SocialSecurityTreatment = 'exempt' | 'taxable' | 'income-based';
+
+// State-specific long-term capital gains treatment
+export type LTCGTreatment = 'ordinary' | 'preferential' | 'exempt';
+
+// Retirement income exemption configuration
+export interface RetirementIncomeExemption {
+  amount: number;
+  appliesTo: ('pension' | '401k' | 'ira' | 'all')[];
+  ageRequirement?: number;
+  perPerson: boolean;
+}
+
+// Social Security exemption phaseout thresholds
+export interface SSExemptionPhaseout {
+  start: number;
+  end: number;
+}
+
+export interface TaxParameters {
+  standardDeduction: number;
+  brackets: TaxBracket[];
+  socialSecurityTaxRate: number; // FICA
+  socialSecurityWageBase: number;
+  medicareTaxRate: number;
+  // Long-term capital gains brackets (based on taxable income thresholds)
+  capitalGainsBrackets?: TaxBracket[];
+
+  // State-specific fields (all optional, for state use):
+  socialSecurityTreatment?: SocialSecurityTreatment;
+  ssExemptionThreshold?: number;
+  ssExemptionPhaseout?: SSExemptionPhaseout;
+  ltcgTreatment?: LTCGTreatment;
+  retirementIncomeExemption?: RetirementIncomeExemption;
+  seniorDeduction?: number;
+  seniorAge?: number;
+  seniorDeductionPerPerson?: boolean;  // If true, MFJ gets double the deduction (assumes both spouses same age)
+}
+
+export const max_year = 2026;
+
+
+/** * Hierarchical Lookups:
+ * AuthorityData: Year -> FilingStatus -> Parameters
+ */
+export type YearConfig = Record<FilingStatus, TaxParameters>;
+export type AuthorityData = Record<number, YearConfig>;
+
+export interface GlobalTaxDatabase {
+  federal: AuthorityData;
+  states: Record<string, AuthorityData>;
+}
+
+
+export const TAX_DATABASE: GlobalTaxDatabase = {
+    federal: {
+        2024: {
+            Single: {
+                standardDeduction: 14600,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 11600, rate: 0.12 },
+                    { threshold: 47151, rate: 0.22 },
+                    { threshold: 100526, rate: 0.24 },
+                    { threshold: 191951, rate: 0.32 },
+                    { threshold: 243726, rate: 0.35 },
+                    { threshold: 609350, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 47025, rate: 0.15 },
+                    { threshold: 518900, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 168600,
+                medicareTaxRate: 0.0145
+            },
+            'Married Filing Jointly': {
+                standardDeduction: 29200,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 23200, rate: 0.12 },
+                    { threshold: 94300, rate: 0.22 },
+                    { threshold: 201050, rate: 0.24 },
+                    { threshold: 383900, rate: 0.32 },
+                    { threshold: 487450, rate: 0.35 },
+                    { threshold: 731200, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 94050, rate: 0.15 },
+                    { threshold: 583750, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 168600,
+                medicareTaxRate: 0.0145
+            },
+            'Married Filing Separately': {
+                standardDeduction: 14600,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 11600, rate: 0.12 },
+                    { threshold: 47150, rate: 0.22 },
+                    { threshold: 100525, rate: 0.24 },
+                    { threshold: 191950, rate: 0.32 },
+                    { threshold: 243725, rate: 0.35 },
+                    { threshold: 365600, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 47025, rate: 0.15 },
+                    { threshold: 291850, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 168600,
+                medicareTaxRate: 0.0145
+            }
+        },
+        2025: {
+            Single: {
+                standardDeduction: 15750,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 11925, rate: 0.12 },
+                    { threshold: 48475, rate: 0.22 },
+                    { threshold: 103350, rate: 0.24 },
+                    { threshold: 197300, rate: 0.32 },
+                    { threshold: 250525, rate: 0.35 },
+                    { threshold: 626350, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 48350, rate: 0.15 },
+                    { threshold: 533400, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 176100,
+                medicareTaxRate: 0.0145
+            },
+            'Married Filing Jointly': {
+                standardDeduction: 31500,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 23850, rate: 0.12 },
+                    { threshold: 96950, rate: 0.22 },
+                    { threshold: 206700, rate: 0.24 },
+                    { threshold: 394600, rate: 0.32 },
+                    { threshold: 501050, rate: 0.35 },
+                    { threshold: 751600, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 96700, rate: 0.15 },
+                    { threshold: 600050, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 176100,
+                medicareTaxRate: 0.0145
+            },
+            'Married Filing Separately': {
+                standardDeduction: 15750,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 11925, rate: 0.12 },
+                    { threshold: 48475, rate: 0.22 },
+                    { threshold: 103350, rate: 0.24 },
+                    { threshold: 197300, rate: 0.32 },
+                    { threshold: 250525, rate: 0.35 },
+                    { threshold: 375800, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 48350, rate: 0.15 },
+                    { threshold: 300000, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 176100,
+                medicareTaxRate: 0.0145
+            }
+        },
+        2026: {
+            Single: {
+                standardDeduction: 16100,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 12400, rate: 0.12 },
+                    { threshold: 50400, rate: 0.22 },
+                    { threshold: 105700, rate: 0.24 },
+                    { threshold: 201775, rate: 0.32 },
+                    { threshold: 256225, rate: 0.35 },
+                    { threshold: 640600, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 49450, rate: 0.15 },
+                    { threshold: 545500, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 184500,
+                medicareTaxRate: 0.0145
+            },
+            'Married Filing Jointly': {
+                standardDeduction: 32200,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 24800, rate: 0.12 },
+                    { threshold: 100800, rate: 0.22 },
+                    { threshold: 211400, rate: 0.24 },
+                    { threshold: 403550, rate: 0.32 },
+                    { threshold: 512450, rate: 0.35 },
+                    { threshold: 768700, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 98900, rate: 0.15 },
+                    { threshold: 613700, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 184500,
+                medicareTaxRate: 0.0145
+            },
+            'Married Filing Separately': {
+                standardDeduction: 16100,
+                brackets: [
+                    { threshold: 0, rate: 0.10 },
+                    { threshold: 12400, rate: 0.12 },
+                    { threshold: 50400, rate: 0.22 },
+                    { threshold: 105700, rate: 0.24 },
+                    { threshold: 201775, rate: 0.32 },
+                    { threshold: 256225, rate: 0.35 },
+                    { threshold: 384350, rate: 0.37 }
+                ],
+                capitalGainsBrackets: [
+                    { threshold: 0, rate: 0.00 },
+                    { threshold: 49450, rate: 0.15 },
+                    { threshold: 306850, rate: 0.20 }
+                ],
+                socialSecurityTaxRate: 0.062,
+                socialSecurityWageBase: 184500,
+                medicareTaxRate: 0.0145
+            }
+        }
+    },
+    states: {
+        "California": {
+            2025: {
+                Single: {
+                    standardDeduction: 5540,
+                    brackets: [
+                        { threshold: 0, rate: 0.01 },
+                        { threshold: 10_757, rate: 0.02 },
+                        { threshold: 25_500, rate: 0.04 },
+                        { threshold: 40_246, rate: 0.06 },
+                        { threshold: 55_867, rate: 0.08 },
+                        { threshold: 70_607, rate: 0.093 },
+                        { threshold: 360_660, rate: 0.103 },
+                        { threshold: 432_788, rate: 0.113 },
+                        { threshold: 721_315, rate: 0.123 },
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 11080,
+                    brackets: [
+                        { threshold: 0, rate: 0.01 },
+                        { threshold: 21_513, rate: 0.02 },
+                        { threshold: 50_999, rate: 0.04 },
+                        { threshold: 80_491, rate: 0.06 },
+                        { threshold: 111_733, rate: 0.08 },
+                        { threshold: 141_213, rate: 0.093 },
+                        { threshold: 721_319, rate: 0.103 },
+                        { threshold: 865_575, rate: 0.113 },
+                        { threshold: 1_442_629, rate: 0.123 },
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 5540,
+                    brackets: [
+                        { threshold: 0, rate: 0.01 },
+                        { threshold: 10_757, rate: 0.02 },
+                        { threshold: 25_500, rate: 0.04 },
+                        { threshold: 40_246, rate: 0.06 },
+                        { threshold: 55_867, rate: 0.08 },
+                        { threshold: 70_607, rate: 0.093 },
+                        { threshold: 360_660, rate: 0.103 },
+                        { threshold: 432_788, rate: 0.113 },
+                        { threshold: 721_315, rate: 0.123 },
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                }
+            },
+            2026: {
+                Single: {
+                    standardDeduction: 5669,
+                    brackets: [
+                        { threshold: 0, rate: 0.01 },
+                        { threshold: 11_015, rate: 0.02 },
+                        { threshold: 26_111, rate: 0.04 },
+                        { threshold: 41_212, rate: 0.06 },
+                        { threshold: 57_208, rate: 0.08 },
+                        { threshold: 72_272, rate: 0.093 },
+                        { threshold: 369_156, rate: 0.103 },
+                        { threshold: 443_175, rate: 0.113 },
+                        { threshold: 738_628, rate: 0.123 },
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 11_338,
+                    brackets: [
+                        { threshold: 0, rate: 0.01 },
+                        { threshold: 22_030, rate: 0.02 },
+                        { threshold: 52_223, rate: 0.04 },
+                        { threshold: 82_423, rate: 0.06 },
+                        { threshold: 114_414, rate: 0.08 },
+                        { threshold: 144_542, rate: 0.093 },
+                        { threshold: 738_310, rate: 0.103 },
+                        { threshold: 885_974, rate: 0.113 },
+                        { threshold: 1_477_252, rate: 0.123 },
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 5669,
+                    brackets: [
+                        { threshold: 0, rate: 0.01 },
+                        { threshold: 11_015, rate: 0.02 },
+                        { threshold: 26_111, rate: 0.04 },
+                        { threshold: 41_212, rate: 0.06 },
+                        { threshold: 57_208, rate: 0.08 },
+                        { threshold: 72_272, rate: 0.093 },
+                        { threshold: 369_156, rate: 0.103 },
+                        { threshold: 443_175, rate: 0.113 },
+                        { threshold: 738_628, rate: 0.123 },
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                }
+            }
+        },
+        "DC": {
+            2024: {
+                Single: {
+                    standardDeduction: 14600,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 29200,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 14600,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+            },
+            2025: {
+                Single: {
+                    standardDeduction: 15000,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 30000,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 15000,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+            },
+            2026: {
+                Single: {
+                    standardDeduction: 15000,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 30000,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 15000,
+                    brackets: [
+                        { threshold: 0, rate: 0.04 },
+                        { threshold: 10_000, rate: 0.06 },
+                        { threshold: 40_000, rate: 0.065 },
+                        { threshold: 60_000, rate: 0.085 },
+                        { threshold: 250_000, rate: 0.0925 },
+                        { threshold: 500_000, rate: 0.0975 },
+                        { threshold: 1_000_000, rate: 0.1075 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+            }
+        },
+        "Texas": {
+            2024: {
+                Single: {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+            },
+            2025: {
+                Single: {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+            },
+            2026: {
+                Single: {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 0,
+                    brackets: [
+                        { threshold: 0, rate: 0.0 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0
+                },
+            }
+        },
+        "North Carolina": {
+            // NC has a flat tax rate - 4.5% in 2024, 4.25% in 2025, 3.99% in 2026+
+            2024: {
+                Single: {
+                    standardDeduction: 12750,
+                    brackets: [
+                        { threshold: 0, rate: 0.045 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 25500,
+                    brackets: [
+                        { threshold: 0, rate: 0.045 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 12750,
+                    brackets: [
+                        { threshold: 0, rate: 0.045 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+            },
+            2025: {
+                Single: {
+                    standardDeduction: 12750,
+                    brackets: [
+                        { threshold: 0, rate: 0.0425 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 25500,
+                    brackets: [
+                        { threshold: 0, rate: 0.0425 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 12750,
+                    brackets: [
+                        { threshold: 0, rate: 0.0425 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+            },
+            2026: {
+                Single: {
+                    standardDeduction: 12750,
+                    brackets: [
+                        { threshold: 0, rate: 0.0399 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 25500,
+                    brackets: [
+                        { threshold: 0, rate: 0.0399 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 12750,
+                    brackets: [
+                        { threshold: 0, rate: 0.0399 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt'
+                },
+            }
+        },
+        "Virginia": {
+            // VA has 4 brackets: 2%, 3%, 5%, 5.75%
+            // VA also has a $12k senior deduction at age 65+
+            2024: {
+                Single: {
+                    standardDeduction: 8500,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 17000,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true  // $24k total for MFJ (both spouses 65+)
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 8500,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true
+                },
+            },
+            2025: {
+                Single: {
+                    standardDeduction: 8750,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 17500,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true  // $24k total for MFJ (both spouses 65+)
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 8750,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true
+                },
+            },
+            2026: {
+                Single: {
+                    standardDeduction: 8750,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true
+                },
+                'Married Filing Jointly': {
+                    standardDeduction: 17500,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true  // $24k total for MFJ (both spouses 65+)
+                },
+                'Married Filing Separately': {
+                    standardDeduction: 8750,
+                    brackets: [
+                        { threshold: 0, rate: 0.02 },
+                        { threshold: 3000, rate: 0.03 },
+                        { threshold: 5000, rate: 0.05 },
+                        { threshold: 17000, rate: 0.0575 }
+                    ],
+                    socialSecurityTaxRate: 0.0,
+                    socialSecurityWageBase: 0,
+                    medicareTaxRate: 0.0,
+                    socialSecurityTreatment: 'exempt',
+                    seniorDeduction: 12000,
+                    seniorAge: 65,
+                    seniorDeductionPerPerson: true
+                },
+            }
+        }
+    }
+};
+
+export const getClosestTaxYear = (year: number): number => {
+    const availableYears = Object.keys(TAX_DATABASE.federal).map(Number);
+    if (availableYears.length === 0) {
+        throw new Error("No tax data available.");
+    }
+
+    return availableYears.reduce((prev, curr) => {
+        return (Math.abs(curr - year) < Math.abs(prev - year) ? curr : prev);
+    });
+ };


### PR DESCRIPTION
Scoped review of federal/state/FICA/capital-gains tax computation and the tax
data tables. ONLY the source files added in the diff are under review. The
test files in this branch are a behavioral reference ONLY (not in the diff)
and may be wrong or timezone-dependent: if source and a test disagree, flag it
as a question, do not assume the test.

ADJUDICATIONS: code-review-pr-50.md … code-review-pr-53.md (in this tree, base
commit) record findings already fixed or ruled by-design — do not resurface
wont-fixes. The planner-side 0% LTCG floor is adjudicated (PR #53 finding 3);
bracket-boundary fixes from PR #53 findings 1/5/7 are already on main.

Recurring problem areas that have actually bitten us here — extra scrutiny:

  1. Social Security taxation. Provisional-income math (85%/50% tiers); the
     THREE SS income classes (SocialSecurityIncome, CurrentSocialSecurityIncome,
     FutureSocialSecurityIncome) are siblings — any filter or instanceof list
     naming only two silently drops the third; SS-exempt-state handling.
  2. Duplicated logic that drifts. calculateStateTax vs
     calculateUnifiedStateTax have diverged before (deductions applied
     differently). If a rule exists in two places, verify EVERY copy; flag the
     duplication itself.
  3. Bracket math edges. Inclusive/exclusive boundary at bracket tops;
     marginal-rate lookups at taxableIncome <= 0 (empty-bracket deref is
     PR #53 finding 15, still open); stacking order of ordinary income vs LTCG
     for the 0/15/20 thresholds; NIIT MAGI threshold (not inflation-indexed by
     law — check it isn't being inflated).
  4. Falsy-zero. `|| default` where 0 is legitimate (a 0% state rate, $0
     deduction override, 0 taxable income) should be `??`.
  5. Data freshness vs logic. The tables (TaxData, brackets, standard
     deductions) drive everything — spot-check a handful of 2025/2026 figures
     against published IRS/SSA values and flag mismatches as DATA findings,
     separate from logic findings (PR #53 flagged the 2025 SS bend points).
  6. Filing-status coverage. MFJ vs Single paths copy-pasted with slight
     variation; verify each threshold table actually differs where the law
     differs (and not where it doesn't).

Output: ranked findings, each with a concrete failure scenario
(inputs/state -> wrong output). Findings that can't name a trigger should say
so explicitly.