### PR TITLE
Scope: Roth/RMD/income-projection/account-growth services (source)

### DIFF
--- a/src/data/ContributionLimits.ts
+++ b/src/data/ContributionLimits.ts
@@ -1,0 +1,181 @@
+/**
+ * Retirement Account Contribution Limits
+ *
+ * IRS contribution limits for 401k, IRA, and HSA accounts by year.
+ * Used for tax optimization recommendations.
+ */
+
+export interface YearlyContributionLimits {
+  // 401k limits
+  traditional401k: number;      // Also applies to Roth 401k (combined limit)
+  catchUp401k: number;          // Additional amount for age 50+
+
+  // IRA limits
+  traditionalIRA: number;       // Also applies to Roth IRA (combined limit)
+  catchUpIRA: number;           // Additional amount for age 50+
+
+  // HSA limits
+  hsaIndividual: number;        // Self-only coverage
+  hsaFamily: number;            // Family coverage
+  catchUpHSA: number;           // Additional amount for age 55+
+
+  // §415(c) annual-additions limit: combined cap on employee (pre-tax + Roth)
+  // + employer contributions to a single defined-contribution plan.
+  // Catch-up contributions are ON TOP of this limit (handled via get415cLimit).
+  section415c: number;
+}
+
+const CONTRIBUTION_LIMITS: Record<number, YearlyContributionLimits> = {
+  2024: {
+    traditional401k: 23000,
+    catchUp401k: 7500,
+    traditionalIRA: 7000,
+    catchUpIRA: 1000,
+    hsaIndividual: 4150,
+    hsaFamily: 8300,
+    catchUpHSA: 1000,
+    section415c: 69000,
+  },
+  2025: {
+    traditional401k: 23500,
+    catchUp401k: 7500,
+    traditionalIRA: 7000,
+    catchUpIRA: 1000,
+    hsaIndividual: 4300,
+    hsaFamily: 8550,
+    catchUpHSA: 1000,
+    section415c: 70000,
+  },
+  2026: {
+    traditional401k: 24500,     // Projected
+    catchUp401k: 7500,
+    traditionalIRA: 7500,
+    catchUpIRA: 1000,
+    hsaIndividual: 4400,        // Projected
+    hsaFamily: 8750,            // Projected
+    catchUpHSA: 1000,
+    section415c: 71000,         // Projected
+  },
+};
+
+/**
+ * Get contribution limits for a specific year.
+ * Falls back to closest available year if exact year not found.
+ *
+ * @param year - The tax year to get limits for
+ * @param inflationAdjusted - If true (default), projects future years with ~2.5% growth.
+ *                            If false, uses latest known values without projection.
+ */
+export function getContributionLimits(year: number, inflationAdjusted: boolean = true): YearlyContributionLimits {
+  if (CONTRIBUTION_LIMITS[year]) {
+    return CONTRIBUTION_LIMITS[year];
+  }
+
+  // Find closest year
+  const years = Object.keys(CONTRIBUTION_LIMITS).map(Number).sort((a, b) => a - b);
+
+  if (year < years[0]) {
+    return CONTRIBUTION_LIMITS[years[0]];
+  }
+
+  // For future years beyond our data
+  const latestYear = years[years.length - 1];
+  const latestLimits = CONTRIBUTION_LIMITS[latestYear];
+
+  // If not inflation adjusted (real dollars mode), use latest known values
+  if (!inflationAdjusted) {
+    return latestLimits;
+  }
+
+  // Project forward with assumed ~2.5% annual increase
+  const yearsAhead = year - latestYear;
+  const inflationFactor = Math.pow(1.025, yearsAhead);
+
+  return {
+    traditional401k: Math.round(latestLimits.traditional401k * inflationFactor / 500) * 500,
+    catchUp401k: latestLimits.catchUp401k,  // Catch-up tends to stay flat
+    traditionalIRA: Math.round(latestLimits.traditionalIRA * inflationFactor / 500) * 500,
+    catchUpIRA: latestLimits.catchUpIRA,
+    hsaIndividual: Math.round(latestLimits.hsaIndividual * inflationFactor / 50) * 50,
+    hsaFamily: Math.round(latestLimits.hsaFamily * inflationFactor / 50) * 50,
+    catchUpHSA: latestLimits.catchUpHSA,
+    section415c: Math.round(latestLimits.section415c * inflationFactor / 1000) * 1000,
+  };
+}
+
+/**
+ * Get the 401k contribution limit for a specific year and age.
+ */
+export function get401kLimit(year: number, age: number, inflationAdjusted: boolean = true): number {
+  const limits = getContributionLimits(year, inflationAdjusted);
+  const base = limits.traditional401k;
+  const catchUp = age >= 50 ? (age >= 60 && age <= 63 ? Math.round(limits.catchUp401k * 1.5) : limits.catchUp401k) : 0;
+  return base + catchUp;
+}
+
+/**
+ * Get the §415(c) annual-additions limit for a specific year and age.
+ *
+ * This caps the COMBINED employee (pre-tax + Roth) + employer contributions to
+ * a single defined-contribution (401k) plan. Per IRS rules, age 50+ catch-up
+ * contributions are allowed ON TOP of the §415(c) limit, so we add the same
+ * catch-up amount used by get401kLimit (including the 60-63 super catch-up).
+ */
+export function get415cLimit(year: number, age: number, inflationAdjusted: boolean = true): number {
+  const limits = getContributionLimits(year, inflationAdjusted);
+  const base = limits.section415c;
+  const catchUp = age >= 50 ? (age >= 60 && age <= 63 ? Math.round(limits.catchUp401k * 1.5) : limits.catchUp401k) : 0;
+  return base + catchUp;
+}
+
+/**
+ * Get the IRA contribution limit for a specific year and age.
+ */
+export function getIRALimit(year: number, age: number, inflationAdjusted: boolean = true): number {
+  const limits = getContributionLimits(year, inflationAdjusted);
+  const base = limits.traditionalIRA;
+  const catchUp = age >= 50 ? limits.catchUpIRA : 0;
+  return base + catchUp;
+}
+
+/**
+ * Get the HSA contribution limit for a specific year, age, and coverage type.
+ */
+export function getHSALimit(
+  year: number,
+  age: number,
+  coverage: 'individual' | 'family',
+  inflationAdjusted: boolean = true
+): number {
+  const limits = getContributionLimits(year, inflationAdjusted);
+  const base = coverage === 'family' ? limits.hsaFamily : limits.hsaIndividual;
+  const catchUp = age >= 55 ? limits.catchUpHSA : 0;
+  return base + catchUp;
+}
+
+/**
+ * Calculate potential tax savings from maxing out a retirement account.
+ */
+export function calculateContributionTaxSavings(
+  currentContribution: number,
+  limit: number,
+  marginalTaxRate: number
+): { additionalContribution: number; taxSavings: number } {
+  const additionalContribution = Math.max(0, limit - currentContribution);
+  const taxSavings = additionalContribution * marginalTaxRate;
+  return { additionalContribution, taxSavings };
+}
+
+/**
+ * Get the ESPP (Employee Stock Purchase Plan) FMV limit.
+ *
+ * IRS limits ESPP purchases to $25,000 of stock Fair Market Value per calendar year.
+ * This is measured at the grant date FMV, not the purchase date.
+ * Note: This is not the amount you can contribute, but the FMV of shares you can acquire.
+ *
+ * @returns Annual ESPP FMV limit ($25,000)
+ */
+export function getESPPLimit(): number {
+  // ESPP limit is fixed at $25,000 FMV and is not adjusted for inflation
+  return 25000;
+}

--- a/src/data/PensionData.tsx
+++ b/src/data/PensionData.tsx
@@ -1,0 +1,396 @@
+/**
+ * Federal Pension Data - FERS and CSRS
+ *
+ * This file contains official federal pension data used for calculating retirement benefits:
+ * - FERS (Federal Employees Retirement System) - for employees hired after 1983
+ * - CSRS (Civil Service Retirement System) - for employees hired before 1984
+ *
+ * Sources:
+ * - OPM FERS: https://www.opm.gov/retirement-center/fers-information/
+ * - OPM CSRS: https://www.opm.gov/retirement-center/csrs-information/
+ * - OPM FERS Supplement: https://www.opm.gov/retirement-center/fers-information/types-of-retirement/#annuity-supplement
+ */
+
+export type PensionSystem = 'FERS' | 'CSRS';
+
+/**
+ * FERS Minimum Retirement Age (MRA) by Birth Year
+ *
+ * The MRA is the earliest age at which a FERS employee can retire
+ * with an immediate (unreduced) annuity with at least 30 years of service.
+ *
+ * For those born 1970 or later: MRA = 57
+ */
+const FERS_MRA_BY_BIRTH_YEAR: Record<number, number> = {
+  1948: 55.167, // 55 years 2 months
+  1949: 55.333, // 55 years 4 months
+  1950: 55.5,   // 55 years 6 months
+  1951: 55.667, // 55 years 8 months
+  1952: 55.833, // 55 years 10 months
+  1953: 56,
+  1954: 56,
+  1955: 56,
+  1956: 56,
+  1957: 56,
+  1958: 56,
+  1959: 56,
+  1960: 56,
+  1961: 56,
+  1962: 56,
+  1963: 56,
+  1964: 56,
+  1965: 56.167, // 56 years 2 months
+  1966: 56.333, // 56 years 4 months
+  1967: 56.5,   // 56 years 6 months
+  1968: 56.667, // 56 years 8 months
+  1969: 56.833, // 56 years 10 months
+  // All birth years 1970+ have MRA of 57
+};
+
+/**
+ * Get FERS MRA for a given birth year
+ * Returns 57 for birth years 1970 and later
+ */
+export function getFERSMRA(birthYear: number): number {
+  if (birthYear >= 1970) return 57;
+  if (birthYear < 1948) return 55;
+  return FERS_MRA_BY_BIRTH_YEAR[birthYear] || 57;
+}
+
+/**
+ * FERS Retirement Eligibility Rules
+ *
+ * Immediate, unreduced retirement:
+ * - Age 62 with 5+ years of service
+ * - Age 60 with 20+ years of service
+ * - MRA with 30+ years of service
+ *
+ * Immediate, reduced retirement (MRA+10):
+ * - MRA with 10+ years of service (reduced by 5% per year under 62)
+ *
+ * Early retirement (RIF/VERA):
+ * - Age 50 with 20+ years, or any age with 25+ years (during RIF/VERA)
+ */
+export interface FERSEligibilityResult {
+  eligible: boolean;
+  reductionPercent: number;
+  message: string;
+}
+
+/**
+ * Check FERS retirement eligibility and calculate any reduction
+ */
+export function checkFERSEligibility(
+  age: number,
+  yearsOfService: number,
+  birthYear: number
+): FERSEligibilityResult {
+  const mra = getFERSMRA(birthYear);
+
+  // Age 62 with 5+ years - full benefit
+  if (age >= 62 && yearsOfService >= 5) {
+    return { eligible: true, reductionPercent: 0, message: 'Full retirement at 62 with 5+ years' };
+  }
+
+  // Age 60 with 20+ years - full benefit
+  if (age >= 60 && yearsOfService >= 20) {
+    return { eligible: true, reductionPercent: 0, message: 'Full retirement at 60 with 20+ years' };
+  }
+
+  // MRA with 30+ years - full benefit
+  if (age >= mra && yearsOfService >= 30) {
+    return { eligible: true, reductionPercent: 0, message: 'Full retirement at MRA with 30+ years' };
+  }
+
+  // MRA with 10-29 years - reduced benefit (5% per year under 62)
+  if (age >= mra && yearsOfService >= 10) {
+    const yearsUnder62 = Math.max(0, 62 - age);
+    const reduction = yearsUnder62 * 5;
+    return {
+      eligible: true,
+      reductionPercent: reduction,
+      message: `MRA+10 retirement with ${reduction}% reduction`
+    };
+  }
+
+  return { eligible: false, reductionPercent: 0, message: 'Not yet eligible for retirement' };
+}
+
+/**
+ * FERS Basic Benefit Calculation
+ *
+ * Formula: Years of Service × High-3 × Multiplier
+ *
+ * Multiplier:
+ * - 1% per year of service
+ * - 1.1% per year if retiring at age 62+ with 20+ years of service
+ *
+ * @param yearsOfService Total years of creditable federal service
+ * @param high3 Average of highest 3 consecutive years of basic pay
+ * @param retirementAge Age at retirement
+ * @returns Annual pension amount before any reductions
+ */
+export function calculateFERSBasicBenefit(
+  yearsOfService: number,
+  high3: number,
+  retirementAge: number
+): number {
+  // 1.1% multiplier if retiring at 62+ with 20+ years
+  const multiplier = (retirementAge >= 62 && yearsOfService >= 20) ? 0.011 : 0.01;
+  return yearsOfService * high3 * multiplier;
+}
+
+/**
+ * FERS Supplement Calculation
+ *
+ * The FERS Supplement is a temporary benefit paid from retirement until age 62,
+ * designed to bridge the gap until Social Security becomes available.
+ *
+ * Formula: (Years of FERS service / 40) × Estimated SS benefit at age 62
+ *
+ * Notes:
+ * - Only available if retiring before age 62
+ * - Subject to Social Security earnings test if working
+ * - Ends at age 62 (when actual SS becomes available)
+ * - Not available for MRA+10 (early reduced) retirees unless they meet exception
+ *
+ * @param yearsOfService Total years of FERS service
+ * @param estimatedSSAt62 Estimated monthly Social Security benefit at age 62
+ * @returns Annual FERS Supplement amount
+ */
+export function calculateFERSSupplement(
+  yearsOfService: number,
+  estimatedSSAt62: number
+): number {
+  // Monthly supplement = (years / 40) × monthly SS at 62
+  const monthlySupplementAmount = (yearsOfService / 40) * estimatedSSAt62;
+  return monthlySupplementAmount * 12;
+}
+
+/**
+ * FERS COLA (Cost of Living Adjustment)
+ *
+ * FERS retirees under age 62 do not receive COLA.
+ * FERS retirees 62+ receive:
+ * - CPI < 2%: Full COLA
+ * - CPI 2-3%: 2% COLA
+ * - CPI > 3%: CPI - 1% COLA
+ *
+ * @param inflation Annual inflation rate (as decimal, e.g., 0.03 for 3%)
+ * @param age Current age of retiree
+ * @returns COLA rate to apply (as decimal)
+ */
+export function getFERSCOLA(inflation: number, age: number): number {
+  // No COLA for FERS retirees under 62
+  if (age < 62) return 0;
+
+  // Full COLA if inflation under 2%
+  if (inflation <= 0.02) return inflation;
+
+  // 2% if inflation between 2-3%
+  if (inflation <= 0.03) return 0.02;
+
+  // CPI - 1% if inflation over 3%
+  return inflation - 0.01;
+}
+
+/**
+ * CSRS Basic Benefit Calculation
+ *
+ * CSRS uses a more generous graduated formula:
+ * - 1.5% × High-3 × first 5 years of service
+ * - 1.75% × High-3 × next 5 years of service (years 6-10)
+ * - 2.0% × High-3 × all years over 10
+ *
+ * Maximum benefit is capped at 80% of High-3.
+ *
+ * @param yearsOfService Total years of creditable federal service
+ * @param high3 Average of highest 3 consecutive years of basic pay
+ * @returns Annual pension amount
+ */
+export function calculateCSRSBasicBenefit(
+  yearsOfService: number,
+  high3: number
+): number {
+  let benefit = 0;
+
+  // First 5 years at 1.5%
+  const first5 = Math.min(yearsOfService, 5);
+  benefit += first5 * high3 * 0.015;
+
+  // Years 6-10 at 1.75%
+  if (yearsOfService > 5) {
+    const next5 = Math.min(yearsOfService - 5, 5);
+    benefit += next5 * high3 * 0.0175;
+  }
+
+  // Years 11+ at 2.0%
+  if (yearsOfService > 10) {
+    const remaining = yearsOfService - 10;
+    benefit += remaining * high3 * 0.02;
+  }
+
+  // Cap at 80% of High-3
+  const maxBenefit = high3 * 0.80;
+  return Math.min(benefit, maxBenefit);
+}
+
+/**
+ * CSRS Retirement Eligibility
+ *
+ * Immediate retirement:
+ * - Age 62 with 5+ years
+ * - Age 60 with 20+ years
+ * - Age 55 with 30+ years
+ *
+ * Early retirement (voluntary):
+ * - Age 50 with 20+ years, or any age with 25+ years (reduced 2% per year under 55)
+ */
+export interface CSRSEligibilityResult {
+  eligible: boolean;
+  reductionPercent: number;
+  message: string;
+}
+
+export function checkCSRSEligibility(
+  age: number,
+  yearsOfService: number
+): CSRSEligibilityResult {
+  // Age 62 with 5+ years - full benefit
+  if (age >= 62 && yearsOfService >= 5) {
+    return { eligible: true, reductionPercent: 0, message: 'Full retirement at 62 with 5+ years' };
+  }
+
+  // Age 60 with 20+ years - full benefit
+  if (age >= 60 && yearsOfService >= 20) {
+    return { eligible: true, reductionPercent: 0, message: 'Full retirement at 60 with 20+ years' };
+  }
+
+  // Age 55 with 30+ years - full benefit
+  if (age >= 55 && yearsOfService >= 30) {
+    return { eligible: true, reductionPercent: 0, message: 'Full retirement at 55 with 30+ years' };
+  }
+
+  // Early retirement: Age 50 with 20+ years, or any age with 25+ years
+  if ((age >= 50 && yearsOfService >= 20) || yearsOfService >= 25) {
+    const yearsUnder55 = Math.max(0, 55 - age);
+    const reduction = yearsUnder55 * 2;
+    return {
+      eligible: true,
+      reductionPercent: Math.min(reduction, 10), // Cap reduction
+      message: `Early retirement with ${reduction}% reduction`
+    };
+  }
+
+  return { eligible: false, reductionPercent: 0, message: 'Not yet eligible for retirement' };
+}
+
+/**
+ * CSRS COLA (Cost of Living Adjustment)
+ *
+ * CSRS retirees receive full CPI-based COLA regardless of age.
+ * Calculated on the anniversary of retirement.
+ *
+ * @param inflation Annual inflation rate (as decimal, e.g., 0.03 for 3%)
+ * @returns COLA rate to apply (same as inflation)
+ */
+export function getCSRSCOLA(inflation: number): number {
+  return inflation;
+}
+
+/**
+ * Calculate High-3 from salary history
+ *
+ * The High-3 is the average of the highest 3 consecutive years of basic pay.
+ * For employees with less than 3 years, it's the average of their entire career.
+ *
+ * @param salaryHistory Array of annual salaries in chronological order
+ * @returns High-3 average
+ */
+export function calculateHigh3(salaryHistory: number[]): number {
+  if (salaryHistory.length === 0) return 0;
+  if (salaryHistory.length < 3) {
+    // Average of entire history if less than 3 years
+    return salaryHistory.reduce((a, b) => a + b, 0) / salaryHistory.length;
+  }
+
+  // Find highest 3 consecutive years
+  let maxAverage = 0;
+  for (let i = 0; i <= salaryHistory.length - 3; i++) {
+    const threeYearSum = salaryHistory[i] + salaryHistory[i + 1] + salaryHistory[i + 2];
+    const average = threeYearSum / 3;
+    maxAverage = Math.max(maxAverage, average);
+  }
+
+  return maxAverage;
+}
+
+/**
+ * Estimate High-3 from current salary and expected years until retirement
+ *
+ * Projects future salary growth to estimate what High-3 will be at retirement.
+ *
+ * @param currentSalary Current annual salary
+ * @param yearsUntilRetirement Years until planned retirement
+ * @param salaryGrowthRate Annual salary growth rate (default 2%)
+ * @returns Estimated High-3 at retirement
+ */
+export function estimateHigh3(
+  currentSalary: number,
+  yearsUntilRetirement: number,
+  salaryGrowthRate: number = 0.02
+): number {
+  if (yearsUntilRetirement <= 0) return currentSalary;
+
+  // Project salaries for the final 3 years before retirement
+  const year1 = currentSalary * Math.pow(1 + salaryGrowthRate, yearsUntilRetirement - 2);
+  const year2 = currentSalary * Math.pow(1 + salaryGrowthRate, yearsUntilRetirement - 1);
+  const year3 = currentSalary * Math.pow(1 + salaryGrowthRate, yearsUntilRetirement);
+
+  return (year1 + year2 + year3) / 3;
+}
+
+/**
+ * Early Retirement Reduction for FERS MRA+10
+ *
+ * If retiring at MRA with 10-29 years of service, benefit is reduced:
+ * - 5% for each year under age 62
+ * - Can be avoided by postponing annuity commencement until age 62
+ *
+ * @param retirementAge Age at retirement
+ * @returns Reduction factor (e.g., 0.75 for 25% reduction)
+ */
+export function getFERSEarlyReduction(retirementAge: number): number {
+  if (retirementAge >= 62) return 1.0;
+
+  const yearsUnder62 = 62 - retirementAge;
+  const reductionPercent = yearsUnder62 * 5; // 5% per year under 62
+  return 1 - (reductionPercent / 100);
+}
+
+/**
+ * Summary of pension system differences
+ */
+export const PENSION_SYSTEM_COMPARISON = {
+  FERS: {
+    name: 'Federal Employees Retirement System',
+    establishedYear: 1987,
+    components: ['Basic Benefit (defined benefit)', 'Social Security', 'TSP (401k-like)'],
+    basicBenefitFormula: '1% (or 1.1% at 62+/20yr) × High-3 × Years',
+    cola: 'Reduced (CPI-1% if CPI > 3%)',
+    socialSecurity: 'Yes, covered',
+    supplement: 'FERS Supplement available until age 62',
+    maxBenefit: 'No explicit cap (but practical limits based on years)',
+  },
+  CSRS: {
+    name: 'Civil Service Retirement System',
+    establishedYear: 1920,
+    closedYear: 1987,
+    components: ['Basic Benefit only (no SS, no TSP match)'],
+    basicBenefitFormula: '1.5%×5yr + 1.75%×5yr + 2%×remaining',
+    cola: 'Full CPI',
+    socialSecurity: 'No, not covered',
+    supplement: 'N/A (no SS to bridge to)',
+    maxBenefit: '80% of High-3',
+  },
+};

--- a/src/data/RMDData.ts
+++ b/src/data/RMDData.ts
@@ -1,0 +1,159 @@
+/**
+ * Required Minimum Distribution (RMD) Data and Calculations
+ *
+ * Based on IRS Uniform Lifetime Table (Table III)
+ * Used for account owners whose spouse is not more than 10 years younger
+ * or is not the sole beneficiary.
+ *
+ * SECURE Act 2.0 (2023): RMD age increased to 73
+ * Starting 2033: RMD age increases to 75
+ */
+
+// IRS Uniform Lifetime Table - Distribution Period by Age
+// Source: IRS Publication 590-B (updated for 2022+)
+const UNIFORM_LIFETIME_TABLE: Record<number, number> = {
+  72: 27.4,
+  73: 26.5,
+  74: 25.5,
+  75: 24.6,
+  76: 23.7,
+  77: 22.9,
+  78: 22.0,
+  79: 21.1,
+  80: 20.2,
+  81: 19.4,
+  82: 18.5,
+  83: 17.7,
+  84: 16.8,
+  85: 16.0,
+  86: 15.2,
+  87: 14.4,
+  88: 13.7,
+  89: 12.9,
+  90: 12.2,
+  91: 11.5,
+  92: 10.8,
+  93: 10.1,
+  94: 9.5,
+  95: 8.9,
+  96: 8.4,
+  97: 7.8,
+  98: 7.3,
+  99: 6.8,
+  100: 6.4,
+  101: 6.0,
+  102: 5.6,
+  103: 5.2,
+  104: 4.9,
+  105: 4.6,
+  106: 4.3,
+  107: 4.1,
+  108: 3.9,
+  109: 3.7,
+  110: 3.5,
+  111: 3.4,
+  112: 3.3,
+  113: 3.1,
+  114: 3.0,
+  115: 2.9,
+  116: 2.8,
+  117: 2.7,
+  118: 2.5,
+  119: 2.3,
+  120: 2.0,
+};
+
+/**
+ * Get the RMD starting age based on birth year
+ * SECURE Act 2.0 rules:
+ * - Born 1950 or earlier: Age 72
+ * - Born 1951-1959: Age 73
+ * - Born 1960 or later: Age 75 (starting 2033)
+ */
+export function getRMDStartAge(birthYear: number): number {
+  if (birthYear <= 1950) {
+    return 72;
+  } else if (birthYear <= 1959) {
+    return 73;
+  } else {
+    return 75;
+  }
+}
+
+/**
+ * Get the distribution period (life expectancy factor) for a given age
+ * Returns the divisor used to calculate RMD amount
+ */
+export function getDistributionPeriod(age: number): number {
+  // For ages below 72, no RMD required (but return a value for calculations)
+  if (age < 72) {
+    return UNIFORM_LIFETIME_TABLE[72];
+  }
+
+  // For ages above 120, use the 120 factor
+  if (age > 120) {
+    return UNIFORM_LIFETIME_TABLE[120];
+  }
+
+  return UNIFORM_LIFETIME_TABLE[age] ?? UNIFORM_LIFETIME_TABLE[120];
+}
+
+/**
+ * Calculate the Required Minimum Distribution for a single account
+ *
+ * @param priorYearEndBalance - Account balance as of December 31 of prior year
+ * @param age - Owner's age at end of current year
+ * @returns RMD amount for the year
+ */
+export function calculateRMD(priorYearEndBalance: number, age: number): number {
+  if (priorYearEndBalance <= 0 || age < 72) {
+    return 0;
+  }
+
+  const distributionPeriod = getDistributionPeriod(age);
+  return priorYearEndBalance / distributionPeriod;
+}
+
+/**
+ * Check if an account type is subject to RMDs
+ * Traditional accounts require RMDs; Roth accounts do not (during owner's lifetime)
+ */
+export function isAccountSubjectToRMD(taxType: string): boolean {
+  return taxType === 'Traditional 401k' || taxType === 'Traditional IRA';
+}
+
+/**
+ * Calculate the RMD penalty for failing to take the full distribution
+ * SECURE Act 2.0 reduced the penalty from 50% to 25%
+ * Can be further reduced to 10% if corrected within correction window
+ */
+export function calculateRMDPenalty(shortfall: number, correctedTimely: boolean = false): number {
+  if (shortfall <= 0) return 0;
+
+  const penaltyRate = correctedTimely ? 0.10 : 0.25;
+  return shortfall * penaltyRate;
+}
+
+/**
+ * Determine if RMDs are required for the given year based on age and birth year
+ */
+export function isRMDRequired(currentAge: number, birthYear: number): boolean {
+  const rmdStartAge = getRMDStartAge(birthYear);
+  return currentAge >= rmdStartAge;
+}
+
+export interface RMDCalculation {
+  accountName: string;
+  accountId: string;
+  priorYearBalance: number;
+  distributionPeriod: number;
+  rmdAmount: number;
+}
+
+export interface RMDSummary {
+  totalRMD: number;
+  accountBreakdown: RMDCalculation[];
+  rmdStartAge: number;
+  currentAge: number;
+  isRequired: boolean;
+}

--- a/src/data/SocialSecurityData.tsx
+++ b/src/data/SocialSecurityData.tsx
@@ -1,0 +1,484 @@
+/**
+ * Social Security Administration (SSA) Historical Data
+ *
+ * This file contains official SSA data used for calculating Social Security benefits:
+ * - Wage indexing factors (for adjusting historical earnings to current wage levels)
+ * - Bend points (thresholds used in Primary Insurance Amount calculation)
+ * - Maximum taxable earnings (Social Security wage base)
+ * - Full Retirement Age by birth year
+ *
+ * Sources:
+ * - SSA National Average Wage Index: https://www.ssa.gov/oact/cola/AWI.html
+ * - SSA Bend Points: https://www.ssa.gov/oact/cola/bendpoints.html
+ * - SSA Contribution and Benefit Base: https://www.ssa.gov/oact/cola/cbb.html
+ */
+
+/**
+ * Average Wage Index Factors
+ *
+ * Used to index historical earnings to age-60 wage levels.
+ * Formula: IndexedEarnings = ActualEarnings × (AvgWageAtAge60 / AvgWageInEarningYear)
+ *
+ * For earnings after age 60, no indexing is applied (factor = 1.0).
+ * The indexing year is typically when the worker turns 60.
+ *
+ * Example: For someone turning 62 in 2024 (born 1962):
+ * - They turned 60 in 2022
+ * - 2022 Average Wage Index = $63,795.13
+ * - For earnings in 2000 ($40,000): IndexedEarnings = $40,000 × (63795.13 / 32154.82) = $79,323
+ */
+const WAGE_INDEX_FACTORS: Record<number, number> = {
+  // Historical data from SSA (actual values)
+  1951: 2951.92,
+  1952: 3098.68,
+  1953: 3273.42,
+  1954: 3293.80,
+  1955: 3378.29,
+  1956: 3594.55,
+  1957: 3724.29,
+  1958: 3784.05,
+  1959: 3920.37,
+  1960: 4050.21,
+  1961: 4123.36,
+  1962: 4304.62,
+  1963: 4403.72,
+  1964: 4598.99,
+  1965: 4723.99,
+  1966: 4965.38,
+  1967: 5185.60,
+  1968: 5580.78,
+  1969: 5940.18,
+  1970: 6334.04,
+  1971: 6642.00,
+  1972: 7168.35,
+  1973: 7686.50,
+  1974: 8251.89,
+  1975: 8675.58,
+  1976: 9249.13,
+  1977: 9779.44,
+  1978: 10556.03,
+  1979: 11554.58,
+  1980: 12696.77,
+  1981: 13977.05,
+  1982: 14878.34,
+  1983: 15589.64,
+  1984: 16555.07,
+  1985: 17275.54,
+  1986: 17962.59,
+  1987: 18788.17,
+  1988: 19793.23,
+  1989: 20571.40,
+  1990: 21458.48,
+  1991: 21831.01,
+  1992: 22577.16,
+  1993: 23139.07,
+  1994: 23829.05,
+  1995: 24715.39,
+  1996: 25821.08,
+  1997: 27354.84,
+  1998: 29010.71,
+  1999: 30491.62,
+  2000: 32154.82,
+  2001: 32974.62,
+  2002: 33544.66,
+  2003: 34535.35,
+  2004: 35797.14,
+  2005: 36917.82,
+  2006: 38744.11,
+  2007: 40649.27,
+  2008: 41639.48,
+  2009: 40729.68,
+  2010: 41641.61,
+  2011: 42892.19,
+  2012: 44321.67,
+  2013: 44888.16,
+  2014: 46199.29,
+  2015: 47826.74,
+  2016: 48617.80,
+  2017: 50326.69,
+  2018: 52145.80,
+  2019: 54099.99,
+  2020: 55628.60,
+  2021: 58177.46,
+  2022: 63795.13,
+  2023: 66621.80, // Estimated based on SSA projections
+  2024: 68000.00, // Estimated
+  2025: 69700.00, // Projected (assume ~2.5% annual growth)
+  2026: 71400.00,
+  2027: 73200.00,
+  2028: 75000.00,
+  2029: 76900.00,
+  2030: 78800.00,
+};
+
+/**
+ * Bend Points by Year
+ *
+ * Used in the Primary Insurance Amount (PIA) calculation formula:
+ * PIA = (90% × first bend point) + (32% × amount between bend points) + (15% × amount above second bend point)
+ *
+ * Example for 2024:
+ * If AIME = $5,000/month:
+ * PIA = (0.90 × $1,115) + (0.32 × ($5,000 - $1,115)) + (0.15 × 0)
+ *     = $1,003.50 + $1,243.20 + $0
+ *     = $2,246.70/month
+ */
+const BEND_POINTS: Record<number, { first: number; second: number }> = {
+  2000: { first: 531, second: 3202 },
+  2001: { first: 561, second: 3381 },
+  2002: { first: 592, second: 3567 },
+  2003: { first: 606, second: 3653 },
+  2004: { first: 612, second: 3689 },
+  2005: { first: 627, second: 3779 },
+  2006: { first: 656, second: 3955 },
+  2007: { first: 680, second: 4100 },
+  2008: { first: 711, second: 4288 },
+  2009: { first: 744, second: 4483 },
+  2010: { first: 761, second: 4586 },
+  2011: { first: 749, second: 4517 },
+  2012: { first: 767, second: 4624 },
+  2013: { first: 791, second: 4768 },
+  2014: { first: 816, second: 4917 },
+  2015: { first: 826, second: 4980 },
+  2016: { first: 856, second: 5157 },
+  2017: { first: 885, second: 5336 },
+  2018: { first: 895, second: 5397 },
+  2019: { first: 926, second: 5583 },
+  2020: { first: 960, second: 5785 },
+  2021: { first: 996, second: 6002 },
+  2022: { first: 1024, second: 6172 },
+  2023: { first: 1115, second: 6721 },
+  2024: { first: 1174, second: 7078 },
+  2025: { first: 1200, second: 7240 }, // Projected based on wage growth
+  2026: { first: 1230, second: 7420 },
+  2027: { first: 1260, second: 7600 },
+  2028: { first: 1290, second: 7790 },
+  2029: { first: 1325, second: 7990 },
+  2030: { first: 1360, second: 8200 },
+};
+
+/**
+ * Social Security Wage Base (Maximum Taxable Earnings)
+ *
+ * The maximum amount of earnings subject to Social Security tax each year.
+ * Earnings above this cap are not taxed for Social Security and do not count toward benefit calculations.
+ *
+ * Example: In 2024, if you earn $200,000:
+ * - Only $168,600 counts for Social Security tax
+ * - Only $168,600 counts toward your benefit calculation
+ */
+const SS_WAGE_BASE: Record<number, number> = {
+  2000: 76200,
+  2001: 80400,
+  2002: 84900,
+  2003: 87000,
+  2004: 87900,
+  2005: 90000,
+  2006: 94200,
+  2007: 97500,
+  2008: 102000,
+  2009: 106800,
+  2010: 106800,
+  2011: 106800,
+  2012: 110100,
+  2013: 113700,
+  2014: 117000,
+  2015: 118500,
+  2016: 118500,
+  2017: 127200,
+  2018: 128400,
+  2019: 132900,
+  2020: 137700,
+  2021: 142800,
+  2022: 147000,
+  2023: 160200,
+  2024: 168600,
+  2025: 176100, // Projected
+  2026: 184500,
+  2027: 192600,
+  2028: 201300,
+  2029: 210400,
+  2030: 219900,
+};
+
+/**
+ * Full Retirement Age (FRA) by Birth Year
+ *
+ * The age at which you're entitled to 100% of your calculated Social Security benefit.
+ * Claiming before FRA reduces benefits; claiming after FRA increases them.
+ *
+ * Birth Year → FRA (in years, decimal for months)
+ * 1960+: 67 years
+ * 1959: 66 years 10 months = 66.833...
+ * 1958: 66 years 8 months = 66.666...
+ * 1955-1956: 66 years 2 months = 66.166...
+ * 1943-1954: 66 years
+ */
+const FRA_BY_BIRTH_YEAR: Record<number, number> = {
+  1937: 65,
+  1938: 65.167, // 65 years 2 months
+  1939: 65.333, // 65 years 4 months
+  1940: 65.5,   // 65 years 6 months
+  1941: 65.667, // 65 years 8 months
+  1942: 65.833, // 65 years 10 months
+  1943: 66,
+  1944: 66,
+  1945: 66,
+  1946: 66,
+  1947: 66,
+  1948: 66,
+  1949: 66,
+  1950: 66,
+  1951: 66,
+  1952: 66,
+  1953: 66,
+  1954: 66,
+  1955: 66.167, // 66 years 2 months
+  1956: 66.333, // 66 years 4 months
+  1957: 66.5,   // 66 years 6 months
+  1958: 66.667, // 66 years 8 months
+  1959: 66.833, // 66 years 10 months
+  1960: 67,
+  1961: 67,
+  1962: 67,
+  1963: 67,
+  1964: 67,
+  1965: 67,
+  1966: 67,
+  1967: 67,
+  1968: 67,
+  1969: 67,
+  1970: 67,
+  1971: 67,
+  1972: 67,
+  1973: 67,
+  1974: 67,
+  1975: 67,
+  1976: 67,
+  1977: 67,
+  1978: 67,
+  1979: 67,
+  1980: 67,
+  1981: 67,
+  1982: 67,
+  1983: 67,
+  1984: 67,
+  1985: 67,
+  1986: 67,
+  1987: 67,
+  1988: 67,
+  1989: 67,
+  1990: 67,
+  1991: 67,
+  1992: 67,
+  1993: 67,
+  1994: 67,
+  1995: 67,
+  1996: 67,
+  1997: 67,
+  1998: 67,
+  1999: 67,
+  2000: 67,
+  2001: 67,
+  2002: 67,
+  2003: 67,
+  2004: 67,
+  2005: 67,
+};
+
+/**
+ * Claiming Age Adjustment Factors
+ *
+ * Multipliers applied to PIA based on claiming age:
+ * - Age 62: 70% (30% reduction for claiming 5 years early)
+ * - Age 63: 75% (25% reduction)
+ * - Age 64: 80% (20% reduction)
+ * - Age 65: 86.7% (13.3% reduction)
+ * - Age 66: 93.3% (6.7% reduction)
+ * - Age 67 (FRA): 100% (no adjustment)
+ * - Age 68: 108% (8% increase per year)
+ * - Age 69: 116%
+ * - Age 70: 124% (maximum, 24% increase)
+ *
+ * Early claiming (before FRA): ~6.67% reduction per year (actually 5/9 of 1% per month for first 36 months, then 5/12 of 1%)
+ * Delayed claiming (after FRA): 8% increase per year (actually 2/3 of 1% per month)
+ */
+/**
+ * Helper function to get claiming age adjustment factor.
+ * Calculates the benefit adjustment based on claiming age relative to Full Retirement Age (FRA).
+ *
+ * Early claiming (before FRA):
+ *   - First 36 months early: 5/9 of 1% reduction per month
+ *   - Additional months early: 5/12 of 1% reduction per month
+ *
+ * Delayed claiming (after FRA):
+ *   - 2/3 of 1% increase per month (8% per year)
+ *
+ * Valid claiming range: 62-70. Ages outside this range use the boundary values.
+ */
+export function getClaimingAdjustment(claimingAge: number, fra: number = 67): number {
+  // Clamp to valid claiming range (62-70)
+  const effectiveAge = Math.max(62, Math.min(70, claimingAge));
+
+  const monthsFromFRA = (effectiveAge - fra) * 12;
+
+  if (effectiveAge < fra) {
+    // Early claiming reduction
+    // First 36 months: 5/9 of 1% per month
+    // Additional months: 5/12 of 1% per month
+    const firstReduction = Math.min(36, Math.abs(monthsFromFRA)) * (5 / 9) * 0.01;
+    const additionalReduction = Math.max(0, Math.abs(monthsFromFRA) - 36) * (5 / 12) * 0.01;
+    return 1.0 - firstReduction - additionalReduction;
+  } else {
+    // Delayed claiming increase
+    // 2/3 of 1% per month (8% per year)
+    const increase = monthsFromFRA * (2 / 3) * 0.01;
+    return 1.0 + increase;
+  }
+}
+
+/**
+ * Helper function to get Full Retirement Age for a birth year
+ * Returns 67 for birth years 1960 and later
+ */
+export function getFRA(birthYear: number): number {
+  if (birthYear >= 1960) return 67;
+  if (birthYear < 1937) return 65;
+  return FRA_BY_BIRTH_YEAR[birthYear] || 67;
+}
+
+/**
+ * Generic helper to look up yearly data with future projection support.
+ * Reduces code duplication across getWageIndexFactor, getBendPoints, getWageBase, etc.
+ */
+export function lookupYearlyData<T>(
+  data: Record<number, T>,
+  year: number,
+  projectFuture: (baseValue: T, growthMultiplier: number) => T,
+  wageGrowthRate: number,
+  inflationAdjusted: boolean
+): T {
+  if (data[year]) {
+    return data[year];
+  }
+
+  const years = Object.keys(data).map(Number);
+  const latestYear = Math.max(...years);
+  const earliestYear = Math.min(...years);
+
+  if (year > latestYear) {
+    const baseValue = data[latestYear];
+    if (!inflationAdjusted) {
+      return baseValue;
+    }
+    const yearsToProject = year - latestYear;
+    const growthMultiplier = Math.pow(1 + wageGrowthRate, yearsToProject);
+    return projectFuture(baseValue, growthMultiplier);
+  }
+
+  return data[earliestYear];
+}
+
+/**
+ * Helper function to get wage index factor for a given year.
+ * For future years beyond available data, projects based on wage growth.
+ */
+export function getWageIndexFactor(
+  year: number,
+  wageGrowthRate: number = 0.025,
+  inflationAdjusted: boolean = true
+): number {
+  return lookupYearlyData(
+    WAGE_INDEX_FACTORS,
+    year,
+    (base, multiplier) => Math.round(base * multiplier * 100) / 100,
+    wageGrowthRate,
+    inflationAdjusted
+  );
+}
+
+/**
+ * Helper function to get bend points for a given year.
+ * For future years, uses projection based on wage growth.
+ */
+export function getBendPoints(
+  year: number,
+  wageGrowthRate: number = 0.025,
+  inflationAdjusted: boolean = true
+): { first: number; second: number } {
+  return lookupYearlyData(
+    BEND_POINTS,
+    year,
+    (base, multiplier) => ({
+      first: Math.round(base.first * multiplier),
+      second: Math.round(base.second * multiplier)
+    }),
+    wageGrowthRate,
+    inflationAdjusted
+  );
+}
+
+/**
+ * Helper function to get wage base for a given year.
+ * For future years, projects based on wage growth.
+ */
+export function getWageBase(
+  year: number,
+  wageGrowthRate: number = 0.025,
+  inflationAdjusted: boolean = true
+): number {
+  return lookupYearlyData(
+    SS_WAGE_BASE,
+    year,
+    (base, multiplier) => Math.round(base * multiplier / 100) * 100,
+    wageGrowthRate,
+    inflationAdjusted
+  );
+}
+
+/**
+ * Earnings Test Limits
+ *
+ * Annual earnings limits for the Social Security Retirement Earnings Test (RET).
+ * If you claim benefits before Full Retirement Age (FRA) and continue working:
+ * - Before FRA: $1 withheld for every $2 earned above limit
+ * - Year of FRA (before month of FRA): $1 withheld for every $3 earned above higher limit
+ * - After FRA: No earnings test applies
+ *
+ * Source: https://www.ssa.gov/oact/cola/rtea.html
+ */
+const EARNINGS_TEST_LIMITS: Record<number, { beforeFRA: number; yearOfFRA: number }> = {
+  2020: { beforeFRA: 18240, yearOfFRA: 48600 },
+  2021: { beforeFRA: 18960, yearOfFRA: 50520 },
+  2022: { beforeFRA: 19560, yearOfFRA: 51960 },
+  2023: { beforeFRA: 21240, yearOfFRA: 56520 },
+  2024: { beforeFRA: 22320, yearOfFRA: 59520 },
+  2025: { beforeFRA: 23400, yearOfFRA: 62160 },
+  // Future projections based on wage growth
+  2026: { beforeFRA: 24000, yearOfFRA: 63700 },
+  2027: { beforeFRA: 24600, yearOfFRA: 65300 },
+  2028: { beforeFRA: 25200, yearOfFRA: 67000 },
+  2029: { beforeFRA: 25850, yearOfFRA: 68700 },
+  2030: { beforeFRA: 26500, yearOfFRA: 70500 },
+};
+
+/**
+ * Helper function to get earnings test limit for a given year.
+ * For future years, projects based on wage growth.
+ */
+export function getEarningsTestLimit(
+  year: number,
+  wageGrowthRate: number = 0.025,
+  inflationAdjusted: boolean = true
+): { beforeFRA: number; yearOfFRA: number } {
+  return lookupYearlyData(
+    EARNINGS_TEST_LIMITS,
+    year,
+    (base, multiplier) => ({
+      beforeFRA: Math.round(base.beforeFRA * multiplier / 100) * 100,
+      yearOfFRA: Math.round(base.yearOfFRA * multiplier / 100) * 100
+    }),
+    wageGrowthRate,
+    inflationAdjusted
+  );
+}

--- a/src/services/simulation/AccountGrowth.ts
+++ b/src/services/simulation/AccountGrowth.ts
@@ -1,0 +1,321 @@
+import { AnyAccount, InvestedAccount, SavedAccount, ESPPAccount, PropertyAccount, DebtAccount, DeficitDebtAccount, ESPPLot } from "../../components/Objects/Accounts/models";
+import { AnyExpense, MortgageExpense, LoanExpense } from "../../components/Objects/Expense/models";
+import { AnyIncome, WorkIncome, getIncomeActiveMultiplier } from "../../components/Objects/Income/models";
+import { AssumptionsState } from "../../components/Objects/Assumptions/AssumptionsContext";
+import { getESPPLimit, get415cLimit } from "../../data/ContributionLimits";
+import { WithdrawalState } from "./types";
+
+export interface InflowResult {
+    totalEmployerMatch: number;
+    totalBucketAllocations: number;
+    bucketDetail: Record<string, number>;
+    esppLots: Record<string, ESPPLot[]>;
+    discretionaryCash: number;
+    deficitDebtPayment: number;
+    logs: string[];
+}
+
+/**
+ * Process payroll contributions, employer match, ESPP purchases,
+ * deficit debt payments, and priority bucket allocations.
+ */
+export function processInflows(
+    incomesWithEarningsTest: AnyIncome[],
+    accounts: AnyAccount[],
+    assumptions: AssumptionsState,
+    year: number,
+    withdrawalState: WithdrawalState,
+    discretionaryCash: number,
+    _existingDeficitDebt: DeficitDebtAccount | undefined,
+    _totalLivingExpenses: number,
+    currentAge: number,
+    logs: string[]
+): InflowResult {
+    const bucketDetail: Record<string, number> = {};
+    let totalEmployerMatch = 0;
+    let totalBucketAllocations = 0;
+    const esppLots: Record<string, ESPPLot[]> = {};
+    let deficitDebtPayment = 0;
+
+    // 5a. Payroll & Match
+    incomesWithEarningsTest.forEach(inc => {
+        if (inc instanceof WorkIncome && inc.matchAccountId) {
+            const activeMultiplier = getIncomeActiveMultiplier(inc, year);
+            if (activeMultiplier === 0) return;
+
+            const currentSelf = withdrawalState.userInflows[inc.matchAccountId] || 0;
+            const currentMatch = withdrawalState.employerInflows[inc.matchAccountId] || 0;
+
+            // preTax401k/roth401k are per pay period; getProratedAnnual converts to the
+            // annual deposit (and already folds in the active-period multiplier).
+            const selfContribution = inc.getProratedAnnual(inc.preTax401k + inc.roth401k, year);
+            let employerMatch = inc.getEffectiveAnnualEmployerMatch() * activeMultiplier;
+
+            // Bug #11: enforce the §415(c) combined annual-additions limit
+            // (employee pre-tax + Roth + employer) for this 401k account. The
+            // §402(g) elective-deferral limit is handled at the income-model
+            // level (get401kLimit / getEffective401k); this is the separate,
+            // higher combined cap. Excess is removed from the employer match
+            // first, since the employee's own deferrals are already capped and
+            // are the participant's money. We clamp using the additions already
+            // routed to this account this year (currentSelf/currentMatch) plus
+            // this income's new contributions, so multiple incomes feeding one
+            // account share a single limit.
+            const limit415c = get415cLimit(year, currentAge, assumptions.macro.inflationAdjusted);
+            const totalAdditions = currentSelf + currentMatch + selfContribution + employerMatch;
+            if (totalAdditions > limit415c) {
+                const excess = totalAdditions - limit415c;
+                const trimmedMatch = Math.max(0, employerMatch - excess);
+                if (trimmedMatch < employerMatch) {
+                    logs.push(`[WARN] §415(c) limit: ${inc.name} employer match reduced by $${(employerMatch - trimmedMatch).toLocaleString(undefined, { maximumFractionDigits: 0 })} to stay within combined $${limit415c.toLocaleString()} 401k limit`);
+                }
+                employerMatch = trimmedMatch;
+            }
+
+            totalEmployerMatch += employerMatch;
+
+            withdrawalState.userInflows[inc.matchAccountId] = currentSelf + selfContribution;
+            withdrawalState.employerInflows[inc.matchAccountId] = currentMatch + employerMatch;
+        }
+    });
+
+    // 5a-2. ESPP Purchase Processing
+    let totalESPPFMVThisYear = 0;
+    const esppLimit = getESPPLimit();
+
+    incomesWithEarningsTest.forEach(inc => {
+        if (!(inc instanceof WorkIncome)) return;
+        if (inc.esppContributionType === 'NONE') return;
+        if (!inc.esppAccountId) return;
+
+        const activeMultiplier = getIncomeActiveMultiplier(inc, year);
+        if (activeMultiplier === 0) return;
+
+        const annualContribution = inc.getAnnualESPPContribution() * activeMultiplier;
+        if (annualContribution <= 0) return;
+
+        const esppAccount = accounts.find(acc => acc.id === inc.esppAccountId && acc instanceof ESPPAccount) as ESPPAccount | undefined;
+        if (!esppAccount) {
+            logs.push(`[WARN] ESPP account ${inc.esppAccountId} not found for ${inc.name}`);
+            return;
+        }
+
+        const purchaseContribution = annualContribution / 2;
+        const stockGrowthRate = inc.esppExpectedStockGrowth / 100;
+
+        for (let purchaseNum = 0; purchaseNum < 2; purchaseNum++) {
+            const grantMonth = purchaseNum * 6;
+            const purchaseMonth = grantMonth + 5;
+            const grantDate = new Date(Date.UTC(year, grantMonth, 1));
+            const purchaseDate = new Date(Date.UTC(year, purchaseMonth, 28));
+
+            const fmvAtGrant = 100;
+            const growthOverPeriod = Math.pow(1 + stockGrowthRate, 0.5);
+            const fmvAtPurchase = fmvAtGrant * growthOverPeriod;
+
+            let basePriceForDiscount: number;
+            if (inc.esppHasLookback) {
+                basePriceForDiscount = Math.min(fmvAtGrant, fmvAtPurchase);
+            } else {
+                basePriceForDiscount = fmvAtPurchase;
+            }
+
+            const discountPercent = inc.esppDiscountPercent / 100;
+            const purchasePrice = basePriceForDiscount * (1 - discountPercent);
+            const discountAmount = basePriceForDiscount - purchasePrice;
+
+            const shares = purchaseContribution / purchasePrice;
+            const fmvOfShares = shares * fmvAtPurchase;
+
+            if (totalESPPFMVThisYear + fmvOfShares > esppLimit) {
+                const remainingFMV = Math.max(0, esppLimit - totalESPPFMVThisYear);
+                if (remainingFMV <= 0) {
+                    logs.push(`[WARN] ESPP: ${inc.name} hit $25k annual limit - purchase skipped`);
+                    continue;
+                }
+                const reducedShares = remainingFMV / fmvAtPurchase;
+                const reducedContribution = reducedShares * purchasePrice;
+                logs.push(`[WARN] ESPP: ${inc.name} purchase reduced to stay within $25k limit`);
+
+                const lot: ESPPLot = {
+                    id: `LOT-${year}-${purchaseNum}-${inc.id}`,
+                    grantDate,
+                    purchaseDate,
+                    fmvAtGrant,
+                    fmvAtPurchase,
+                    purchasePrice,
+                    shares: reducedShares,
+                    totalCost: reducedContribution,
+                    discountAmount
+                };
+
+                withdrawalState.userInflows[esppAccount.id] = (withdrawalState.userInflows[esppAccount.id] || 0) + (reducedShares * fmvAtPurchase);
+                totalESPPFMVThisYear += remainingFMV;
+
+                if (!esppLots[esppAccount.id]) esppLots[esppAccount.id] = [];
+                esppLots[esppAccount.id].push(lot);
+            } else {
+                const lot: ESPPLot = {
+                    id: `LOT-${year}-${purchaseNum}-${inc.id}`,
+                    grantDate,
+                    purchaseDate,
+                    fmvAtGrant,
+                    fmvAtPurchase,
+                    purchasePrice,
+                    shares,
+                    totalCost: purchaseContribution,
+                    discountAmount
+                };
+
+                withdrawalState.userInflows[esppAccount.id] = (withdrawalState.userInflows[esppAccount.id] || 0) + fmvOfShares;
+                totalESPPFMVThisYear += fmvOfShares;
+
+                if (!esppLots[esppAccount.id]) esppLots[esppAccount.id] = [];
+                esppLots[esppAccount.id].push(lot);
+
+                logs.push(`[FLOW] ESPP: ${inc.name} purchased ${shares.toFixed(2)} shares @ $${purchasePrice.toFixed(2)} (${(discountPercent * 100).toFixed(0)}% discount${inc.esppHasLookback ? ' + lookback' : ''})`);
+            }
+        }
+    });
+
+    // Note: Deficit debt paydown and priority waterfall are handled by
+    // SurplusAllocator.allocateSurplus() in the V2 YearSolver path.
+
+    return {
+        totalEmployerMatch,
+        totalBucketAllocations,
+        bucketDetail,
+        esppLots,
+        discretionaryCash,
+        deficitDebtPayment,
+        logs
+    };
+}
+
+/**
+ * Grow all accounts: apply inflows, compound growth, handle ESPP lots, and linked data.
+ */
+export function growAccounts(
+    accounts: AnyAccount[],
+    expenses: AnyExpense[],
+    withdrawalState: WithdrawalState,
+    conversionDeposits: Record<string, number>,
+    esppLots: Record<string, ESPPLot[]>,
+    deficitDebtPayment: number,
+    existingDeficitDebt: DeficitDebtAccount | undefined,
+    assumptions: AssumptionsState,
+    year: number,
+    returnOverride: number | undefined,
+    _logs: string[]
+): AnyAccount[] {
+    const DEFICIT_DEBT_ID = 'system-deficit-debt';
+    const DEFICIT_DEBT_NAME = 'Uncovered Deficit';
+
+    // 6. LINKED DATA (Mortgages/Loans)
+    const linkedData = new Map<string, { balance: number; value?: number }>();
+    expenses.forEach(exp => {
+        if (exp instanceof MortgageExpense && exp.linkedAccountId) {
+            linkedData.set(exp.linkedAccountId, { balance: exp.loan_balance, value: exp.valuation });
+        } else if (exp instanceof LoanExpense && exp.linkedAccountId) {
+            linkedData.set(exp.linkedAccountId, { balance: exp.amount });
+        }
+    });
+
+    // 7. GROW ACCOUNTS
+    let nextAccounts: AnyAccount[] = accounts.map(acc => {
+        const userIn = withdrawalState.userInflows[acc.id] || 0;
+        const employerIn = withdrawalState.employerInflows[acc.id] || 0;
+        const totalIn = userIn + employerIn;
+
+        const linkedState = linkedData.get(acc.id);
+
+        if (acc instanceof PropertyAccount) {
+            let finalLoanBalance = linkedState?.balance;
+            if (finalLoanBalance !== undefined && totalIn > 0) {
+                finalLoanBalance = Math.max(0, finalLoanBalance - totalIn);
+            }
+            return acc.increment(assumptions, { newLoanBalance: finalLoanBalance, newValue: linkedState?.value });
+        }
+
+        if (acc instanceof DeficitDebtAccount) {
+            const newBalance = Math.max(0, acc.amount - deficitDebtPayment);
+            return acc.increment(assumptions, newBalance);
+        }
+
+        if (acc instanceof DebtAccount) {
+            let finalBalance = linkedState?.balance ?? (acc.amount * (1 + acc.apr / 100));
+            if (totalIn > 0) finalBalance = Math.max(0, finalBalance - totalIn);
+            return acc.increment(assumptions, finalBalance);
+        }
+
+        if (acc instanceof InvestedAccount) {
+            const convAmount = conversionDeposits[acc.id] || 0;
+            return acc.increment(assumptions, userIn, employerIn, returnOverride, convAmount, year);
+        }
+
+        if (acc instanceof SavedAccount) {
+            return acc.increment(assumptions, totalIn);
+        }
+
+        if (acc instanceof ESPPAccount) {
+            let workingAccount: ESPPAccount = acc;
+
+            // Apply any withdrawal (sale) recorded for this account: sell shares at the
+            // current (start-of-year) FMV per share before growth, using the account's
+            // configured lot-selling order. This keeps the ESPP balance conserved.
+            const grossWithdrawn = userIn < 0 ? -userIn : 0;
+            if (grossWithdrawn > 0) {
+                const totalShares = workingAccount.lots.reduce((sum, lot) => sum + lot.shares, 0);
+                const fmvPerShare = totalShares > 0 ? workingAccount.amount / totalShares : 0;
+                if (fmvPerShare > 0) {
+                    const sharesToSell = Math.min(totalShares, grossWithdrawn / fmvPerShare);
+                    // removeSoldShares only accepts 'fifo' | 'disqualifying_first' | 'qualifying_first'.
+                    // ESPPWithdrawalPreference also includes 'dont_sell_until_qualifying', which has no
+                    // direct sell-order equivalent here, so it falls back to 'fifo'.
+                    const pref = workingAccount.withdrawalPreference;
+                    const lotOrder: 'fifo' | 'disqualifying_first' | 'qualifying_first' =
+                        pref === 'disqualifying_first' || pref === 'qualifying_first' || pref === 'fifo'
+                            ? pref
+                            : 'fifo';
+                    workingAccount = workingAccount.removeSoldShares(sharesToSell, fmvPerShare, undefined, lotOrder);
+                }
+            }
+
+            let grownAccount = workingAccount.increment(assumptions, returnOverride);
+
+            const newLots = esppLots[acc.id] || [];
+            if (newLots.length > 0) {
+                for (const lot of newLots) {
+                    grownAccount = grownAccount.addLot(lot);
+                }
+            }
+
+            return grownAccount;
+        }
+
+        const _exhaustiveCheck: never = acc;
+        return _exhaustiveCheck;
+    });
+
+    // Handle deficit debt: either update existing, add new, or remove
+    if (existingDeficitDebt) {
+        const finalDeficitDebtBalance = existingDeficitDebt.amount - deficitDebtPayment;
+        const hasDeficitDebtInAccounts = nextAccounts.some(acc => acc.id === DEFICIT_DEBT_ID);
+
+        if (finalDeficitDebtBalance > 0) {
+            if (hasDeficitDebtInAccounts) {
+                nextAccounts = nextAccounts.map(acc =>
+                    acc.id === DEFICIT_DEBT_ID
+                        ? new DeficitDebtAccount(DEFICIT_DEBT_ID, DEFICIT_DEBT_NAME, finalDeficitDebtBalance)
+                        : acc
+                );
+            } else {
+                nextAccounts = [...nextAccounts, new DeficitDebtAccount(DEFICIT_DEBT_ID, DEFICIT_DEBT_NAME, finalDeficitDebtBalance)];
+            }
+        } else {
+            nextAccounts = nextAccounts.filter(acc => acc.id !== DEFICIT_DEBT_ID);
+        }
+    }
+
+    return nextAccounts;
+}

--- a/src/services/simulation/CashflowDetailBuilder.ts
+++ b/src/services/simulation/CashflowDetailBuilder.ts
@@ -1,0 +1,196 @@
+import {
+    AnyIncome,
+    WorkIncome,
+    PassiveIncome,
+    SocialSecurityIncome,
+    CurrentSocialSecurityIncome,
+    FutureSocialSecurityIncome,
+    FERSPensionIncome,
+    CSRSPensionIncome,
+} from "../../components/Objects/Income/models";
+import {
+    AnyExpense,
+    MortgageExpense,
+    CLASS_TO_CATEGORY,
+    isLongTermGoal,
+    getGoalFundAnnualSetAside,
+} from "../../components/Objects/Expense/models";
+import { AnyAccount, InvestedAccount } from "../../components/Objects/Accounts/models";
+import {
+    CashflowDetail,
+    CashflowIncomeKind,
+    CashflowIncomeSource,
+} from "./types";
+
+const MIN_AMOUNT = 0.005;
+
+interface BuildCashflowDetailInput {
+    /** Active incomes after earnings test, including RMD-sourced PassiveIncomes (shown as income). */
+    incomes: AnyIncome[];
+    /** Expenses after lifestyle creep + GK trim. */
+    expenses: AnyExpense[];
+    /** All accounts (used to resolve match account taxType and reinvested-income destinations). */
+    accounts: AnyAccount[];
+    /** Total payroll insurance deduction for the year. */
+    insurance: number;
+    year: number;
+    /**
+     * Sum of `w.tax` over the year's brokerage/ESPP withdrawals — the planner's
+     * LTCG estimate that was baked into the gross-up. Routed straight to the
+     * government, never lands as user cash. Stored on CashflowDetail so the
+     * Sankey can subtract it from the gross withdrawal inflow.
+     */
+    brokerageLTCGFromGross: number;
+    /**
+     * The ACTUAL employer match the sim deposited, keyed by destination account id
+     * (withdrawalState.employerInflows) — already §415(c)-trimmed by
+     * AccountGrowth.processInflows, so it is authoritative. When present, the
+     * Roth/pretax match split is derived from this map instead of recomputing via
+     * getEffectiveAnnualEmployerMatch (which ignores the §415(c) trim and overstates
+     * the match, breaking inflow=outflow for high earners at the combined 401k limit).
+     */
+    employerInflows?: Record<string, number>;
+}
+
+/**
+ * Build the per-year cashflow detail consumed by the Sankey chart.
+ *
+ * The sim already does all this math while running — this just packages
+ * the per-source breakdown into a stable shape so the chart doesn't have
+ * to re-derive it (and drift from the sim's actual values).
+ */
+export function buildCashflowDetail(input: BuildCashflowDetailInput): CashflowDetail {
+    const { incomes, expenses, accounts, insurance, year, brokerageLTCGFromGross, employerInflows } = input;
+
+    const incomeBySource: CashflowIncomeSource[] = [];
+    let userPreTax401k = 0;
+    let userRoth401k = 0;
+    let employerMatchPreTax = 0;
+    let employerMatchRoth = 0;
+
+    for (const inc of incomes) {
+        const amount = inc.getProratedAnnual ? inc.getProratedAnnual(inc.amount, year) : 0;
+
+        if (inc instanceof WorkIncome) {
+            // Track work-income contributions even when amount==0 is impossible here
+            // (inactive work incomes are filtered upstream by milestones / earnings test).
+            if (amount >= MIN_AMOUNT) {
+                incomeBySource.push({ name: inc.name, amount, kind: 'work' });
+            }
+            userPreTax401k += inc.getProratedAnnual(inc.preTax401k, year);
+            userRoth401k += inc.getProratedAnnual(inc.roth401k, year);
+
+            if (inc.matchAccountId && !employerInflows) {
+                const match = inc.getEffectiveAnnualEmployerMatch(year);
+                if (match >= MIN_AMOUNT) {
+                    const matchAccount = accounts.find(a => a.id === inc.matchAccountId);
+                    const isRoth = matchAccount instanceof InvestedAccount &&
+                        (matchAccount.taxType === 'Roth 401k' || matchAccount.taxType === 'Roth IRA');
+                    if (isRoth) {
+                        employerMatchRoth += match;
+                    } else {
+                        employerMatchPreTax += match;
+                    }
+                }
+            }
+            continue;
+        }
+
+        if (amount < MIN_AMOUNT) continue;
+
+        if (inc instanceof PassiveIncome) {
+            // RMDs are surfaced as spendable income (they drain the Traditional account
+            // via userInflows, but cash-flow-wise they're a required distribution that
+            // funds expenses, with any surplus reinvested). They are deliberately NOT in
+            // cashflow.withdrawalDetail, so showing them here is the single representation.
+            const kind: CashflowIncomeKind = inc.isReinvested ? 'reinvested' : 'passive';
+            const source: CashflowIncomeSource = { name: inc.name, amount, kind };
+
+            if (inc.isReinvested) {
+                // Interest incomes have ids of the form `interest-{accountId}-{year}`.
+                // Resolve the account so the chart can label the destination correctly.
+                const idParts = inc.id.startsWith('interest-') ? inc.id.split('-') : null;
+                const accountId = idParts && idParts.length >= 3
+                    ? idParts.slice(1, -1).join('-')
+                    : null;
+                const account = accountId ? accounts.find(a => a.id === accountId) : null;
+                source.accountName = account?.name ?? inc.name.replace(' Interest', '');
+            }
+
+            incomeBySource.push(source);
+        } else if (
+            inc instanceof SocialSecurityIncome ||
+            inc instanceof CurrentSocialSecurityIncome ||
+            inc instanceof FutureSocialSecurityIncome
+        ) {
+            incomeBySource.push({ name: inc.name, amount, kind: 'ss' });
+        } else if (inc instanceof FERSPensionIncome) {
+            // Include the MRA-to-62 supplement so the Sankey matches spendable income.
+            incomeBySource.push({ name: inc.name, amount: inc.getTotalAnnualAmount(year), kind: 'pension' });
+        } else if (inc instanceof CSRSPensionIncome) {
+            incomeBySource.push({ name: inc.name, amount, kind: 'pension' });
+        } else {
+            incomeBySource.push({ name: inc.name, amount, kind: 'passive' });
+        }
+    }
+
+    // When the sim's actual deposited match is available, derive the Roth/pretax
+    // split from it (per destination account, already §415(c)-trimmed) so the Sankey
+    // matches what AccountGrowth deposited rather than an untrimmed recompute.
+    if (employerInflows) {
+        for (const [accountId, match] of Object.entries(employerInflows)) {
+            if (match < MIN_AMOUNT) continue;
+            const matchAccount = accounts.find(a => a.id === accountId);
+            const isRoth = matchAccount instanceof InvestedAccount &&
+                (matchAccount.taxType === 'Roth 401k' || matchAccount.taxType === 'Roth IRA');
+            if (isRoth) {
+                employerMatchRoth += match;
+            } else {
+                employerMatchPreTax += match;
+            }
+        }
+    }
+
+    let mortgagePrincipal = 0;
+    let mortgageInterestEscrow = 0;
+    for (const exp of expenses) {
+        if (exp instanceof MortgageExpense) {
+            const amort = exp.calculateAnnualAmortization(year);
+            mortgagePrincipal += amort.totalPrincipal;
+            mortgageInterestEscrow += amort.totalPayment - amort.totalPrincipal;
+        }
+    }
+
+    const expensesByCategory: Record<string, number> = {};
+    for (const exp of expenses) {
+        if (exp instanceof MortgageExpense) continue;
+        // Long-term goals report $0 from getAnnualAmount, but their committed
+        // set-aside IS in the sim's living expenses (SimulationEngine counts it
+        // and credits the fund). Without a matching category here the Sankey's
+        // Expenses node is unbalanced by exactly the set-aside.
+        const amount = isLongTermGoal(exp) && exp.goalAccountId
+            ? (getGoalFundAnnualSetAside(expenses, exp.goalAccountId, year) ?? 0)
+            : exp.getAnnualAmount(year);
+        if (amount < MIN_AMOUNT) continue;
+        // Each goal gets its own labeled node ("Car (goal)") — clearer in the
+        // chart than a generic "Goals" bucket, and the "(goal)" suffix avoids
+        // colliding with a regular expense of the same name.
+        const category = isLongTermGoal(exp)
+            ? `${exp.name} (goal)`
+            : (CLASS_TO_CATEGORY[exp.constructor.name] || 'Other');
+        expensesByCategory[category] = (expensesByCategory[category] || 0) + amount;
+    }
+
+    return {
+        incomeBySource,
+        userPreTax401k,
+        userRoth401k,
+        employerMatchPreTax,
+        employerMatchRoth,
+        insurance,
+        mortgagePrincipal,
+        mortgageInterestEscrow,
+        expensesByCategory,
+        brokerageLTCGFromGross,
+    };
+}

--- a/src/services/simulation/IncomeClassifier.ts
+++ b/src/services/simulation/IncomeClassifier.ts
@@ -1,0 +1,162 @@
+/**
+ * IncomeClassifier.ts
+ *
+ * Classifies income into spendable vs reinvested categories for deficit calculation.
+ *
+ * Income Classification Rules:
+ * - Spendable: Cash available to cover expenses (wages, SS, pensions, rental, etc.)
+ * - Reinvested: Taxable but not available as cash (reinvested dividends/interest)
+ * - RMD Income: Required distributions - always spendable and taxable
+ * - Conversion Income: Roth conversions - taxable but NOT spendable (it's a transfer)
+ */
+
+import { AnyIncome, PassiveIncome, WorkIncome, SocialSecurityIncome, CurrentSocialSecurityIncome, FutureSocialSecurityIncome, FERSPensionIncome, CSRSPensionIncome, WindfallIncome } from "../../components/Objects/Income/models";
+import { ClassifiedIncome, IncomeClassificationResult, DecisionLogEntry } from "./types";
+
+/**
+ * Classifies all active incomes for a simulation year.
+ *
+ * @param incomes - All income objects for the year
+ * @param rmdAmount - Total RMD amount for the year (from RMD processing)
+ * @param conversionAmount - Total Roth conversion amount (taxable but not spendable)
+ * @param year - Current simulation year
+ * @returns Classified income breakdown
+ */
+export function classifyIncome(
+    incomes: AnyIncome[],
+    rmdAmount: number,
+    conversionAmount: number,
+    year: number // Current simulation year for date-based filtering
+): IncomeClassificationResult {
+    const decisions: DecisionLogEntry[] = [];
+
+    // Initialize breakdown
+    const breakdown = {
+        wages: 0,
+        socialSecurity: 0,
+        pensions: 0,
+        passive: 0,
+        rmd: rmdAmount,
+        reinvested: 0,
+    };
+
+    let spendable = 0;
+    let reinvested = 0;
+
+    for (const income of incomes) {
+        // Pass year to apply date-based filtering (incomes outside their date range return 0)
+        const annualAmount = income.getAnnualAmount(year);
+        if (annualAmount <= 0) continue;
+
+        if (income instanceof WorkIncome) {
+            // Work income is always spendable
+            spendable += annualAmount;
+            breakdown.wages += annualAmount;
+        } else if (income instanceof SocialSecurityIncome ||
+            income instanceof CurrentSocialSecurityIncome ||
+            income instanceof FutureSocialSecurityIncome) {
+            // Social Security is always spendable
+            spendable += annualAmount;
+            breakdown.socialSecurity += annualAmount;
+        } else if (income instanceof FERSPensionIncome) {
+            // FERS pension is always spendable; include the MRA-to-62 supplement.
+            const fersTotal = income.getTotalAnnualAmount(year);
+            spendable += fersTotal;
+            breakdown.pensions += fersTotal;
+        } else if (income instanceof CSRSPensionIncome) {
+            // CSRS pension is always spendable
+            spendable += annualAmount;
+            breakdown.pensions += annualAmount;
+        } else if (income instanceof PassiveIncome) {
+            // PassiveIncome can be reinvested or spendable based on isReinvested flag
+            if (income.isReinvested) {
+                reinvested += annualAmount;
+                breakdown.reinvested += annualAmount;
+            } else {
+                spendable += annualAmount;
+                breakdown.passive += annualAmount;
+            }
+
+            // Special handling for RMD-sourced passive income
+            // Note: RMD creates a PassiveIncome with sourceType 'RMD', but the actual RMD amount
+            // is passed in separately to avoid double-counting. We skip RMD-sourced passive income.
+            if (income.sourceType === 'RMD') {
+                // RMD amount is passed in separately, don't double-count
+                // Actually, let's undo what we just added since RMD is tracked separately
+                if (income.isReinvested) {
+                    reinvested -= annualAmount;
+                    breakdown.reinvested -= annualAmount;
+                } else {
+                    spendable -= annualAmount;
+                    breakdown.passive -= annualAmount;
+                }
+            }
+        } else if (income instanceof WindfallIncome) {
+            // Windfalls are spendable
+            spendable += annualAmount;
+            breakdown.passive += annualAmount;
+        } else {
+            // Default: treat as spendable passive income
+            spendable += annualAmount;
+            breakdown.passive += annualAmount;
+        }
+    }
+
+    // RMD is always spendable (passed in separately)
+    spendable += rmdAmount;
+
+    // Calculate taxable total:
+    // - All spendable income is taxable
+    // - Reinvested income is taxable
+    // - RMD is already included in spendable
+    // - Conversion is taxable but not spendable
+    const taxableTotal = spendable + reinvested + conversionAmount;
+
+    const classified: ClassifiedIncome = {
+        spendable,
+        reinvested,
+        rmdIncome: rmdAmount,
+        conversionIncome: conversionAmount,
+        taxableTotal,
+        breakdown,
+    };
+
+    // Log significant classifications
+    if (reinvested > 0) {
+        decisions.push({
+            category: 'tax',
+            amount: reinvested,
+            description: `Reinvested income of $${reinvested.toLocaleString()} is taxable but not available for spending.`,
+        });
+    }
+
+    if (conversionAmount > 0) {
+        decisions.push({
+            category: 'conversion',
+            amount: conversionAmount,
+            description: `Roth conversion of $${conversionAmount.toLocaleString()} is taxable but not spendable (transfer between accounts).`,
+        });
+    }
+
+    return {
+        classified,
+        logs: decisions.map(d => d.description),
+    };
+}
+
+/**
+ * Get total Social Security benefits from incomes.
+ * Used for SS taxability calculation (not the same as taxable SS).
+ */
+export function getTotalSSBenefits(incomes: AnyIncome[], year: number): number {
+    let total = 0;
+    for (const income of incomes) {
+        if (income instanceof SocialSecurityIncome ||
+            income instanceof CurrentSocialSecurityIncome ||
+            income instanceof FutureSocialSecurityIncome) {
+            total += income.getAnnualAmount(year);
+        }
+    }
+    return total;
+}
+

--- a/src/services/simulation/IncomeProjection.ts
+++ b/src/services/simulation/IncomeProjection.ts
@@ -1,0 +1,339 @@
+import { AnyIncome, WorkIncome, FutureSocialSecurityIncome, FERSPensionIncome, CSRSPensionIncome, PassiveIncome } from "../../components/Objects/Income/models";
+import { AnyAccount, SavedAccount } from "../../components/Objects/Accounts/models";
+import { AssumptionsState, getRetirementAge, getLifeExpectancy, getBirthYear } from "../../components/Objects/Assumptions/AssumptionsContext";
+import { calculateHigh3, checkFERSEligibility, checkCSRSEligibility, calculateFERSBasicBenefit, calculateCSRSBasicBenefit } from "../../data/PensionData";
+import { calculateAIME, extractEarningsFromSimulation, calculateEarningsTestReduction } from "../SocialSecurityCalculator";
+import { getFRA } from "../../data/SocialSecurityData";
+import * as TaxService from "../../components/Objects/Taxes/TaxService";
+import { SimulationYear } from "./types";
+
+export interface IncomeProjectionResult {
+    nextIncomes: AnyIncome[];
+    interestIncomes: PassiveIncome[];
+    allIncomes: AnyIncome[];
+    logs: string[];
+}
+
+/**
+ * Project incomes for the next year: grow work income, calculate pensions,
+ * determine Social Security benefits, apply earnings test, and compute interest income.
+ */
+export function projectIncomes(
+    year: number,
+    incomes: AnyIncome[],
+    accounts: AnyAccount[],
+    assumptions: AssumptionsState,
+    previousSimulation: SimulationYear[],
+    currentAge: number,
+    isRetired: boolean,
+    logs: string[]
+): IncomeProjectionResult {
+    // Filter out previous year's interest and RMD income - they're regenerated fresh each year
+    const regularIncomes = incomes.filter(inc => {
+        if (inc instanceof PassiveIncome && (inc.sourceType === 'Interest' || inc.sourceType === 'RMD')) {
+            return false;
+        }
+        return true;
+    });
+
+    const nextIncomes = regularIncomes.map(inc => {
+        // End work income at retirement if no end date is set
+        if (inc instanceof WorkIncome && isRetired && !inc.end_date) {
+            const retirementYear = getBirthYear(assumptions.milestones) + getRetirementAge(assumptions.milestones);
+
+            return new WorkIncome(
+                inc.id,
+                inc.name,
+                0, // Zero out the income
+                inc.frequency,
+                inc.earned_income,
+                0, // Zero out preTax401k
+                0, // Zero out insurance
+                0, // Zero out roth401k
+                0, // Zero out employerMatch
+                inc.matchAccountId,
+                inc.taxType,
+                inc.contributionGrowthStrategy,
+                inc.startDate,
+                new Date(Date.UTC(retirementYear - 1, 11, 31)),
+                0, // hsaContribution
+                inc.autoMax401k,
+                inc.esppContributionType,
+                0, // esppContributionAmount
+                inc.esppDiscountPercent,
+                inc.esppHasLookback,
+                inc.esppOfferingPeriodMonths,
+                inc.esppAccountId,
+                inc.esppExpectedStockGrowth,
+                inc.pensionSystem,
+                inc.startMilestoneId,
+                inc.endMilestoneId,  // CRITICAL: Preserve milestone IDs
+                inc.employerMatchType,
+                inc.employerMatchPercent,
+                inc.employerMatchMax,
+            );
+        }
+
+        // Handle FERS Pension
+        if (inc instanceof FERSPensionIncome) {
+            if (inc.autoCalculateHigh3 && inc.linkedIncomeId) {
+                // Build salary history from prior simulation years. The linked WorkIncome is
+                // filtered out of `incomes` once the user retires, so the High-3 calculation
+                // must NOT depend on it still being present in the current year's incomes.
+                const salaryHistory: number[] = previousSimulation
+                    .map(simYear => {
+                        const prevLinked = simYear.incomes.find(i => i.id === inc.linkedIncomeId);
+                        if (prevLinked instanceof WorkIncome) {
+                            return prevLinked.getAnnualAmount(simYear.year);
+                        }
+                        return 0;
+                    })
+                    .filter(s => s > 0);
+
+                // If the linked income is still active this year, include its salary too.
+                const linkedIncome = incomes.find(i => i.id === inc.linkedIncomeId);
+                if (linkedIncome instanceof WorkIncome) {
+                    const currentSalary = linkedIncome.getAnnualAmount(year);
+                    if (currentSalary > 0) salaryHistory.push(currentSalary);
+                }
+
+                if (currentAge === inc.retirementAge && salaryHistory.length > 0) {
+                    const high3 = calculateHigh3(salaryHistory);
+                    const baseBenefit = calculateFERSBasicBenefit(inc.yearsOfService, high3, inc.retirementAge);
+                    const eligibility = checkFERSEligibility(inc.retirementAge, inc.yearsOfService, inc.birthYear);
+                    const reductionFactor = 1 - (eligibility.reductionPercent / 100);
+                    const actualBenefit = baseBenefit * reductionFactor;
+
+                    logs.push(`[PENSION] FERS Pension started: High-3 calculated as $${high3.toLocaleString()}/yr from ${salaryHistory.length} years of salary history`);
+                    if (eligibility.reductionPercent > 0) {
+                        logs.push(`   Base benefit: $${baseBenefit.toLocaleString()}/yr, reduced by ${eligibility.reductionPercent}% (${eligibility.message})`);
+                    }
+                    logs.push(`   Annual benefit: $${actualBenefit.toLocaleString()}/yr`);
+
+                    return new FERSPensionIncome(
+                        inc.id, inc.name, inc.yearsOfService, high3,
+                        inc.retirementAge, inc.birthYear, actualBenefit,
+                        inc.fersSupplement, inc.estimatedSSAt62,
+                        inc.startDate, inc.end_date,
+                        inc.autoCalculateHigh3, inc.linkedIncomeId,
+                        inc.startMilestoneId, inc.endMilestoneId
+                    );
+                }
+            }
+            return inc.increment(assumptions, year, currentAge);
+        }
+
+        // Handle CSRS Pension
+        if (inc instanceof CSRSPensionIncome) {
+            if (inc.autoCalculateHigh3 && inc.linkedIncomeId) {
+                // Build salary history from prior simulation years. The linked WorkIncome is
+                // filtered out of `incomes` once the user retires, so the High-3 calculation
+                // must NOT depend on it still being present in the current year's incomes.
+                const salaryHistory: number[] = previousSimulation
+                    .map(simYear => {
+                        const prevLinked = simYear.incomes.find(i => i.id === inc.linkedIncomeId);
+                        if (prevLinked instanceof WorkIncome) {
+                            return prevLinked.getAnnualAmount(simYear.year);
+                        }
+                        return 0;
+                    })
+                    .filter(s => s > 0);
+
+                // If the linked income is still active this year, include its salary too.
+                const linkedIncome = incomes.find(i => i.id === inc.linkedIncomeId);
+                if (linkedIncome instanceof WorkIncome) {
+                    const currentSalary = linkedIncome.getAnnualAmount(year);
+                    if (currentSalary > 0) salaryHistory.push(currentSalary);
+                }
+
+                if (currentAge === inc.retirementAge && salaryHistory.length > 0) {
+                    const high3 = calculateHigh3(salaryHistory);
+                    const baseBenefit = calculateCSRSBasicBenefit(inc.yearsOfService, high3);
+
+                    const eligibility = checkCSRSEligibility(inc.retirementAge, inc.yearsOfService);
+                    const reductionFactor = 1 - (eligibility.reductionPercent / 100);
+                    const actualBenefit = baseBenefit * reductionFactor;
+
+                    logs.push(`[PENSION] CSRS Pension started: High-3 calculated as $${high3.toLocaleString()}/yr from ${salaryHistory.length} years of salary history`);
+                    if (eligibility.reductionPercent > 0) {
+                        logs.push(`   Base benefit: $${baseBenefit.toLocaleString()}/yr, reduced by ${eligibility.reductionPercent}% (${eligibility.message})`);
+                    }
+                    logs.push(`   Annual benefit: $${actualBenefit.toLocaleString()}/yr`);
+
+                    return new CSRSPensionIncome(
+                        inc.id, inc.name, inc.yearsOfService, high3,
+                        inc.retirementAge, actualBenefit,
+                        inc.startDate, inc.end_date,
+                        inc.autoCalculateHigh3, inc.linkedIncomeId,
+                        inc.startMilestoneId, inc.endMilestoneId
+                    );
+                }
+            }
+            return inc.increment(assumptions);
+        }
+
+        if (inc instanceof FutureSocialSecurityIncome) {
+            // Recalculate PIA every year until claiming age so it reflects growing earnings history.
+            // After claiming age (or if already activated), fall through to inc.increment() for COLA.
+            // Only enter this block if: (before claiming) OR (at claiming and not yet activated)
+            const shouldRecalculate = currentAge < inc.claimingAge ||
+                (currentAge === inc.claimingAge && inc.calculatedPIA === 0);
+
+            if (shouldRecalculate) {
+                try {
+                    const inflationAdjusted = assumptions.macro.inflationAdjusted;
+                    const earningsHistory = extractEarningsFromSimulation(
+                        previousSimulation,
+                        assumptions.demographics.priorEarnings,
+                        inflationAdjusted,
+                        incomes
+                    );
+
+                    const birthYear = getBirthYear(assumptions.milestones);
+                    const wageGrowthRate = assumptions.macro.inflationRate / 100;
+                    const aimeCalc = calculateAIME(earningsHistory, year, inc.claimingAge, birthYear, wageGrowthRate, inflationAdjusted);
+
+                    const fundingPercent = (assumptions.income?.socialSecurityFundingPercent ?? 100) / 100;
+                    const adjustedMonthlyBenefit = aimeCalc.adjustedBenefit * fundingPercent;
+
+                    logs.push(`Social Security PIA calculated: $${adjustedMonthlyBenefit.toFixed(2)}/month (claiming at age ${inc.claimingAge})`);
+                    logs.push(`  AIME: $${aimeCalc.aime.toFixed(2)}, PIA: $${aimeCalc.pia.toFixed(2)}${fundingPercent < 1 ? `, Funding: ${fundingPercent * 100}%` : ''}`);
+
+                    if (currentAge === inc.claimingAge) {
+                        // At claiming age - activate the income
+                        // Set both calculatedPIA (feeds amount) and projectedPIA
+                        const endDate = new Date(Date.UTC(
+                            birthYear + getLifeExpectancy(assumptions.milestones),
+                            11, 31
+                        ));
+                        return new FutureSocialSecurityIncome(
+                            inc.id,
+                            inc.name,
+                            inc.claimingAge,
+                            adjustedMonthlyBenefit,  // calculatedPIA - activates income (amount = PIA * 12)
+                            year,
+                            new Date(Date.UTC(year, 0, 1)),
+                            endDate,
+                            inc.startMilestoneId,
+                            inc.endMilestoneId,
+                            adjustedMonthlyBenefit   // projectedPIA - same as calculatedPIA at activation
+                        );
+                    } else {
+                        // Before claiming age - store projectedPIA for planning, but keep amount = 0
+                        // calculatedPIA = 0 so amount stays 0 (income not yet active)
+                        // projectedPIA = calculated value for Roth conversion planning
+                        const claimingYear = birthYear + inc.claimingAge;
+                        const futureStartDate = new Date(Date.UTC(claimingYear, 0, 1));
+                        return new FutureSocialSecurityIncome(
+                            inc.id,
+                            inc.name,
+                            inc.claimingAge,
+                            0,  // calculatedPIA = 0 (amount stays 0, income not active)
+                            year,  // calculationYear = current year when PIA was calculated
+                            futureStartDate,
+                            inc.end_date,
+                            inc.startMilestoneId,
+                            inc.endMilestoneId,
+                            adjustedMonthlyBenefit  // projectedPIA = calculated value for planning
+                        );
+                    }
+                } catch (error) {
+                    console.error('Error calculating Social Security benefits:', error);
+                    logs.push(`[WARN] Error calculating Social Security benefits: ${error}`);
+                    return inc.increment(assumptions);
+                }
+            }
+            // After claiming age (or already activated): falls through to inc.increment() below for COLA
+        }
+
+        // Pass year and age for WorkIncome to support TRACK_ANNUAL_MAX strategy
+        if (inc instanceof WorkIncome) {
+            return inc.increment(assumptions, year, currentAge);
+        }
+
+        return inc.increment(assumptions);
+    });
+
+    // Apply earnings test to FutureSocialSecurityIncome if claiming before FRA
+    const incomesWithEarningsTest = nextIncomes.map(inc => {
+        if (inc instanceof FutureSocialSecurityIncome && inc.calculatedPIA > 0) {
+            const birthYear = getBirthYear(assumptions.milestones);
+            const fra = getFRA(birthYear);
+
+            if (currentAge < fra) {
+                const earnedIncome = TaxService.getEarnedIncome(nextIncomes, year);
+                const annualSSBenefit = inc.getProratedAnnual(inc.amount, year);
+                const wageGrowthRate = assumptions.macro.inflationRate / 100;
+                const inflationAdjusted = assumptions.macro.inflationAdjusted;
+
+                const earningsTest = calculateEarningsTestReduction(
+                    annualSSBenefit,
+                    earnedIncome,
+                    currentAge,
+                    fra,
+                    year,
+                    wageGrowthRate,
+                    inflationAdjusted
+                );
+
+                if (earningsTest.appliesTest && earningsTest.amountWithheld > 0) {
+                    const monthlyReduced = earningsTest.reducedBenefit / 12;
+
+                    logs.push(`[WARN] Earnings test applied: SS benefit reduced from $${(annualSSBenefit/12).toFixed(2)}/month to $${monthlyReduced.toFixed(2)}/month`);
+                    logs.push(`  ${earningsTest.reason}`);
+                    logs.push(`  Amount withheld: $${earningsTest.amountWithheld.toLocaleString()}/year`);
+                    logs.push(`  Note: Withheld benefits would be recalculated at FRA (not yet implemented)`);
+
+                    return new FutureSocialSecurityIncome(
+                        inc.id,
+                        inc.name,
+                        inc.claimingAge,
+                        monthlyReduced,
+                        inc.calculationYear,
+                        inc.startDate,
+                        inc.end_date,
+                        inc.startMilestoneId,
+                        inc.endMilestoneId,
+                        inc.projectedPIA
+                    );
+                }
+            }
+        }
+        return inc;
+    });
+
+    // Calculate interest income from savings accounts (before they grow)
+    const interestIncomes: PassiveIncome[] = [];
+    for (const acc of accounts) {
+        if (acc instanceof SavedAccount && acc.apr > 0 && acc.amount > 0) {
+            const interestEarned = acc.amount * (acc.apr / 100);
+            if (interestEarned > 0.01) {
+                interestIncomes.push(new PassiveIncome(
+                    `interest-${acc.id}-${year}`,
+                    `${acc.name} Interest`,
+                    interestEarned,
+                    'Annually',
+                    'No',
+                    'Interest',
+                    // Use UTC so getIncomeActiveMultiplier (which reads getUTC*) sees a
+                    // clean full-calendar-year active window (multiplier = 1.0). Local
+                    // new Date(year, ...) shifts into the prior/next year in +UTC zones,
+                    // mis-prorating this full-year reinvested income.
+                    new Date(Date.UTC(year, 0, 1)),
+                    new Date(Date.UTC(year, 11, 31)),
+                    true  // isReinvested
+                ));
+            }
+        }
+    }
+
+    // Combine regular incomes with interest income for tax calculations
+    const allIncomes = [...incomesWithEarningsTest, ...interestIncomes];
+
+    return {
+        nextIncomes: incomesWithEarningsTest,
+        interestIncomes,
+        allIncomes,
+        logs
+    };
+}

--- a/src/services/simulation/MilestoneEvaluator.ts
+++ b/src/services/simulation/MilestoneEvaluator.ts
@@ -1,0 +1,401 @@
+import { AnyAccount, InvestedAccount, SavedAccount, DebtAccount, PropertyAccount, ESPPAccount, DeficitDebtAccount } from "../../components/Objects/Accounts/models";
+import { MortgageExpense, LoanExpense, AnyExpense } from "../../components/Objects/Expense/models";
+import { CustomMilestone, MilestoneCondition, MilestoneReachEvent } from "./types";
+import { getTaxParameters, calculateTotalFederalTax } from "../../components/Objects/Taxes/TaxService";
+import { FilingStatus } from "../../data/TaxData";
+
+/**
+ * Context for evaluating milestone conditions
+ */
+export interface MilestoneContext {
+    accounts: AnyAccount[];
+    expenses: AnyExpense[];
+    year: number;
+    age: number;
+    milestoneReachYears?: Map<string, number>;  // milestoneId -> year reached (for YEARS_AFTER_MILESTONE)
+    filingStatus?: FilingStatus;  // user's filing status, for the EXPENSES_GROSSED_UP tax gross-up (defaults to Single)
+}
+
+/**
+ * Calculate total net worth: all assets minus all liabilities
+ */
+export function calculateNetWorth(accounts: AnyAccount[], expenses: AnyExpense[]): number {
+    let assets = 0;
+    let liabilities = 0;
+
+    accounts.forEach(account => {
+        if (account instanceof DeficitDebtAccount) {
+            liabilities += account.amount;
+        } else if (account instanceof DebtAccount) {
+            liabilities += account.amount;
+        } else if (account instanceof PropertyAccount) {
+            // Property value minus loan balance
+            assets += account.amount; // Value
+            liabilities += account.loanAmount || 0;
+        } else if (account instanceof InvestedAccount || account instanceof SavedAccount || account instanceof ESPPAccount) {
+            assets += account.amount;
+        }
+    });
+
+    // Build set of expense ids that are linked to an account (so the loan is
+    // already counted on the account side) to avoid double-counting.
+    const linkedExpenseIds = new Set<string>();
+    accounts.forEach(a => {
+        if ((a instanceof PropertyAccount || a instanceof DebtAccount) && a.linkedAccountId) {
+            linkedExpenseIds.add(a.linkedAccountId);
+        }
+    });
+
+    // Also include mortgage and loan balances from standalone expenses
+    // (skip those linked to an account, already counted above).
+    expenses.forEach(expense => {
+        if (expense instanceof MortgageExpense) {
+            if (!linkedExpenseIds.has(expense.id)) liabilities += expense.loan_balance;
+        } else if (expense instanceof LoanExpense) {
+            if (!linkedExpenseIds.has(expense.id)) liabilities += expense.amount;
+        }
+    });
+
+    return assets - liabilities;
+}
+
+/**
+ * Calculate liquid net worth: only Brokerage + Savings accounts
+ * (Not retirement accounts like 401k, IRA, etc.)
+ */
+export function calculateLiquidNetWorth(accounts: AnyAccount[]): number {
+    let liquid = 0;
+
+    accounts.forEach(account => {
+        if (account instanceof SavedAccount) {
+            liquid += account.amount;
+        } else if (account instanceof InvestedAccount && account.taxType === 'Brokerage') {
+            liquid += account.amount;
+        } else if (account instanceof ESPPAccount) {
+            // ESPP is liquid (publicly traded stock)
+            liquid += account.amount;
+        }
+    });
+
+    return liquid;
+}
+
+/**
+ * Calculate total debt: all debt accounts + mortgage/loan balances
+ */
+export function calculateTotalDebt(accounts: AnyAccount[], expenses: AnyExpense[]): number {
+    let debt = 0;
+
+    accounts.forEach(account => {
+        if (account instanceof DeficitDebtAccount) {
+            debt += account.amount;
+        } else if (account instanceof DebtAccount) {
+            debt += account.amount;
+        } else if (account instanceof PropertyAccount) {
+            debt += account.loanAmount || 0;
+        }
+    });
+
+    // Build set of expense ids that are linked to an account (so the loan is
+    // already counted on the account side) to avoid double-counting.
+    const linkedExpenseIds = new Set<string>();
+    accounts.forEach(a => {
+        if ((a instanceof PropertyAccount || a instanceof DebtAccount) && a.linkedAccountId) {
+            linkedExpenseIds.add(a.linkedAccountId);
+        }
+    });
+
+    // Also include mortgage and loan balances from standalone expenses
+    // (skip those linked to an account, already counted above).
+    expenses.forEach(expense => {
+        if (expense instanceof MortgageExpense) {
+            if (!linkedExpenseIds.has(expense.id)) debt += expense.loan_balance;
+        } else if (expense instanceof LoanExpense) {
+            if (!linkedExpenseIds.has(expense.id)) debt += expense.amount;
+        }
+    });
+
+    return debt;
+}
+
+/**
+ * Calculate total annual expenses
+ * Used for expense multiple calculations (e.g., 25x expenses for FI)
+ */
+export function calculateAnnualExpenses(expenses: AnyExpense[], year: number): number {
+    let total = 0;
+
+    expenses.forEach(expense => {
+        // Check if expense is active in this year
+        const startYear = expense.startDate ? expense.startDate.getUTCFullYear() : 0;
+        const endYear = expense.endDate ? expense.endDate.getUTCFullYear() : 9999;
+
+        if (year >= startYear && year <= endYear) {
+            if (expense instanceof MortgageExpense) {
+                total += expense.calculateAnnualAmortization(year).totalPayment;
+            } else if (expense instanceof LoanExpense) {
+                total += expense.calculateAnnualAmortization(year).totalPayment;
+            } else {
+                total += expense.getAnnualAmount(year);
+            }
+        }
+    });
+
+    return total;
+}
+
+/**
+ * Fallback filing status for the expense gross-up, used only when the
+ * MilestoneContext doesn't carry one. 'Single' is the same conservative default
+ * the app ships with (TaxContext.defaultTaxState) and yields the least-favorable
+ * brackets, so the grossed-up target is never optimistic.
+ */
+const GROSS_UP_DEFAULT_FILING_STATUS: FilingStatus = 'Single';
+
+/**
+ * Gross up after-tax living expenses into the pre-tax withdrawal needed to fund
+ * them, using the real federal bracket schedule for the given year instead of a
+ * flat assumed rate.
+ *
+ * A retiree who needs `netExpenses` to spend must withdraw enough pre-tax
+ * dollars `gross` such that `gross - tax(gross) === netExpenses`, i.e.
+ * `gross === netExpenses + tax(gross)`. Because `tax(gross)` depends on `gross`,
+ * we solve it with a short fixed-point iteration (gross starts at the raw
+ * expenses and is bumped by the tax owed each pass). This converges quickly
+ * because the federal schedule is piecewise-linear; a handful of iterations is
+ * more than enough.
+ *
+ * The withdrawal is modeled as ordinary income (the typical case for funding
+ * retirement from Traditional 401k/IRA balances), so it correctly benefits from
+ * the standard deduction and the lower brackets — making the effective rate far
+ * more accurate than the previous flat 15%, especially at modest spend levels.
+ *
+ * Falls back to a flat 15% gross-up if tax parameters can't be resolved for the
+ * year (mirrors the previous behavior so the milestone never silently breaks).
+ */
+function grossUpExpenses(netExpenses: number, year: number, filingStatus: FilingStatus): number {
+    const FALLBACK_TAX_RATE = 0.15;
+
+    const fedParams = getTaxParameters(year, filingStatus, "federal");
+    if (!fedParams) {
+        return netExpenses / (1 - FALLBACK_TAX_RATE);
+    }
+
+    // Fixed-point solve for gross such that gross - tax(gross) === netExpenses.
+    let gross = netExpenses;
+    for (let i = 0; i < 8; i++) {
+        const tax = calculateTotalFederalTax(
+            gross,  // ordinary income (Traditional-account withdrawal)
+            0,      // socialSecurityBenefits
+            0,      // shortTermCapitalGains
+            0,      // longTermCapitalGains
+            0,      // preTaxDeductions (already retired; none assumed)
+            filingStatus,
+            fedParams,
+        ).totalTax;
+        const next = netExpenses + tax;
+        if (Math.abs(next - gross) < 1) {
+            gross = next;
+            break;
+        }
+        gross = next;
+    }
+
+    return gross;
+}
+
+/**
+ * Calculate the target value for comparison based on valueType
+ */
+function calculateTargetValue(condition: MilestoneCondition, context: MilestoneContext): number | null {
+    const valueType = condition.valueType || 'FIXED';
+
+    switch (valueType) {
+        case 'FIXED':
+            return condition.value;
+
+        case 'EXPENSES': {
+            // value × annual expenses (e.g., 25x expenses for 4% rule)
+            // Living expenses only - does NOT include taxes
+            const annualExpenses = calculateAnnualExpenses(context.expenses, context.year);
+            if (annualExpenses <= 0) return null; // Can't multiply by zero expenses
+            return condition.value * annualExpenses;
+        }
+
+        case 'EXPENSES_GROSSED_UP': {
+            // value × (pre-tax dollars needed to net the annual expenses).
+            //
+            // Previously this used a flat 15% rate (expenses / (1 - 0.15)),
+            // ignoring filing status, state, and the actual bracket schedule.
+            // We now derive the gross-up from the real federal tax brackets for
+            // the milestone's year via grossUpExpenses() (solving
+            // gross - tax(gross) === expenses), which is materially more
+            // accurate — at low spend the standard deduction makes the effective
+            // rate well under 15%, and at high spend the upper brackets push it
+            // above 15%.
+            //
+            // The user's real filingStatus is threaded through MilestoneContext
+            // (set by SimulationEngine). Still federal-only: MilestoneContext does
+            // not carry stateResidency, so STATE tax is not included in the
+            // gross-up — a fuller fix would thread stateResidency through too.
+            const annualExpenses = calculateAnnualExpenses(context.expenses, context.year);
+            if (annualExpenses <= 0) return null;
+            const grossedUpExpenses = grossUpExpenses(
+                annualExpenses,
+                context.year,
+                context.filingStatus ?? GROSS_UP_DEFAULT_FILING_STATUS,
+            );
+            return condition.value * grossedUpExpenses;
+        }
+
+        case 'MILESTONE_PLUS': {
+            // milestone year/age + value offset
+            if (!condition.referenceMilestoneId || !context.milestoneReachYears) {
+                return null; // Missing reference
+            }
+            const reachedYear = context.milestoneReachYears.get(condition.referenceMilestoneId);
+            if (reachedYear === undefined) {
+                return null; // Referenced milestone hasn't been reached yet
+            }
+            // For YEAR conditions, return the year + offset
+            // For AGE conditions, convert to age equivalent
+            if (condition.type === 'AGE') {
+                // Convert the milestone's reach-year to the age the user was when it
+                // was reached, then add the offset. (No '_age' key is ever stored in
+                // milestoneReachYears, so this derivation is the sole path.)
+                return (reachedYear - context.year + context.age) + condition.value;
+            }
+            return reachedYear + condition.value;
+        }
+
+        default:
+            return condition.value;
+    }
+}
+
+/**
+ * Evaluate a single condition against the context
+ */
+function evaluateCondition(condition: MilestoneCondition, context: MilestoneContext): boolean {
+    // Get the measured value (left side of comparison)
+    let measuredValue: number;
+
+    switch (condition.type) {
+        case 'NET_WORTH':
+            measuredValue = calculateNetWorth(context.accounts, context.expenses);
+            break;
+        case 'LIQUID_NET_WORTH':
+            measuredValue = calculateLiquidNetWorth(context.accounts);
+            break;
+        case 'TOTAL_DEBT':
+            measuredValue = calculateTotalDebt(context.accounts, context.expenses);
+            break;
+        case 'YEAR':
+            measuredValue = context.year;
+            break;
+        case 'AGE':
+            measuredValue = context.age;
+            break;
+        default:
+            return false;
+    }
+
+    // Get the target value (right side of comparison)
+    const targetValue = calculateTargetValue(condition, context);
+    if (targetValue === null) {
+        return false; // Couldn't calculate target (e.g., milestone not reached yet)
+    }
+
+    switch (condition.operator) {
+        case '>=':
+            return measuredValue >= targetValue;
+        case '<=':
+            return measuredValue <= targetValue;
+        case '>':
+            return measuredValue > targetValue;
+        case '<':
+            return measuredValue < targetValue;
+        case '=':
+            return measuredValue === targetValue;
+        default:
+            return false;
+    }
+}
+
+/**
+ * Evaluate if a milestone has been reached (all conditions must be met)
+ */
+export function evaluateMilestone(milestone: CustomMilestone, context: MilestoneContext): boolean {
+    // All conditions must be met (AND logic)
+    return milestone.conditions.every(condition => evaluateCondition(condition, context));
+}
+
+/**
+ * Evaluate all milestones and return newly reached ones
+ * @param milestones - All defined milestones
+ * @param previouslyReached - IDs of milestones already reached in prior years
+ * @param context - Current simulation context
+ * @returns Object with newly reached milestones and updated active set
+ */
+export function evaluateAllMilestones(
+    milestones: CustomMilestone[],
+    previouslyReached: Set<string>,
+    context: MilestoneContext
+): {
+    newlyReached: MilestoneReachEvent[];
+    activeMilestones: string[];
+} {
+    const newlyReached: MilestoneReachEvent[] = [];
+    const activeMilestones = new Set(previouslyReached);
+
+    milestones.forEach(milestone => {
+        // Skip if already reached
+        if (previouslyReached.has(milestone.id)) {
+            return;
+        }
+
+        // Check if conditions are now met
+        if (evaluateMilestone(milestone, context)) {
+            newlyReached.push({
+                milestoneId: milestone.id,
+                yearReached: context.year,
+                ageReached: context.age,
+            });
+            activeMilestones.add(milestone.id);
+        }
+    });
+
+    return {
+        newlyReached,
+        activeMilestones: Array.from(activeMilestones),
+    };
+}
+
+/**
+ * Check if an income/expense should be active based on milestone state
+ * @param startMilestoneId - Milestone that triggers start (optional)
+ * @param endMilestoneId - Milestone that triggers end (optional)
+ * @param currentMilestones - Set of milestone IDs reached as of current year
+ * @param previousMilestones - Set of milestone IDs reached as of previous year (optional, defaults to currentMilestones)
+ * @returns true if the item should be active
+ */
+export function isActiveByMilestone(
+    startMilestoneId: string | undefined,
+    endMilestoneId: string | undefined,
+    currentMilestones: Set<string>,
+    previousMilestones?: Set<string>
+): boolean {
+    // START: use current state (begin immediately when milestone is reached)
+    if (startMilestoneId && !currentMilestones.has(startMilestoneId)) {
+        return false;
+    }
+
+    // END: use previous state (continue through the year milestone is reached)
+    // If no previous state provided, fall back to current (for backwards compatibility)
+    const endCheckSet = previousMilestones ?? currentMilestones;
+    if (endMilestoneId && endCheckSet.has(endMilestoneId)) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/services/simulation/RMDService.ts
+++ b/src/services/simulation/RMDService.ts
@@ -1,0 +1,138 @@
+import { AnyAccount, InvestedAccount } from "../../components/Objects/Accounts/models";
+import { PassiveIncome } from "../../components/Objects/Income/models";
+import { AssumptionsState, getBirthYear } from "../../components/Objects/Assumptions/AssumptionsContext";
+import { calculateRMD, isAccountSubjectToRMD, isRMDRequired, RMDCalculation } from "../../data/RMDData";
+import { SimulationYear, WithdrawalState } from "./types";
+
+export interface RMDResult {
+    rmdDetails: SimulationYear['rmdDetails'];
+    rmdIncomes: PassiveIncome[];
+    logs: string[];
+}
+
+/**
+ * Process Required Minimum Distributions for Traditional accounts.
+ * RMDs must be taken starting at age 72-75 depending on birth year.
+ * Amount is based on prior year's ending balance divided by life expectancy factor.
+ */
+export function processRMDs(
+    year: number,
+    accounts: AnyAccount[],
+    assumptions: AssumptionsState,
+    previousSimulation: SimulationYear[],
+    currentAge: number,
+    totalGrossIncome: number,
+    withdrawalState: WithdrawalState,
+    logs: string[]
+): RMDResult {
+    const birthYearForRMD = getBirthYear(assumptions.milestones);
+    const rmdRequired = isRMDRequired(currentAge, birthYearForRMD);
+
+    if (!rmdRequired) {
+        return {
+            rmdDetails: undefined,
+            rmdIncomes: [],
+            logs
+        };
+    }
+
+    const rmdCalculations: RMDCalculation[] = [];
+    let totalRMDRequired = 0;
+    let totalRMDWithdrawn = 0;
+    const rmdIncomes: PassiveIncome[] = [];
+
+    for (const account of accounts) {
+        if (!(account instanceof InvestedAccount)) continue;
+        if (!isAccountSubjectToRMD(account.taxType)) continue;
+
+        // Get prior year's ending balance for RMD calculation.
+        // Bug #12: base the RMD requirement on the VESTED prior-year balance so
+        // the requirement and the withdrawal cap (availableBalance below) share
+        // the same basis. Using full balance here while capping withdrawals at
+        // vested fabricates a phantom shortfall + 25% penalty for unvested
+        // employer money the owner cannot legally distribute. The IRS bases RMDs
+        // on the account balance, but unvested employer funds are not yet the
+        // owner's assets, so vested balance is the conservative, consistent basis.
+        const priorYearSim = previousSimulation[previousSimulation.length - 1];
+        let priorYearBalance = account.vestedAmount;
+
+        if (priorYearSim) {
+            const priorAccount = priorYearSim.accounts.find(a => a.id === account.id);
+            if (priorAccount instanceof InvestedAccount) {
+                priorYearBalance = priorAccount.vestedAmount;
+            }
+        }
+
+        const rmdAmount = calculateRMD(priorYearBalance, currentAge);
+        if (rmdAmount <= 0) continue;
+
+        rmdCalculations.push({
+            accountName: account.name,
+            accountId: account.id,
+            priorYearBalance: priorYearBalance,
+            distributionPeriod: priorYearBalance / rmdAmount,
+            rmdAmount: rmdAmount
+        });
+
+        totalRMDRequired += rmdAmount;
+
+        const availableBalance = account.vestedAmount;
+        const actualWithdrawal = Math.min(rmdAmount, availableBalance);
+
+        if (actualWithdrawal > 0) {
+            // Create RMD income object - makes RMD visible to Roth conversion
+            const rmdIncome = new PassiveIncome(
+                `rmd-${account.id}-${year}`,
+                `RMD from ${account.name}`,
+                actualWithdrawal,
+                'Annually',
+                'No',
+                'RMD',
+                new Date(year, 0, 1),
+                new Date(year, 11, 31),
+                false
+            );
+            rmdIncomes.push(rmdIncome);
+
+            // Update totalGrossIncome so it includes RMD for cash flow calculations
+            totalGrossIncome += actualWithdrawal;
+            withdrawalState.totalGrossIncome = totalGrossIncome;
+
+            // Drain the account. This is the ONLY money movement — growAccounts applies
+            // userInflows to the balance (AccountGrowth.ts), so the Traditional account
+            // drops by exactly the RMD regardless of how it's later reported.
+            withdrawalState.userInflows[account.id] = (withdrawalState.userInflows[account.id] || 0) - actualWithdrawal;
+            totalRMDWithdrawn += actualWithdrawal;
+
+            // NOTE: the RMD is intentionally NOT added to withdrawalState.totalWithdrawals
+            // or withdrawalDetail. It is surfaced as spendable INCOME (a PassiveIncome with
+            // sourceType 'RMD', classified into `spendable` by IncomeClassifier), so adding
+            // it to the withdrawal tallies too would double-count the same dollars in the
+            // Sankey cash accounting (inflated `investedUser`/`totalInvested`). RMD = income
+            // that funds expenses, with any surplus reinvested.
+            logs.push(`📋 RMD from ${account.name}: $${actualWithdrawal.toLocaleString(undefined, { maximumFractionDigits: 0 })}`);
+        }
+    }
+
+    // Calculate shortfall and penalty
+    const shortfall = Math.max(0, totalRMDRequired - totalRMDWithdrawn);
+    const penalty = shortfall * 0.25;
+
+    if (shortfall > 0) {
+        logs.push(`[WARN] RMD shortfall: $${shortfall.toLocaleString(undefined, { maximumFractionDigits: 0 })} - Penalty: $${penalty.toLocaleString(undefined, { maximumFractionDigits: 0 })}`);
+    }
+
+    const rmdDetails: SimulationYear['rmdDetails'] = {
+        totalRMD: totalRMDRequired,
+        totalWithdrawn: totalRMDWithdrawn,
+        accountBreakdown: rmdCalculations,
+        shortfall: shortfall,
+        penalty: penalty
+    };
+
+    return {
+        rmdDetails,
+        rmdIncomes,
+        logs
+    };
+}

--- a/src/services/simulation/RothConversionDP.ts
+++ b/src/services/simulation/RothConversionDP.ts
@@ -1,0 +1,1358 @@
+/**
+ * RothConversionDP.ts
+ *
+ * Backward-induction dynamic-programming Roth conversion planner.
+ *
+ * Solved once over the full retirement horizon, this module produces a
+ * year-by-year conversion plan that minimizes lifetime tax under the
+ * deterministic baseline, with a small back-load preference (δ) layered
+ * on top. The result is a `Map<year, conversionAmount>` consumed by the
+ * DP-precomputed conversion strategy in YearSolver.
+ *
+ * State (3D): `(year, traditional_balance, roth_balance)`. Decision:
+ * this year's total Traditional → Roth conversion amount (including any
+ * std-ded-headroom portion that the baseline would do for free — the
+ * DP picks total).
+ *
+ * Cell evaluation: the year's spending need + this year's tax minus
+ * cash supplied by ordinary income forms a `gap`, which flows through
+ * the real-sim withdrawal order brokerage → roth → trad. Trad-spending
+ * is endogenous (depends on roth state and conversion size) and feeds
+ * back into ordinary income; we resolve via a small fixed-point
+ * iteration. `yearTax` is the year's actual tax; the V-table sums
+ * (yearTax + infeasibility-penalty × unmetNeed) across the horizon.
+ *
+ * V-table: `V[t]` is a flat `Float64Array` of size
+ * `(TRAD_BUCKETS+1) × (ROTH_BUCKETS+1)`. Backward sweep is a triple
+ * loop over `(t, tradIdx, rothIdx)` with an inner conversion loop;
+ * future cost is looked up via bilinear interpolation in (trad, roth).
+ * Forward extract walks `(trad, roth)` jointly from
+ * `(currentTradBalance, currentRothBalance)`.
+ *
+ * Approximations:
+ * - Brokerage is exogenous (per-year baseline cap, not state). Plans
+ *   that drain brokerage harder than baseline see an inflated cap in
+ *   later years — accepted to keep state at 3D.
+ * - LTCG income comes from baseline; plans diverging materially in
+ *   brokerage usage under-count LTCG tax. Same trade-off.
+ * - 5-year Roth-conversion withdrawal rule: not modeled.
+ * - IRMAA: not in the codebase yet; will flow through automatically
+ *   once `calculateEffectiveConversionTax` learns about it.
+ * - Monte-Carlo path divergence: handled at the call site by re-running
+ *   the DP per path.
+ */
+
+import { TaxParameters, FilingStatus } from "../../data/TaxData";
+import { TaxState } from "../../components/Objects/Taxes/TaxContext";
+import { AssumptionsState, getBirthYear } from "../../components/Objects/Assumptions/AssumptionsContext";
+import { SimulationYear, DPYearTrace } from "./types";
+import * as TaxService from "../../components/Objects/Taxes/TaxService";
+import { ACAOptions } from "./helpers";
+import { getDistributionPeriod, getRMDStartAge } from "../../data/RMDData";
+import { getAcaCliffThreshold } from "./TaxOptimizedWithdrawal";
+import { InvestedAccount } from "../../components/Objects/Accounts/models";
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/**
+ * Per-year back-load preference. Defined as:
+ *   V(t, b) = min over c of [tax(c) + (1 / (1 + δ)) × V(t+1, b')]
+ * δ > 0 makes future tax look slightly cheaper than present tax, biasing the
+ * optimal plan toward later conversions at the cost of some lifetime-tax
+ * efficiency. δ = 0 gives the lifetime-optimal (mildly front-loaded) plan.
+ *
+ * 0.015 = 1.5%/year — see project memory for rationale.
+ */
+export const DP_BACKLOAD_DELTA = 0.015;
+
+const TRAD_BUCKETS = 100;
+/**
+ * Roth-balance grid resolution for the 3D state extension. With
+ * `determineMaxRoth`'s upper bound of `(roth + trad) × growth^horizon × 1.3`,
+ * a typical 30-year retirement spans ~10× initial wealth, so 50 buckets
+ * gives ~$320k resolution on a $16M maxRoth — coarse but adequate for
+ * distinguishing "Roth depleted" from "Roth has cushion" (the dominant
+ * decision the roth dim drives). Halving from 100 to 50 also halves the
+ * 2D backward-sweep work, which dominates planConversionsViaDP runtime.
+ * Bump if optimization decisions look noisy in late-horizon years.
+ * Memory: (TRAD+1)*(ROTH+1)*horizon*8 = ~150 KB/year × 60yr ≈ 9 MB worst-case.
+ */
+const ROTH_BUCKETS = 50;
+const CONVERSION_BUCKETS = 200;
+const BALANCE_HEADROOM_FACTOR = 1.3;
+const MIN_BALANCE_RANGE = 100_000;
+const MIN_CONVERSION_RANGE = 10_000;
+/**
+ * Caps the per-year conversion grid. Without a cap, dC = currentTradBalance / 50,
+ * so a $1.5M trad portfolio gets $30k buckets — too coarse to pick std-deduction
+ * headroom (~$29k) precisely, and the DP rounds many years to $0. $500k easily
+ * spans the top federal bracket from $0 income, so any optimum will land below it.
+ */
+const MAX_CONVERSION_CAP = 500_000;
+const ACA_SUBSIDY_LOSS_DEFAULT = 12_000;
+/**
+ * Per-dollar penalty added to yearCost when a (year, trad, roth, conversion)
+ * cell can't fund the year's totalNeed (= spendingNeed + yearTax) from the
+ * waterfall. Without this, the DP would happily pick "drain trad to zero
+ * early so RMDs are 0 forever" because no future tax dominates a real
+ * lifetime — but that plan is bankrupt at age 70. Penalty makes infeasible
+ * plans strictly dominated. Tunable: $10/$1 unmet is heavy enough that the
+ * solver will choose any feasible alternative.
+ */
+const INFEASIBILITY_PENALTY_PER_DOLLAR = 10;
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Per-year exogenous context the DP needs: everything that does not change
+ * with the conversion decision. Built once from the baseline simulation.
+ */
+export interface DPYearContext {
+    year: number;
+    age: number;
+
+    /**
+     * Ordinary income on this year's tax return EXCLUDING SS, EXCLUDING the
+     * RMD (DP re-derives RMD from its own trad-balance state), and EXCLUDING
+     * any Roth conversion (DP's `c` decision variable IS the total conversion
+     * for the year — see evaluateCell, where it's added to ordIncomeBase).
+     * Including baseline conversion here would force the DP to think only of
+     * "extra above baseline," and the final sim — which executes whatever
+     * amount the DP returns — would then never replay the baseline std-ded
+     * portion.
+     */
+    nonSSOrdinaryIncomeExclRMD: number;
+    /** Gross SS benefits (taxable portion is computed inside calculateTotalFederalTax). */
+    ssBenefits: number;
+    /** Realized LTCG + qualified dividends. */
+    ltcgIncome: number;
+
+    filingStatus: FilingStatus;
+    fedParams: TaxParameters;
+    stateParams: TaxParameters | null;
+    acaOptions?: ACAOptions;
+
+    /** Trad withdrawal for spending in baseline (excludes RMD; approximated as constant across DP plans). Phase 2: still consumed by the (in-flight 2D) solver. Phase 3 replaces this with endogenous trad-spending in evaluateCell. */
+    baselineTradWithdrawal: number;
+
+    /**
+     * Pre-tax spending need for the year — `cashflow.totalExpense − (fed + state + fica)`.
+     * Used by the 3D solver (Phase 3) as the cash demand the waterfall must cover.
+     * Tax is excluded because the DP recomputes its own per-plan year-tax; including
+     * baseline tax here would double-count.
+     */
+    spendingNeed: number;
+    /**
+     * Brokerage balance ENTERING the year (= end of prior year), used by
+     * evaluateCell as the cap on `fromBrokerage` in the spending waterfall.
+     * For the first context year (= retirementYear), this is
+     * end-of-(retirementYear − 1) — pulled from baseline if available, else
+     * from the `startingBrokerageBalance` passed into `buildDPYearContexts`.
+     *
+     * Approximation note: brokerage is exogenous in pure-3D state, so each
+     * year's cap reflects baseline's brokerage trajectory, not the chosen
+     * plan's. A DP plan that drains brokerage harder than baseline will
+     * under-state the constraint in later years (cap = baseline's larger
+     * entering balance, not plan's depleted reality). Accepted to keep
+     * state at 3D; revisit if plans diverge materially from baseline
+     * brokerage usage.
+     */
+    baselineBrokerageAvailable: number;
+    /** Net growth rate for Roth accounts (mirrors `growthRate` for trad). */
+    rothGrowthRate: number;
+
+    /** Diagnostic only: baseline (std-ded-only sub-sim) Roth/brokerage/trad for this year. Not consumed by the solver — printed in per-year debug to make DP-vs-reality divergence visible. */
+    baselineRothBalance?: number;
+    baselineBrokerageBalance?: number;
+    baselineTradBalance?: number;
+    /** Diagnostic only: baseline sub-sim's actual conversion amount this year. */
+    baselineConversionAmount?: number;
+    /** Diagnostic only — set on the FIRST context: baseline trad at (retirementYear − 1). Used to detect off-by-one between DP starting balance and where real-sim's trad actually is at retirement-year start. */
+    diagnosticPreRetirementBaselineTrad?: number;
+
+    /** Net (RoR − weighted ER) growth rate for trad accounts. */
+    growthRate: number;
+    /** Distribution-period divisor for RMD (0 if age < RMD start age). */
+    rmdDivisor: number;
+}
+
+/** Inputs to the DP solver. */
+export interface DPInputs {
+    contexts: DPYearContext[];
+    /** Current Traditional balance — the DP's starting trad-balance state. */
+    currentTradBalance: number;
+    /**
+     * Current Roth balance — the DP's starting roth-balance state for the
+     * 3D extension. Phase 1 plumbs this through but the solver does not yet
+     * branch on it (V-table is still 1D in trad). Phase 4 wires it in.
+     */
+    currentRothBalance: number;
+    /**
+     * Per-year back-load preference. Defaults to DP_BACKLOAD_DELTA.
+     * Exposed as a parameter so tests can pin δ = 0 for deterministic checks.
+     */
+    backloadDelta?: number;
+}
+
+/** Diagnostic info surfaced to the debug page. */
+export interface DPDiagnostics {
+    backloadDelta: number;
+    tradBuckets: number;
+    rothBuckets: number;
+    conversionBuckets: number;
+    /**
+     * Legacy max-of-horizon scalars (kept for backward compatibility with
+     * existing diagnostic consumers and tests). The 3D solver actually
+     * uses per-year scales `dBByYear` / `dRothByYear` below.
+     */
+    maxBalance: number;
+    maxRoth: number;
+    dB: number;
+    dRoth: number;
+    /**
+     * Per-year V-table grid scales. Index `t` is the bucket width at the
+     * START of year `t`; length is `horizonYears + 1`. Each year's grid
+     * adapts to that year's reachable (trad, roth) range so early years
+     * (where conversion decisions matter) get fine resolution and late
+     * years (where roth has compounded) get coarser buckets.
+     */
+    dBByYear: number[];
+    dRothByYear: number[];
+    /**
+     * Per-year conversion-grid bucket width. Index `t` is the conversion
+     * bucket size for year `t`; the largest candidate that year is
+     * `CONVERSION_BUCKETS × dCByYear[t]`. Sized to year `t`'s reachable
+     * trad balance so late-year conversions above the year-0 ceiling are
+     * still evaluated.
+     */
+    dCByYear: number[];
+    dC: number;
+    maxConversion: number;
+    horizonYears: number;
+    elapsedMs: number;
+    /** Per-year (year → recommended conversion amount). Same data as conversionsByYear, kept for chart rendering. */
+    perYearAmounts: Array<{ year: number; age: number; amount: number; estimatedTradBalance: number }>;
+    /** Debug log lines summarizing solver setup, grid, and per-year forward-walk decisions. */
+    summaryLogs: string[];
+    /** Per-year debug strings keyed by simulation year. Consumed by planConversionDP and pushed into the year's decisions/logs. */
+    perYearDebug: Map<number, string[]>;
+    /**
+     * Structured per-year traces (numeric form of [DEBUG DP …] logs). Consumed
+     * by the Roth debug screen to render the cost curve, waterfall, and
+     * balance-flow visualizations.
+     */
+    perYearTraces: Map<number, DPYearTrace>;
+}
+
+export interface DPPlan {
+    conversionsByYear: Map<number, number>;
+    diagnostics: DPDiagnostics;
+}
+
+// =============================================================================
+// CONTEXT EXTRACTION
+// =============================================================================
+
+/**
+ * Sum brokerage balances for a SimulationYear. Diagnostic only.
+ */
+function sumBrokerageBalanceDiag(simYear: SimulationYear): number {
+    return simYear.accounts
+        .filter((acc): acc is InvestedAccount =>
+            acc instanceof InvestedAccount && acc.taxType === 'Brokerage'
+        )
+        .reduce((sum, acc) => sum + acc.vestedAmount, 0);
+}
+
+/**
+ * Sum Roth balances for a SimulationYear. Diagnostic only.
+ */
+function sumRothBalanceDiag(simYear: SimulationYear): number {
+    return simYear.accounts
+        .filter((acc): acc is InvestedAccount =>
+            acc instanceof InvestedAccount && acc.taxType === 'Roth IRA'
+        )
+        .reduce((sum, acc) => sum + acc.vestedAmount, 0);
+}
+
+/**
+ * Sum traditional balances for a SimulationYear. Diagnostic only.
+ */
+function sumTradBalanceDiag(simYear: SimulationYear): number {
+    return simYear.accounts
+        .filter((acc): acc is InvestedAccount =>
+            acc instanceof InvestedAccount &&
+            (acc.taxType === 'Traditional 401k' || acc.taxType === 'Traditional IRA')
+        )
+        .reduce((sum, acc) => sum + acc.vestedAmount, 0);
+}
+
+/**
+ * Sum trad withdrawals from this year's withdrawalDetail. RMDs are no longer in
+ * withdrawalDetail (they're surfaced as income), so this is already RMD-free.
+ */
+function sumTraditionalWithdrawals(simYear: SimulationYear): number {
+    const traditionalNames = new Set(
+        simYear.accounts
+            .filter((acc): acc is InvestedAccount =>
+                acc instanceof InvestedAccount &&
+                (acc.taxType === 'Traditional 401k' || acc.taxType === 'Traditional IRA')
+            )
+            .map(acc => acc.name)
+    );
+    let total = 0;
+    for (const [name, amount] of Object.entries(simYear.cashflow.withdrawalDetail || {})) {
+        if (traditionalNames.has(name)) total += amount;
+    }
+    return total;
+}
+
+/**
+ * Compute the balance-weighted net growth rate for trad accounts in this
+ * baseline year. Mirrors InvestedAccount.increment (models.tsx:199-201) so
+ * DP's forward sweep tracks real-sim's actual trad evolution. Per-account
+ * formula: (customROR ?? globalROR) + inflationAdjustment − expenseRatio.
+ * Inflation is added when assumptions.macro.inflationAdjusted is true (the
+ * sim runs in nominal dollars). Weighted by vested balance across trad
+ * accounts.
+ */
+function getNetGrowthRate(simYear: SimulationYear, assumptions: AssumptionsState): number {
+    const tradAccounts = simYear.accounts.filter((acc): acc is InvestedAccount =>
+        acc instanceof InvestedAccount &&
+        (acc.taxType === 'Traditional 401k' || acc.taxType === 'Traditional IRA')
+    );
+    const globalRoR = assumptions.investments.returnRates.ror ?? 7;
+    const inflationAdjustment = assumptions.macro.inflationAdjusted
+        ? assumptions.macro.inflationRate
+        : 0;
+    const totalBalance = tradAccounts.reduce((s, a) => s + a.vestedAmount, 0);
+    if (totalBalance <= 0) {
+        return (globalRoR + inflationAdjustment) / 100;
+    }
+    const weightedRatePct = tradAccounts.reduce((sum, a) => {
+        const ror = a.customROR ?? globalRoR;
+        const accountRatePct = ror + inflationAdjustment - a.expenseRatio;
+        return sum + accountRatePct * a.vestedAmount;
+    }, 0) / totalBalance;
+    return weightedRatePct / 100;
+}
+
+/**
+ * Same formula as `getNetGrowthRate` but filtering for Roth accounts. Used
+ * by the 3D solver to project Roth-balance evolution year-over-year. When
+ * a baseline year has no Roth balance, falls back to the global RoR (DP
+ * may project a Roth balance even where baseline has none, e.g. via
+ * conversions earlier in the plan).
+ */
+function getRothGrowthRate(simYear: SimulationYear, assumptions: AssumptionsState): number {
+    const rothAccounts = simYear.accounts.filter((acc): acc is InvestedAccount =>
+        acc instanceof InvestedAccount && acc.taxType === 'Roth IRA'
+    );
+    const globalRoR = assumptions.investments.returnRates.ror ?? 7;
+    const inflationAdjustment = assumptions.macro.inflationAdjusted
+        ? assumptions.macro.inflationRate
+        : 0;
+    const totalBalance = rothAccounts.reduce((s, a) => s + a.vestedAmount, 0);
+    if (totalBalance <= 0) {
+        return (globalRoR + inflationAdjustment) / 100;
+    }
+    const weightedRatePct = rothAccounts.reduce((sum, a) => {
+        const ror = a.customROR ?? globalRoR;
+        const accountRatePct = ror + inflationAdjustment - a.expenseRatio;
+        return sum + accountRatePct * a.vestedAmount;
+    }, 0) / totalBalance;
+    return weightedRatePct / 100;
+}
+
+/**
+ * Build per-year contexts from a baseline simulation timeline.
+ *
+ * The baseline should be a std-ded-only, no-extra-conversion full-horizon sim
+ * (so its `nonSSOrdinaryIncome` does not include the conversion the DP is
+ * deciding). Out-of-retirement years (before retirementAge) are skipped.
+ */
+export function buildDPYearContexts(
+    baseline: SimulationYear[],
+    assumptions: AssumptionsState,
+    taxState: TaxState,
+    retirementYear: number,
+    /**
+     * Brokerage balance entering the FIRST context year (= retirementYear).
+     * Falls back to baseline lookup at (retirementYear − 1) when that year
+     * is in the baseline; this param covers the already-retired-today case
+     * where no prior baseline year exists. Subsequent contexts always use
+     * baseline's prior-year ending balance.
+     */
+    startingBrokerageBalance: number,
+): DPYearContext[] {
+    const contexts: DPYearContext[] = [];
+    const birthYear = getBirthYear(assumptions.milestones);
+    const rmdStartAge = getRMDStartAge(birthYear);
+
+    // Diagnostic: capture the baseline sub-sim's trad balance at the year
+    // BEFORE retirement. If `currentTradBalance` (used by DP's forward sweep)
+    // matches this value, it means the lookup is grabbing the end-of-(year
+    // before retirement) record — which is the correct start-of-retirement
+    // state. If `currentTradBalance` matches baselineTrad@retirementYear
+    // (which is what the existing setup log compares), there's a one-year
+    // off-by-one (DP is starting from end-of-retirement-year-1 baseline).
+    const preRetirementSimYear = baseline.find(y => y.year === retirementYear - 1);
+    const preRetirementBaselineTrad = preRetirementSimYear
+        ? sumTradBalanceDiag(preRetirementSimYear)
+        : undefined;
+
+    // Track the previous sim year so each context can record the brokerage
+    // balance ENTERING that year (= prior year's end). For the first context
+    // (= retirementYear), prev = preRetirementSimYear; if that doesn't
+    // exist (retiring in year 0 of the sim), fall back to startingBrokerageBalance.
+    let prevSimYear: SimulationYear | undefined = preRetirementSimYear;
+
+    for (const simYear of baseline) {
+        if (simYear.year < retirementYear) {
+            prevSimYear = simYear;
+            continue;
+        }
+        const age = simYear.year - birthYear;
+
+        const ssBenefits = TaxService.getSocialSecurityBenefits(simYear.incomes, simYear.year);
+        const grossIncome = TaxService.getGrossIncome(simYear.incomes, simYear.year);
+
+        // Traditional non-RMD withdrawals are taxed as ordinary income but aren't
+        // tracked as Income objects. Phase 2: trad-spending becomes endogenous in
+        // the 3D solver (Phase 3's evaluateCell rewrite); we no longer add
+        // baseline trad-spending into nonSSOrdinaryIncomeExclRMD. Still computed
+        // to populate `baselineTradWithdrawal`, which the in-flight 2D solver
+        // uses until Phase 3 lands.
+        // withdrawalDetail no longer includes RMD (RMD is surfaced as income), so the
+        // trad withdrawal sum is already RMD-free — no subtraction needed.
+        const tradNonRMDWithdrawals = sumTraditionalWithdrawals(simYear);
+        const baselineRMDAmount = simYear.rmdDetails?.totalRMD ?? 0;
+
+        // getGrossIncome includes RMD (PassiveIncome with sourceType='RMD') but
+        // excludes conversions and non-RMD trad withdrawals. We want
+        // plan-INDEPENDENT ordinary-on-return — wages/pension/passive — EXCLUDING
+        // RMD, SS, conversion, AND baseline trad withdrawals. RMD, conversion,
+        // and trad-spending are added back inside evaluateCell using state-derived
+        // amounts (Phase 3 makes trad-spending endogenous; Phase 2 leaves a
+        // brief inconsistency where the 2D solver under-counts ordinary income
+        // in trad-spending years).
+        const nonSSOrdinaryIncomeExclRMD = Math.max(
+            0,
+            grossIncome - ssBenefits - baselineRMDAmount,
+        );
+        const ltcgIncome = simYear.taxDetails.longTermCapitalGains ?? 0;
+
+        const fedParams = TaxService.getTaxParameters(
+            simYear.year, taxState.filingStatus, 'federal', undefined, assumptions
+        );
+        if (!fedParams) continue;
+        const stateParams = TaxService.getTaxParameters(
+            simYear.year, taxState.filingStatus, 'state', taxState.stateResidency, assumptions
+        );
+
+        // ACA cliff applies pre-65 only (Medicare eligibility starts at 65).
+        let acaOptions: ACAOptions | undefined;
+        if (assumptions.investments.acaAware !== false && age < 65) {
+            const acaFiling: 'single' | 'married_filing_jointly' =
+                taxState.filingStatus === 'Married Filing Jointly' ? 'married_filing_jointly' : 'single';
+            acaOptions = {
+                currentAge: age,
+                acaSubsidyAware: true,
+                acaCliffThreshold: getAcaCliffThreshold(acaFiling, simYear.year),
+                estimatedSubsidyLoss: ACA_SUBSIDY_LOSS_DEFAULT,
+            };
+        }
+
+        const growthRate = getNetGrowthRate(simYear, assumptions);
+        const rothGrowthRate = getRothGrowthRate(simYear, assumptions);
+        const rmdDivisor = age >= rmdStartAge ? getDistributionPeriod(age) : 0;
+
+        // Pre-tax spending need: cashflow.totalExpense includes baseline taxes,
+        // which the DP recomputes per-plan. Strip them so we don't double-count.
+        // Early-withdrawal penalty is rolled into `fed` already.
+        const baselineTaxes =
+            (simYear.taxDetails.fed ?? 0)
+            + (simYear.taxDetails.state ?? 0)
+            + (simYear.taxDetails.fica ?? 0);
+        const spendingNeed = Math.max(
+            0,
+            (simYear.cashflow.totalExpense ?? 0) - baselineTaxes,
+        );
+
+        // Brokerage entering this year. For the first context (= retirementYear),
+        // prevSimYear is preRetirementSimYear (year retirementYear − 1) when
+        // available; otherwise fall back to the caller-supplied
+        // startingBrokerageBalance. For subsequent retirement years, prevSimYear
+        // is always populated from the prior loop iteration.
+        const baselineBrokerageAvailable = prevSimYear
+            ? sumBrokerageBalanceDiag(prevSimYear)
+            : startingBrokerageBalance;
+
+        contexts.push({
+            year: simYear.year,
+            age,
+            nonSSOrdinaryIncomeExclRMD,
+            ssBenefits,
+            ltcgIncome,
+            filingStatus: taxState.filingStatus,
+            fedParams,
+            stateParams: stateParams ?? null,
+            acaOptions,
+            baselineTradWithdrawal: tradNonRMDWithdrawals,
+            spendingNeed,
+            baselineBrokerageAvailable,
+            rothGrowthRate,
+            baselineRothBalance: sumRothBalanceDiag(simYear),
+            baselineBrokerageBalance: sumBrokerageBalanceDiag(simYear),
+            baselineTradBalance: sumTradBalanceDiag(simYear),
+            baselineConversionAmount: simYear.rothConversion?.amount ?? 0,
+            // Attach the pre-retirement diagnostic only to the FIRST context
+            // (i.e., when this is the first push for retirementYear).
+            diagnosticPreRetirementBaselineTrad:
+                contexts.length === 0 ? preRetirementBaselineTrad : undefined,
+            growthRate,
+            rmdDivisor,
+        });
+
+        prevSimYear = simYear;
+    }
+
+    return contexts;
+}
+
+// =============================================================================
+// CELL EVALUATION
+// =============================================================================
+
+/**
+ * Compute this year's absolute total tax (federal + state + ACA penalty) for
+ * a given total ordinary-income figure. The DP's V-table accumulates these
+ * absolute taxes across the horizon, which lets it see future-RMD savings
+ * from a today-conversion (lower future trad → lower future RMD → lower
+ * future ordinary income → lower future absolute tax). A conversion's
+ * marginal tax cost is just `yearTax(with conv) − yearTax(without conv)`.
+ */
+function computeYearTax(
+    ordinaryIncome: number,
+    ctx: DPYearContext,
+): number {
+    const fed = TaxService.calculateTotalFederalTax(
+        ordinaryIncome,
+        ctx.ssBenefits,
+        0,                       // STCG
+        ctx.ltcgIncome,
+        0,                       // preTaxDeductions (already in nonSSOrdinaryIncomeExclRMD)
+        ctx.filingStatus,
+        ctx.fedParams,
+    ).totalTax;
+
+    let state = 0;
+    if (ctx.stateParams) {
+        // Most states tax LTCG as ordinary. SS treatment mirrors the real sim's
+        // calculateUnifiedStateTax (stateTax.ts): `ordinaryIncome` here already
+        // EXCLUDES SS, so the state base is non-SS ordinary + LTCG, plus — only
+        // for states that tax SS — the IRS-taxable portion of SS. SS-taxing
+        // states (e.g. via the SS torpedo) make a conversion that raises
+        // provisional income create real state tax the DP must price in.
+        let stateBase = ordinaryIncome + ctx.ltcgIncome;
+        if (ctx.ssBenefits > 0 && ctx.stateParams.socialSecurityTreatment === 'taxable') {
+            // agiExcludingSS = non-SS ordinary + LTCG (preTaxDeductions already
+            // folded into nonSSOrdinaryIncomeExclRMD upstream).
+            const taxableSS = TaxService.getTaxableSocialSecurityBenefits(
+                ctx.ssBenefits,
+                ordinaryIncome + ctx.ltcgIncome,
+                0,
+                ctx.filingStatus,
+            );
+            stateBase += taxableSS;
+        }
+        state = TaxService.calculateTax(stateBase, 0, ctx.stateParams);
+    }
+
+    let acaPenalty = 0;
+    if (ctx.acaOptions) {
+        // ACA MAGI ≈ ordinaryIncome + full SS + LTCG. Cliff is binary at threshold.
+        const magi = ordinaryIncome + ctx.ssBenefits + ctx.ltcgIncome;
+        if (magi >= ctx.acaOptions.acaCliffThreshold) {
+            acaPenalty = ctx.acaOptions.estimatedSubsidyLoss;
+        }
+    }
+
+    return fed + state + acaPenalty;
+}
+
+/**
+ * Single-cell evaluation (3D-ready): given (tradBalance, rothBalance,
+ * conversion, ctx), simulate the year's spending waterfall and tax in
+ * one shot.
+ *
+ * Tax routing mirrors the real sim's WITHHOLD path: the year's gap
+ * (spending need + this-year tax − cash from ordinary income) flows
+ * through the withdrawal order brokerage → roth → trad. The portion that
+ * ends up coming from trad (`tradSpending`) becomes ordinary income and
+ * feeds back into the tax calc. yearTax and tradSpending are coupled, so
+ * we resolve via a small fixed-point iteration. Most years converge in 0
+ * iterations because there's enough brokerage + Roth (or enough ordinary
+ * income from SS/RMD/pension) to keep tradSpending = 0 — the
+ * initial-guess yearTax is already exact.
+ *
+ * Returns:
+ * - `yearTax`: actual federal + state + ACA tax (no infeasibility penalty;
+ *   the solver applies that separately via `unmetNeed`).
+ * - `conversionMarginal`: yearTax − taxBaseline (diagnostic only).
+ * - `tradNext`, `rothNext`: end-of-year balances after flows + growth.
+ * - `tradSpending`, `fromRoth`, `fromBrokerage`: waterfall breakdown for
+ *   diagnostics.
+ * - `unmetNeed`: dollars of `totalNeed` the waterfall couldn't source
+ *   (means the plan ran out of money this year). Solver penalizes via
+ *   INFEASIBILITY_PENALTY_PER_DOLLAR.
+ *
+ * `taxBaseline` is `computeYearTax(ordinaryIncomeBase, ctx)` — i.e. tax
+ * with conversion = 0 and no trad-spending. Used only for the marginal
+ * diagnostic. Cached by the caller so the inner conversion-loop doesn't
+ * recompute it 200× per (year, trad, roth).
+ *
+ * Brokerage is exogenous (per-year baseline cap, not state) — see module
+ * header. LTCG is taken from baseline as well; if a DP plan draws much
+ * more from brokerage than baseline, this under-counts LTCG tax. Known
+ * limitation, accepted to keep state at 3D.
+ */
+function evaluateCell(
+    tradBalance: number,
+    rothBalance: number,
+    conversion: number,
+    ctx: DPYearContext,
+    taxBaseline: number,
+    /**
+     * Pre-computed initial-guess tax = `computeYearTax(ordIncomeExclTradSpend,
+     * ctx)`, i.e. the year's tax assuming zero trad-spending. This quantity
+     * depends only on (conversion, tradBalance via RMD) and NOT on
+     * rothBalance, so the backward sweep hoists it out of the rothIdx loop and
+     * passes it in to avoid recomputing the full fed+state+SS tax once per
+     * rothIdx. When omitted (forward extract / debug-curve paths), it's
+     * computed inline as before. The fixed-point still recomputes tax inside
+     * the loop whenever trad-spending > 0 (the roth-dependent path), so
+     * results are numerically identical.
+     */
+    precomputedInitialTax?: number,
+): {
+    yearTax: number;
+    conversionMarginal: number;
+    tradNext: number;
+    rothNext: number;
+    tradSpending: number;
+    fromRoth: number;
+    fromBrokerage: number;
+    unmetNeed: number;
+} {
+    const rmd = ctx.rmdDivisor > 0 ? tradBalance / ctx.rmdDivisor : 0;
+    const ordIncomeExclTradSpend = ctx.nonSSOrdinaryIncomeExclRMD + rmd + conversion;
+    const tradAvailableForSpending = Math.max(0, tradBalance - conversion - rmd);
+
+    // Cash that ordinary income provides this year — wages/pension/passive
+    // (nonSSOrdExclRMD), full SS benefits, and RMD all land in the user's
+    // pocket and offset the spending+tax demand. Without this offset the
+    // waterfall would over-source by the full ordinary-income amount, which
+    // in late retirement years (SS+RMD) can be tens of thousands of dollars.
+    // Conversion is intentionally NOT in here: a conversion creates ordinary
+    // income for tax purposes but is a Trad→Roth transfer, not cash.
+    const cashFromOrdinary =
+        ctx.nonSSOrdinaryIncomeExclRMD + ctx.ssBenefits + rmd;
+
+    // Initial guess: tax assuming no trad-spending. This is exact when the
+    // waterfall can cover totalNeed from brokerage + roth alone (the common
+    // case in early retirement years). Depends only on (conversion,
+    // tradBalance) — the backward sweep precomputes it once per (tradIdx,
+    // convIdx) and passes it in (see precomputedInitialTax docs).
+    let yearTax = precomputedInitialTax !== undefined
+        ? precomputedInitialTax
+        : computeYearTax(ordIncomeExclTradSpend, ctx);
+    let fromBrokerage = 0;
+    let fromRoth = 0;
+    let tradSpending = 0;
+
+    // Fixed-point: yearTax → totalNeed → waterfall → tradSpending →
+    // ordIncome → yearTax. Up to 5 iterations; in practice 1-2.
+    for (let iter = 0; iter < 5; iter++) {
+        // totalNeed is the cash gap the waterfall must source: spending
+        // demand (livingPlusPayroll + this year's tax) minus cash supplied
+        // by ordinary income. Clamped to ≥ 0 — surplus years have no gap.
+        const totalNeed = Math.max(
+            0,
+            ctx.spendingNeed + yearTax - cashFromOrdinary,
+        );
+        fromBrokerage = Math.min(totalNeed, ctx.baselineBrokerageAvailable);
+        const remainingAfterBrokerage = totalNeed - fromBrokerage;
+        fromRoth = Math.min(remainingAfterBrokerage, rothBalance);
+        const tradSpendingNeeded = Math.max(0, remainingAfterBrokerage - fromRoth);
+        tradSpending = Math.min(tradSpendingNeeded, tradAvailableForSpending);
+
+        // No trad-spending ⇒ initial yearTax guess was exact, done.
+        if (tradSpending === 0) break;
+
+        const ordIncome = ordIncomeExclTradSpend + tradSpending;
+        const newYearTax = computeYearTax(ordIncome, ctx);
+        if (Math.abs(newYearTax - yearTax) < 1) {
+            yearTax = newYearTax;
+            break;
+        }
+        yearTax = newYearTax;
+    }
+
+    const totalNeedFinal = Math.max(
+        0,
+        ctx.spendingNeed + yearTax - cashFromOrdinary,
+    );
+    const sourced = fromBrokerage + fromRoth + tradSpending;
+    const unmetNeed = Math.max(0, totalNeedFinal - sourced);
+
+    const conversionMarginal = Math.max(0, yearTax - taxBaseline);
+    const tradNext = Math.max(0, tradBalance - conversion - rmd - tradSpending) * (1 + ctx.growthRate);
+    const rothNext = Math.max(0, rothBalance + conversion - fromRoth) * (1 + ctx.rothGrowthRate);
+
+    return {
+        yearTax,
+        conversionMarginal,
+        tradNext,
+        rothNext,
+        tradSpending,
+        fromRoth,
+        fromBrokerage,
+        unmetNeed,
+    };
+}
+
+/**
+ * Bilinear interpolation lookup into a 2D value-function table indexed by
+ * (tradIdx, rothIdx). The table is stored as a flat Float64Array with stride
+ * (ROTH_BUCKETS + 1) in the roth dimension — element at (tradIdx, rothIdx)
+ * lives at `V[tradIdx * (rothBuckets + 1) + rothIdx]`.
+ *
+ * Out-of-grid values clamp to the table boundary in each dimension. Returns
+ * the bilinear blend of the four enclosing corner samples weighted by the
+ * fractional position within the (trad, roth) cell.
+ */
+function interpV2D(
+    V: Float64Array,
+    tradBalance: number,
+    rothBalance: number,
+    dB: number,
+    dRoth: number,
+    tradBuckets: number,
+    rothBuckets: number,
+): number {
+    const trad = tradBalance < 0 ? 0 : tradBalance;
+    const roth = rothBalance < 0 ? 0 : rothBalance;
+
+    let tIdx = trad / dB;
+    let rIdx = roth / dRoth;
+    if (tIdx > tradBuckets) tIdx = tradBuckets;
+    if (rIdx > rothBuckets) rIdx = rothBuckets;
+
+    const t0 = tIdx | 0;
+    const r0 = rIdx | 0;
+    const t1 = t0 < tradBuckets ? t0 + 1 : tradBuckets;
+    const r1 = r0 < rothBuckets ? r0 + 1 : rothBuckets;
+
+    const tFrac = tIdx - t0;
+    const rFrac = rIdx - r0;
+
+    const stride = rothBuckets + 1;
+    const v00 = V[t0 * stride + r0];
+    const v01 = V[t0 * stride + r1];
+    const v10 = V[t1 * stride + r0];
+    const v11 = V[t1 * stride + r1];
+
+    const v0 = v00 * (1 - rFrac) + v01 * rFrac;
+    const v1 = v10 * (1 - rFrac) + v11 * rFrac;
+    return v0 * (1 - tFrac) + v1 * tFrac;
+}
+
+// =============================================================================
+// SOLVER
+// =============================================================================
+
+/**
+ * Compute per-year grid scales (`dBByYear`, `dRothByYear`) for the V-table.
+ *
+ * A single uniform grid is the wrong shape for a long-horizon DP: realistic
+ * roth/trad values span ~$200k–$2M in year 1 but compound to tens of
+ * millions over a 40+ year horizon. With one `dRoth`, either early-year
+ * values fall inside a single bucket (interp manufactures fake costs from
+ * unreachable corners) or late-year values exceed the grid (clipped at
+ * boundary). Per-year scales adapt to each year's reachable range.
+ *
+ * Bounds are derived from two independent forward simulations:
+ * - **Trad-max trajectory** (no conversions, no spending): RMD + growth
+ *   only. Maximizes the trad balance reachable at year `t`.
+ * - **Roth-max trajectory** (convert MAX_CONVERSION_CAP/yr, no spending,
+ *   no withdrawals): drains trad into roth as fast as the inner-loop
+ *   conversion cap allows, then lets the roth pile compound. Maximizes
+ *   the roth balance reachable at year `t`.
+ *
+ * Both bounds get a 30% headroom factor and a `MIN_BALANCE_RANGE` floor
+ * so the grid stays usable for small portfolios. Returned arrays have
+ * length `horizonYears + 1` (index `t` covers V[t]'s start-of-year-`t`
+ * state space; index `horizonYears` is the terminal V-table).
+ */
+function determineGridScales(
+    contexts: DPYearContext[],
+    currentTradBalance: number,
+    currentRothBalance: number,
+): { dBByYear: number[]; dRothByYear: number[]; dCByYear: number[] } {
+    const horizonYears = contexts.length;
+    const tradMaxByYear: number[] = new Array(horizonYears + 1);
+    const rothMaxByYear: number[] = new Array(horizonYears + 1);
+    tradMaxByYear[0] = currentTradBalance;
+    rothMaxByYear[0] = currentRothBalance;
+
+    // Trad-max trajectory: no conversions, no spending.
+    {
+        let trad = currentTradBalance;
+        for (let t = 0; t < horizonYears; t++) {
+            const ctx = contexts[t];
+            const rmd = ctx.rmdDivisor > 0 ? trad / ctx.rmdDivisor : 0;
+            trad = Math.max(0, trad - rmd) * (1 + ctx.growthRate);
+            tradMaxByYear[t + 1] = trad;
+        }
+    }
+
+    // Roth-max trajectory: convert as fast as the per-year cap allows.
+    {
+        let trad = currentTradBalance;
+        let roth = currentRothBalance;
+        for (let t = 0; t < horizonYears; t++) {
+            const ctx = contexts[t];
+            const rmd = ctx.rmdDivisor > 0 ? trad / ctx.rmdDivisor : 0;
+            const conv = Math.min(MAX_CONVERSION_CAP, Math.max(0, trad - rmd));
+            trad = Math.max(0, trad - conv - rmd) * (1 + ctx.growthRate);
+            roth = (roth + conv) * (1 + ctx.rothGrowthRate);
+            rothMaxByYear[t + 1] = roth;
+        }
+    }
+
+    const dBByYear = tradMaxByYear.map(v =>
+        Math.max(MIN_BALANCE_RANGE, v * BALANCE_HEADROOM_FACTOR) / TRAD_BUCKETS
+    );
+    const dRothByYear = rothMaxByYear.map(v =>
+        Math.max(MIN_BALANCE_RANGE, v * BALANCE_HEADROOM_FACTOR) / ROTH_BUCKETS
+    );
+
+    // Per-year conversion grid: each year's dC scales to that year's
+    // reachable trad balance (the no-conversion/no-spending trad-max
+    // trajectory), applying the MAX_CONVERSION_CAP ceiling and
+    // MIN_CONVERSION_RANGE floor off the projected balance rather than the
+    // year-0 balance.
+    // This preserves fine early-year resolution AND full late-year reach,
+    // so conversions between the old year-0 ceiling and a later cell's true
+    // cMax are no longer silently truncated.
+    const dCByYear = tradMaxByYear.map(v =>
+        Math.min(MAX_CONVERSION_CAP, Math.max(MIN_CONVERSION_RANGE, v)) / CONVERSION_BUCKETS
+    );
+
+    return { dBByYear, dRothByYear, dCByYear };
+}
+
+/**
+ * Run the DP backward sweep + forward extract, producing a per-year plan.
+ */
+export function planConversionsViaDP(inputs: DPInputs): DPPlan {
+    const startedAt = performance.now();
+    const { contexts, currentTradBalance, currentRothBalance } = inputs;
+    const delta = inputs.backloadDelta ?? DP_BACKLOAD_DELTA;
+    const discountFactor = 1 / (1 + delta);
+
+    const horizonYears = contexts.length;
+
+    // Empty-horizon edge case.
+    if (horizonYears === 0) {
+        return {
+            conversionsByYear: new Map(),
+            diagnostics: {
+                backloadDelta: delta,
+                tradBuckets: TRAD_BUCKETS,
+                rothBuckets: ROTH_BUCKETS,
+                conversionBuckets: CONVERSION_BUCKETS,
+                maxBalance: 0,
+                maxRoth: 0,
+                dB: 0,
+                dRoth: 0,
+                dBByYear: [],
+                dRothByYear: [],
+                dCByYear: [],
+                dC: 0,
+                maxConversion: 0,
+                horizonYears: 0,
+                elapsedMs: 0,
+                perYearAmounts: [],
+                summaryLogs: ['[DEBUG DP] Empty horizon — no contexts to solve.'],
+                perYearDebug: new Map(),
+                perYearTraces: new Map(),
+            },
+        };
+    }
+
+    const { dBByYear, dRothByYear, dCByYear } = determineGridScales(
+        contexts, currentTradBalance, currentRothBalance,
+    );
+    // Legacy/representative scalars: max-of-horizon. Some diagnostics
+    // consumers (and tests) reference `dB`, `dRoth`, `maxBalance`,
+    // `maxRoth` as scalars; we surface the worst-case bucket width across
+    // the horizon for backward compatibility.
+    const dB = Math.max(...dBByYear);
+    const dRoth = Math.max(...dRothByYear);
+    const maxBalance = dB * TRAD_BUCKETS;
+    const maxRoth = dRoth * ROTH_BUCKETS;
+    // Representative scalars for diagnostics: the conversion grid is now
+    // per-year (dCByYear), so surface the widest bucket across the horizon
+    // (and its implied ceiling) for the DPDiagnostics fields and any
+    // consumer (e.g. RothConversionDebug.tsx) that reads scalar dC /
+    // maxConversion. The solver itself uses dCByYear[t] per cell.
+    const dC = Math.max(...dCByYear);
+    const maxConversion = dC * CONVERSION_BUCKETS;
+    const summaryLogs: string[] = [];
+    const perYearDebug = new Map<number, string[]>();
+    const perYearTraces = new Map<number, DPYearTrace>();
+    const fmt$ = (n: number) => '$' + Math.round(n).toLocaleString();
+    const vTableMB =
+        ((TRAD_BUCKETS + 1) * (ROTH_BUCKETS + 1) * (horizonYears + 1) * 8) / (1024 * 1024);
+    summaryLogs.push(
+        `[DEBUG DP] solver: δ=${(delta * 100).toFixed(2)}%, df=${discountFactor.toFixed(4)}, ` +
+        `tradBuckets=${TRAD_BUCKETS}, rothBuckets=${ROTH_BUCKETS}, convBuckets=${CONVERSION_BUCKETS}, ` +
+        `maxConversion=${fmt$(maxConversion)} (dC=${fmt$(dC)}), horizon=${horizonYears} years, ` +
+        `V-table 2D ≈ ${vTableMB.toFixed(2)} MB`,
+    );
+    // Per-year grid scales. Each year `t` has its own dB[t]/dRoth[t]
+    // sized to that year's reachable (trad, roth) range. Early years
+    // get fine resolution where conversion decisions matter; late years
+    // get looser buckets where roth has compounded but decisions are
+    // already locked in. Sample the first few years and a midpoint plus
+    // the last to see the shape — printing all 46+ years would be noise.
+    const sampleYears = Array.from(new Set([
+        0, 1, 5,
+        Math.floor(horizonYears / 2),
+        horizonYears - 1, horizonYears,
+    ].filter(t => t >= 0 && t <= horizonYears)));
+    const dBSamples = sampleYears
+        .map(t => `t=${t}:${fmt$(dBByYear[t])}`).join(', ');
+    const dRothSamples = sampleYears
+        .map(t => `t=${t}:${fmt$(dRothByYear[t])}`).join(', ');
+    summaryLogs.push(
+        `[DEBUG DP] per-year dB (trad bucket width): ${dBSamples}`,
+    );
+    summaryLogs.push(
+        `[DEBUG DP] per-year dRoth (roth bucket width): ${dRothSamples}`,
+    );
+    let baselineTradPeak = 0;
+    let baselineRothPeak = 0;
+    for (const c of contexts) {
+        if ((c.baselineTradBalance ?? 0) > baselineTradPeak) baselineTradPeak = c.baselineTradBalance ?? 0;
+        if ((c.baselineRothBalance ?? 0) > baselineRothPeak) baselineRothPeak = c.baselineRothBalance ?? 0;
+    }
+    summaryLogs.push(
+        `[DEBUG DP] grid-sizing rationale: ` +
+        `baselineTradPeak=${fmt$(baselineTradPeak)}, ` +
+        `baselineRothPeak=${fmt$(baselineRothPeak)}. ` +
+        `Per-year scales above adapt to each year's reachable range; ` +
+        `legacy max scalars: maxBalance=${fmt$(maxBalance)} (dB=${fmt$(dB)}), ` +
+        `maxRoth=${fmt$(maxRoth)} (dRoth=${fmt$(dRoth)}).`,
+    );
+    summaryLogs.push(
+        `[DEBUG DP] start: currentTradBalance=${fmt$(currentTradBalance)}, ` +
+        `currentRothBalance=${fmt$(currentRothBalance)} ` +
+        `(both at start of FIRST context year — should be retirement-year balances, not today's), ` +
+        `firstYear=${contexts[0].year} (age ${contexts[0].age}), ` +
+        `lastYear=${contexts[horizonYears - 1].year} (age ${contexts[horizonYears - 1].age})`,
+    );
+    // Sample first 3 contexts so the user can see what the DP is seeing.
+    for (let i = 0; i < Math.min(3, horizonYears); i++) {
+        const c = contexts[i];
+        summaryLogs.push(
+            `[DEBUG DP] ctx[${i}] year=${c.year} age=${c.age}: ` +
+            `nonSSOrdExclRMD=${fmt$(c.nonSSOrdinaryIncomeExclRMD)}, ss=${fmt$(c.ssBenefits)}, ` +
+            `ltcg=${fmt$(c.ltcgIncome)}, ` +
+            `baselineTradWithdrawal=${fmt$(c.baselineTradWithdrawal)}, ` +
+            `rmdDivisor=${c.rmdDivisor.toFixed(2)}, growth=${(c.growthRate * 100).toFixed(2)}%`,
+        );
+    }
+
+    // V[t] is a flat Float64Array indexed by `tradIdx * (ROTH_BUCKETS+1) + rothIdx`,
+    // total size (TRAD_BUCKETS+1) × (ROTH_BUCKETS+1). V[horizonYears] is the terminal
+    // value (all zeros — no future tax).
+    const V_STRIDE = ROTH_BUCKETS + 1;
+    const V_SIZE = (TRAD_BUCKETS + 1) * V_STRIDE;
+    const V: Float64Array[] = new Array(horizonYears + 1);
+    for (let t = 0; t <= horizonYears; t++) {
+        V[t] = new Float64Array(V_SIZE);
+    }
+
+    // -----------------------------------------------------------------
+    // Backward sweep — 3D state (year, tradIdx, rothIdx).
+    //
+    // For each (t, tradIdx, rothIdx) cell, iterate over conversion buckets,
+    // evaluate the cell to get (yearTax, tradNext, rothNext, unmetNeed),
+    // then look up V[t+1] at (tradNext, rothNext) via bilinear interpolation
+    // in trad and roth. The minimum total-cost conversion wins.
+    //
+    // Phase 4 caveat: the inner conversion loop and `taxBaseline` only
+    // depend on (t, tradIdx) — recomputing them per rothIdx wastes work.
+    // We hoist them outside the rothIdx loop.
+    // -----------------------------------------------------------------
+    for (let t = horizonYears - 1; t >= 0; t--) {
+        const ctx = contexts[t];
+        const Vnext = V[t + 1];
+        const Vt = V[t];
+        const dB_t = dBByYear[t];
+        const dRoth_t = dRothByYear[t];
+        const dB_next = dBByYear[t + 1];
+        const dRoth_next = dRothByYear[t + 1];
+
+        for (let bi = 0; bi <= TRAD_BUCKETS; bi++) {
+            const b = bi * dB_t;
+
+            const rmdAtB = ctx.rmdDivisor > 0 ? b / ctx.rmdDivisor : 0;
+            const cMax = Math.max(0, b - rmdAtB);
+            // Baseline (no-conversion, no-trad-spending) tax — only used for
+            // the marginal diagnostic. Doesn't depend on rothIdx.
+            const taxBaseline = computeYearTax(ctx.nonSSOrdinaryIncomeExclRMD + rmdAtB, ctx);
+
+            // Hoist the roth-INDEPENDENT initial-guess tax out of the rothIdx
+            // loop. For a fixed (bi, ci), the conversion `c` and RMD are fixed
+            // (cMax depends only on b), so `ordIncomeExclTradSpend =
+            // nonSSOrdinaryIncomeExclRMD + rmdAtB + c` — and thus its full
+            // fed+state+SS tax — is identical across all rothIdx values. We
+            // compute it once per (bi, ci) here and reuse it for every ri.
+            // The fixed-point inside evaluateCell still recomputes tax when
+            // trad-spending > 0 (the genuinely roth-dependent path), so
+            // results are numerically identical.
+            const initialTaxByCi: number[] = new Array(CONVERSION_BUCKETS + 1);
+            {
+                let ci = 0;
+                for (; ci <= CONVERSION_BUCKETS; ci++) {
+                    const c = Math.min(ci * dCByYear[t], cMax);
+                    initialTaxByCi[ci] =
+                        computeYearTax(ctx.nonSSOrdinaryIncomeExclRMD + rmdAtB + c, ctx);
+                    if (c >= cMax) break;
+                }
+            }
+
+            for (let ri = 0; ri <= ROTH_BUCKETS; ri++) {
+                const r = ri * dRoth_t;
+
+                let bestCost = Infinity;
+
+                for (let ci = 0; ci <= CONVERSION_BUCKETS; ci++) {
+                    const c = Math.min(ci * dCByYear[t], cMax);
+                    const { yearTax, tradNext, rothNext, unmetNeed } =
+                        evaluateCell(b, r, c, ctx, taxBaseline, initialTaxByCi[ci]);
+
+                    const futureCost = interpV2D(
+                        Vnext, tradNext, rothNext,
+                        dB_next, dRoth_next, TRAD_BUCKETS, ROTH_BUCKETS,
+                    );
+                    const yearCost = yearTax + unmetNeed * INFEASIBILITY_PENALTY_PER_DOLLAR;
+                    const totalCost = yearCost + discountFactor * futureCost;
+
+                    if (totalCost < bestCost) bestCost = totalCost;
+
+                    if (c >= cMax) break;
+                }
+
+                Vt[bi * V_STRIDE + ri] = bestCost === Infinity ? taxBaseline : bestCost;
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Forward extract: walk the policy from current state.
+    // -----------------------------------------------------------------
+    const conversionsByYear = new Map<number, number>();
+    const perYearAmounts: DPDiagnostics['perYearAmounts'] = [];
+
+    let trad = currentTradBalance;
+    let roth = currentRothBalance;
+    // Snapshot for first-year debug: lets us see in the inspector whether the
+    // starting balances DP was handed match the baseline sub-sim's
+    // retirement-year balances (they should, per the a7eca53 fix).
+    const firstCtx = contexts[0];
+    const preRetirementBaselineTradVal = firstCtx.diagnosticPreRetirementBaselineTrad;
+    const startingDebug =
+        `[DEBUG DP setup] year=${firstCtx.year} (first context): ` +
+        `startingTrad=${fmt$(currentTradBalance)}, startingRoth=${fmt$(currentRothBalance)} ` +
+        `(both passed into planConversionsViaDP), ` +
+        `baselineTrad@firstYear=${fmt$(firstCtx.baselineTradBalance ?? 0)} (END of retirement year in baseline), ` +
+        `baselineTrad@(firstYear-1)=${preRetirementBaselineTradVal !== undefined ? fmt$(preRetirementBaselineTradVal) : 'n/a'} ` +
+        `(END of year BEFORE retirement = START of retirement year). ` +
+        `If startingTrad matches baselineTrad@(firstYear-1) ⇒ correct (start-of-retirement). ` +
+        `If startingTrad matches baselineTrad@firstYear ⇒ off-by-one (DP is starting from end-of-retirement-year baseline).`;
+
+    for (let t = 0; t < horizonYears; t++) {
+        const ctx = contexts[t];
+        const Vnext = V[t + 1];
+        const dB_next = dBByYear[t + 1];
+        const dRoth_next = dRothByYear[t + 1];
+
+        const rmdAtB = ctx.rmdDivisor > 0 ? trad / ctx.rmdDivisor : 0;
+        const cMax = Math.max(0, trad - rmdAtB);
+        const taxBaseline = computeYearTax(ctx.nonSSOrdinaryIncomeExclRMD + rmdAtB, ctx);
+
+        let bestC = 0;
+        let bestCost = Infinity;
+        let bestTradNext = trad;
+        let bestRothNext = roth;
+        let bestYearTax = 0;
+        let bestMarginal = 0;
+        let bestTradSpending = 0;
+        let bestFromRoth = 0;
+        let bestFromBrokerage = 0;
+        let bestUnmetNeed = 0;
+        // For the diagnostic table: cost @ c=0 vs cost @ a non-zero candidate.
+        let costAtZero = Infinity;
+        let yearTaxAtZero = 0;
+        let futureAtZero = 0;
+        let bestFuture = 0;
+
+        for (let ci = 0; ci <= CONVERSION_BUCKETS; ci++) {
+            const c = Math.min(ci * dCByYear[t], cMax);
+            const { yearTax, conversionMarginal, tradNext, rothNext, tradSpending, fromRoth, fromBrokerage, unmetNeed } =
+                evaluateCell(trad, roth, c, ctx, taxBaseline);
+
+            const futureCost = interpV2D(
+                Vnext, tradNext, rothNext,
+                dB_next, dRoth_next, TRAD_BUCKETS, ROTH_BUCKETS,
+            );
+            const yearCost = yearTax + unmetNeed * INFEASIBILITY_PENALTY_PER_DOLLAR;
+            const totalCost = yearCost + discountFactor * futureCost;
+
+            if (ci === 0) {
+                costAtZero = totalCost;
+                yearTaxAtZero = yearTax;
+                futureAtZero = futureCost;
+            }
+
+            if (totalCost < bestCost) {
+                bestCost = totalCost;
+                bestC = c;
+                bestTradNext = tradNext;
+                bestRothNext = rothNext;
+                bestYearTax = yearTax;
+                bestMarginal = conversionMarginal;
+                bestFuture = futureCost;
+                bestTradSpending = tradSpending;
+                bestFromRoth = fromRoth;
+                bestFromBrokerage = fromBrokerage;
+                bestUnmetNeed = unmetNeed;
+            }
+
+            if (c >= cMax) break;
+        }
+
+        conversionsByYear.set(ctx.year, bestC);
+        perYearAmounts.push({
+            year: ctx.year,
+            age: ctx.age,
+            amount: bestC,
+            estimatedTradBalance: trad,
+        });
+
+        // Per-year debug emitted to the year inspector via planConversionDP.
+        const debugLines: string[] = [];
+        if (t === 0) {
+            // Surface the setup info on the first conversion year so the user
+            // can spot starting-balance issues right in the inspector.
+            debugLines.push(startingDebug);
+        }
+        debugLines.push(
+            `[DEBUG DP solver] year=${ctx.year} age=${ctx.age}: ` +
+            `tradEntering=${fmt$(trad)}, rmdAtB=${fmt$(rmdAtB)}, cMax=${fmt$(cMax)}, ` +
+            `taxBaseline=${fmt$(taxBaseline)}`,
+        );
+        debugLines.push(
+            `[DEBUG DP solver] year=${ctx.year}: chose c=${fmt$(bestC)} ` +
+            `(yearTax=${fmt$(bestYearTax)}, marginal=${fmt$(bestMarginal)}, ` +
+            `discountedFuture=${fmt$(discountFactor * bestFuture)}, totalCost=${fmt$(bestCost)}, ` +
+            `tradNext=${fmt$(bestTradNext)}, rothNext=${fmt$(bestRothNext)})`,
+        );
+        debugLines.push(
+            `[DEBUG DP solver] year=${ctx.year}: c=0 totalCost=${fmt$(costAtZero)} ` +
+            `(yearTax=${fmt$(yearTaxAtZero)}, discountedFuture=${fmt$(discountFactor * futureAtZero)})`,
+        );
+        // Cost-curve sample at FEDERAL BRACKET BOUNDARIES so each segment in
+        // the rate-analysis table represents a single bracket — marginals
+        // read 10% → 12% → 22% → 24% → 32% → 35% as expected, instead of
+        // averages across multi-bracket ranges. Always include 0, the std-ded
+        // boundary, the chosen c, and cMax.
+        //
+        // Conversion needed to land taxable ordinary income at federal bracket
+        // threshold T:  c = (stdDed + T) − existingOrdinaryAtCellEntry
+        // where existingOrdinary = nonSSOrdinaryIncomeExclRMD + rmd (excludes
+        // the conversion itself, which we're varying).
+        const stdDed = ctx.fedParams.standardDeduction;
+        const existingOrdinary = ctx.nonSSOrdinaryIncomeExclRMD + rmdAtB;
+        const stdDedBoundaryC = Math.max(0, stdDed - existingOrdinary);
+        const bracketSampleCs = ctx.fedParams.brackets.map(
+            b => Math.max(0, stdDed + b.threshold - existingOrdinary),
+        );
+        const sampleCs = [
+            0,
+            stdDedBoundaryC,
+            ...bracketSampleCs,
+            bestC,
+            cMax,
+        ]
+            .filter(c => c >= 0 && c <= cMax)
+            .sort((a, b) => a - b)
+            .filter((c, i, arr) => i === 0 || Math.abs(c - arr[i - 1]) > 0.5);
+        const curveParts: string[] = [];
+        const costCurve: DPYearTrace['costCurve'] = [];
+        for (const sampleC of sampleCs) {
+            const r = evaluateCell(trad, roth, sampleC, ctx, taxBaseline);
+            const fc = interpV2D(
+                Vnext, r.tradNext, r.rothNext,
+                dB_next, dRoth_next, TRAD_BUCKETS, ROTH_BUCKETS,
+            );
+            const yc = r.yearTax + r.unmetNeed * INFEASIBILITY_PENALTY_PER_DOLLAR;
+            const dFut = discountFactor * fc;
+            const total = yc + dFut;
+            curveParts.push(
+                `c=${fmt$(sampleC)}→total=${fmt$(total)}` +
+                ` (yearTax=${fmt$(r.yearTax)}, dFut=${fmt$(dFut)}, ` +
+                `tradNext=${fmt$(r.tradNext)}, rothNext=${fmt$(r.rothNext)})`,
+            );
+            costCurve.push({
+                c: sampleC,
+                yearTax: r.yearTax,
+                discountedFuture: dFut,
+                totalCost: total,
+                tradNext: r.tradNext,
+                rothNext: r.rothNext,
+            });
+        }
+        debugLines.push(
+            `[DEBUG DP curve] year=${ctx.year}: ${curveParts.join(' | ')}`,
+        );
+        // Waterfall breakdown for the chosen conversion. The 3D solver
+        // tracks the running roth balance forward, so `cap` reflects what
+        // DP's own plan has left in Roth this year — not a baseline proxy.
+        // gap = max(0, spendingNeed + yearTax − cashFromOrdinary); sourced
+        // brokerage → roth → trad in the real-sim withdrawal order.
+        const cashFromOrd =
+            ctx.nonSSOrdinaryIncomeExclRMD + ctx.ssBenefits + rmdAtB;
+        const gap = Math.max(0, ctx.spendingNeed + bestYearTax - cashFromOrd);
+        debugLines.push(
+            `[DEBUG DP waterfall] year=${ctx.year}: ` +
+            `spendingNeed=${fmt$(ctx.spendingNeed)} + yearTax=${fmt$(bestYearTax)} − ` +
+            `cashFromOrdinary=${fmt$(cashFromOrd)} = gap=${fmt$(gap)} → ` +
+            `fromBrokerage=${fmt$(bestFromBrokerage)} (cap=${fmt$(ctx.baselineBrokerageAvailable)}), ` +
+            `fromRoth=${fmt$(bestFromRoth)} (cap=${fmt$(roth)}), ` +
+            `tradSpending=${fmt$(bestTradSpending)}, unmetNeed=${fmt$(bestUnmetNeed)}`,
+        );
+        // Forward-sweep decomposition: shows exactly how DP is propagating
+        // trad and roth jointly under the chosen plan.
+        // tradAfterFlows = tradEntering − conversion − rmd − tradSpending
+        // tradNext = tradAfterFlows × (1 + growthRate)
+        // rothAfterFlows = rothEntering + conversion − fromRoth
+        // rothNext = max(0, rothAfterFlows) × (1 + rothGrowthRate)
+        const tradAfterFlows = trad - bestC - rmdAtB - bestTradSpending;
+        const rothAfterFlows = roth + bestC - bestFromRoth;
+        debugLines.push(
+            `[DEBUG DP forward] year=${ctx.year}: ` +
+            `tradEntering=${fmt$(trad)} − c=${fmt$(bestC)} − rmd=${fmt$(rmdAtB)} − ` +
+            `tradSpending=${fmt$(bestTradSpending)} ` +
+            `= ${fmt$(tradAfterFlows)} × (1 + ${(ctx.growthRate * 100).toFixed(2)}%) = tradNext=${fmt$(bestTradNext)}`,
+        );
+        debugLines.push(
+            `[DEBUG DP forward roth] year=${ctx.year}: ` +
+            `rothEntering=${fmt$(roth)} + c=${fmt$(bestC)} − fromRoth=${fmt$(bestFromRoth)} ` +
+            `= ${fmt$(rothAfterFlows)} × (1 + ${(ctx.rothGrowthRate * 100).toFixed(2)}%) = rothNext=${fmt$(bestRothNext)}`,
+        );
+        // Baseline trajectory snapshot (std-ded-only sub-sim). The 3D solver
+        // tracks both trad and roth jointly under DP's own plan, so divergence
+        // from baseline here is expected and informative — compare DP's
+        // tradEntering / rothEntering above with these baseline values to see
+        // how the chosen plan differs.
+        debugLines.push(
+            `[DEBUG DP baseline] year=${ctx.year}: ` +
+            `baselineTrad=${fmt$(ctx.baselineTradBalance ?? 0)}, ` +
+            `baselineRoth=${fmt$(ctx.baselineRothBalance ?? 0)}, ` +
+            `baselineBrokerage=${fmt$(ctx.baselineBrokerageBalance ?? 0)}, ` +
+            `baselineConversion=${fmt$(ctx.baselineConversionAmount ?? 0)}, ` +
+            `baselineTradWithdrawal=${fmt$(ctx.baselineTradWithdrawal)}`,
+        );
+        perYearDebug.set(ctx.year, debugLines);
+
+        // Structured trace for the Roth debug screen.
+        const trace: DPYearTrace = {
+            year: ctx.year,
+            age: ctx.age,
+            chosenC: bestC,
+            yearTax: bestYearTax,
+            conversionMarginal: bestMarginal,
+            discountedFuture: discountFactor * bestFuture,
+            totalCost: bestCost,
+            tradEntering: trad,
+            rothEntering: roth,
+            rmdAtEntering: rmdAtB,
+            cMax,
+            taxBaselineNoConv: taxBaseline,
+            tradNext: bestTradNext,
+            rothNext: bestRothNext,
+            spendingNeed: ctx.spendingNeed,
+            cashFromOrdinary: cashFromOrd,
+            gap,
+            fromBrokerage: bestFromBrokerage,
+            fromRoth: bestFromRoth,
+            tradSpending: bestTradSpending,
+            unmetNeed: bestUnmetNeed,
+            baselineBrokerageCap: ctx.baselineBrokerageAvailable,
+            costCurve,
+            baselineTrad: ctx.baselineTradBalance,
+            baselineRoth: ctx.baselineRothBalance,
+            baselineBrokerage: ctx.baselineBrokerageBalance,
+            baselineConversion: ctx.baselineConversionAmount,
+            dB: dBByYear[t],
+            dRoth: dRothByYear[t],
+        };
+        perYearTraces.set(ctx.year, trace);
+
+        trad = bestTradNext;
+        roth = bestRothNext;
+    }
+
+    const elapsedMs = performance.now() - startedAt;
+    const totalConverted = Array.from(conversionsByYear.values()).reduce((s, a) => s + a, 0);
+    const yearsConverting = Array.from(conversionsByYear.values()).filter(a => a > 0).length;
+    summaryLogs.push(
+        `[DEBUG DP] result: totalConverted=${fmt$(totalConverted)} across ${yearsConverting}/${horizonYears} years, ` +
+        `elapsed=${elapsedMs.toFixed(1)}ms`,
+    );
+
+    return {
+        conversionsByYear,
+        diagnostics: {
+            backloadDelta: delta,
+            tradBuckets: TRAD_BUCKETS,
+            rothBuckets: ROTH_BUCKETS,
+            conversionBuckets: CONVERSION_BUCKETS,
+            maxBalance,
+            maxRoth,
+            dB,
+            dRoth,
+            dBByYear,
+            dRothByYear,
+            dCByYear,
+            dC,
+            maxConversion,
+            horizonYears,
+            elapsedMs,
+            perYearAmounts,
+            summaryLogs,
+            perYearDebug,
+            perYearTraces,
+        },
+    };
+}


### PR DESCRIPTION
Scoped review of the retirement-flow services: Roth conversion planning, RMDs,
income projection (SS/pensions/interest), account growth and contributions,
milestone evaluation, and their data tables. ONLY the source files added in
the diff are under review. The test files in this branch are a behavioral
reference ONLY (not in the diff) and may be wrong or timezone-dependent: if
source and a test disagree, flag it as a question, do not assume the test.

ADJUDICATIONS: code-review-pr-50.md … code-review-pr-53.md (in this tree, base
commit) record findings already fixed or ruled by-design — do not resurface
wont-fixes. Known-open low-priority items live there too (e.g. PR #53
findings 12/13). Roth conversion strategy is back-loaded BY DESIGN (SORR);
do not propose front-loading/bracket-equalization "fixes".

Recurring problem areas that have actually bitten us here — extra scrutiny:

  1. Roth conversion mechanics. IRS ordering (contributions -> oldest
     conversions -> earnings) and the 5-year clock; the ACA look-ahead and the
     main withdrawal loop must drain the SAME conversion list (no
     double-spend); conversion sizing must not double-count taxable SS in
     provisional income (bit us before).
  2. RMD modeling. Divisor basis (prior Dec-31 balance, vested vs full);
     divisor table values at extreme ages; duplicate divisor tables drifting
     (fix EVERY copy); the 25% shortfall excise flowing into the year's taxes.
  3. Contribution caps. 415(c) combined employee+employer limit — the trimmed
     deposit in AccountGrowth is authoritative; any path recomputing employer
     match without the trim drifts from what was actually deposited.
  4. The three SS income classes are siblings — instanceof lists naming only
     two silently drop the third. Pension COLA (FERS diet-COLA rules) and the
     MRA-to-62 supplement window boundaries.
  5. Date-only / timezone handling. Pension + SS start dates are built with
     Date.UTC in places and local constructors in others, then read with the
     other family's accessors (PR #53 finding 13 — reinvested-interest income
     built local, read UTC — is still open). The unit suite runs in UTC and
     structurally cannot catch these.
  6. Goal sinking funds (new architecture, 2026-06): goal funding is a
     committed transfer credited by the engine; goal-fund accounts are
     reserved. AccountGrowth/contribution paths must not also route generic
     inflows into them.
  7. Falsy-zero. `|| default` where 0 is valid (customROR=0, COLA=0,
     expenseRatio=0) should be `??`.

Output: ranked findings, each with a concrete failure scenario
(inputs/state -> wrong output). Findings that can't name a trigger should say
so explicitly.