### PR TITLE
Scope: domain models + simulation orchestration (source)

### DIFF
--- a/src/components/Objects/Accounts/models.tsx
+++ b/src/components/Objects/Accounts/models.tsx
@@ -1,0 +1,1015 @@
+import { AssumptionsState } from "../Assumptions/AssumptionsContext";
+import { parseDate, hasClassName } from "../modelUtils";
+
+// 1. Interface
+
+export interface Account {
+  id: string;
+  name: string;
+  amount: number;
+}
+
+// 2. Base Abstract Class
+abstract class BaseAccount implements Account {
+  constructor(
+    public id: string,
+    public name: string,
+    public amount: number
+  ) {}
+}
+
+// 3. Concrete Classes
+
+export const TaxTypeEnum = ['Brokerage', 'Roth 401k', 'Traditional 401k', 'Roth IRA', 'Traditional IRA', 'HSA'] as const;
+export type TaxType = typeof TaxTypeEnum[number];
+
+// ESPP Lot interface for tracking individual share purchases
+export interface ESPPLot {
+  id: string;
+  grantDate: Date;        // Start of the offering period
+  purchaseDate: Date;     // End of the offering period when shares were purchased
+  fmvAtGrant: number;     // Fair market value per share at grant date
+  fmvAtPurchase: number;  // Fair market value per share at purchase date
+  purchasePrice: number;  // Price paid per share (after discount)
+  shares: number;         // Number of shares purchased
+  totalCost: number;      // Cost basis (purchasePrice * shares)
+  discountAmount: number; // Per-share discount (for tax calculation)
+}
+
+// Brokerage Lot interface for tracking individual contributions (simulation-internal, not persisted)
+export interface BrokerageLot {
+  purchaseYear: number;    // Year contribution was made
+  costBasis: number;       // Original amount (never grows)
+  currentValue: number;    // Market value (grows with returns)
+}
+
+export class SavedAccount extends BaseAccount {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    public apr: number = 0
+  ) {
+    super(id, name, amount);
+  }
+
+  increment (_assumptions: AssumptionsState, annualContribution: number = 0): SavedAccount {
+    // BOY timing: Apply contribution first, then growth
+    const amount = (this.amount + annualContribution) * (1 + this.apr/100);
+    return new SavedAccount(this.id, this.name, amount, this.apr);
+  }
+}
+
+export class InvestedAccount extends BaseAccount {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    // New: Track the specific portion of 'amount' that came from the employer
+    public employerBalance: number = 0,
+    // New: How many years have we been accumulating/vesting?
+    public tenureYears: number = 0,
+    public expenseRatio: number = 0.1,
+    public taxType: TaxType = 'Brokerage',
+    public isContributionEligible: boolean = true,
+    public vestedPerYear: number = 0.2, // 20% per year (5 year graded)
+    // Track total contributions for capital gains calculation
+    // costBasis = amount initially put in (contributions), gains = amount - costBasis
+    public costBasis: number = amount, // Default to current amount for backwards compatibility
+    // Optional custom return rate (overrides global assumptions)
+    public customROR?: number, // undefined means use global assumptions
+    // Track Roth conversion amounts with the year they occurred (for 5-year rule)
+    public conversionHistory: { year: number; amount: number }[] = [],
+    // Simulation-internal lot tracking for brokerage accounts (not persisted)
+    public lots: BrokerageLot[] = [],
+  ) {
+    super(id, name, amount);
+  }
+
+  // Total amount in costBasis that came from conversions
+  get totalConversionBasis(): number {
+    return this.conversionHistory.reduce((sum, c) => sum + c.amount, 0);
+  }
+
+  // Amount of costBasis that represents regular contributions (not conversions)
+  get regularContributions(): number {
+    return Math.max(0, this.costBasis - this.totalConversionBasis);
+  }
+
+  // Calculate unrealized gains (amount above cost basis)
+  get unrealizedGains(): number {
+    return Math.max(0, this.amount - this.costBasis);
+  }
+
+  // Calculate what portion of a withdrawal would be gains vs basis (proportional method)
+  calculateWithdrawalAllocation(withdrawAmount: number): { basis: number; gains: number } {
+    if (this.amount <= 0) return { basis: 0, gains: 0 };
+
+    const gainsPortion = this.unrealizedGains / this.amount;
+    const basisPortion = 1 - gainsPortion;
+
+    return {
+      basis: withdrawAmount * basisPortion,
+      gains: withdrawAmount * gainsPortion,
+    };
+  }
+
+  // Calculate lot-aware withdrawal breakdown for brokerage accounts
+  // Uses FIFO (First In, First Out) - sells oldest lots first
+  // Returns short-term vs long-term gains based on holding period of each lot
+  calculateLotAwareWithdrawal(withdrawAmount: number, currentYear: number): {
+    shortTermGains: number; longTermGains: number; basisReturn: number
+  } {
+    // Fall back to simple method if no lots present
+    if (this.lots.length === 0 || this.amount <= 0) {
+      const allocation = this.calculateWithdrawalAllocation(withdrawAmount);
+      return { shortTermGains: 0, longTermGains: allocation.gains, basisReturn: allocation.basis };
+    }
+
+    const totalLotValue = this.lots.reduce((sum, lot) => sum + lot.currentValue, 0);
+    if (totalLotValue <= 0) {
+      return { shortTermGains: 0, longTermGains: 0, basisReturn: withdrawAmount };
+    }
+
+    let shortTermGains = 0;
+    let longTermGains = 0;
+    let basisReturn = 0;
+    let remainingToWithdraw = Math.min(withdrawAmount, totalLotValue);
+
+    // FIFO: Sort lots by purchaseYear ascending (oldest first)
+    const sortedLots = [...this.lots].sort((a, b) => a.purchaseYear - b.purchaseYear);
+
+    for (const lot of sortedLots) {
+      if (remainingToWithdraw <= 0) break;
+
+      // How much to take from this lot
+      const lotWithdraw = Math.min(lot.currentValue, remainingToWithdraw);
+      remainingToWithdraw -= lotWithdraw;
+
+      // Calculate basis and gain for this portion
+      // Basis withdrawn is proportional to value withdrawn from this lot
+      const lotWithdrawPct = lot.currentValue > 0 ? lotWithdraw / lot.currentValue : 0;
+      const lotBasisWithdrawn = lot.costBasis * lotWithdrawPct;
+      const lotGain = Math.max(0, lotWithdraw - lotBasisWithdrawn);
+
+      basisReturn += lotBasisWithdrawn;
+
+      // Long-term if held >= 2 years (conservative with year-only precision)
+      // e.g., purchased 2022, sold 2024 → difference = 2 → definitely long-term
+      // Using >= 2 avoids misclassifying short-term as long-term (Dec 2023 → Jan 2024 = 1 year diff but only 1 month held)
+      if (currentYear - lot.purchaseYear >= 2) {
+        longTermGains += lotGain;
+      } else {
+        shortTermGains += lotGain;
+      }
+    }
+
+    return { shortTermGains, longTermGains, basisReturn };
+  }
+
+  // Helper to calculate the current "Risk" (Unvested Amount)
+  get nonVestedAmount(): number {
+    // Cap vesting at 100% (1.0)
+    const vestedPct = Math.min(1, this.tenureYears * this.vestedPerYear);
+    return this.employerBalance * (1 - vestedPct);
+  }
+
+  get vestedAmount(): number {
+    return this.amount - this.nonVestedAmount;
+  }
+
+  increment(
+    assumptions: AssumptionsState,
+    userContribution: number = 0,
+    employerContribution: number = 0,
+    overrideReturnRate?: number,
+    conversionAmount: number = 0,
+    currentYear: number = 0
+  ): InvestedAccount {
+
+    // 1. Calculate Growth Rate
+    // Priority: overrideReturnRate (Monte Carlo) > customROR (per-account) > global assumptions
+    let returnRate: number;
+    if (overrideReturnRate !== undefined) {
+      // overrideReturnRate is a percentage (e.g., 7 for 7%), already includes inflation if applicable
+      // Still subtract expense ratio
+      returnRate = 1 + (overrideReturnRate - this.expenseRatio) / 100;
+    } else if (this.customROR !== undefined) {
+      // Use per-account custom ROR (already a percentage, e.g., 7 for 7%)
+      returnRate = 1 + (this.customROR + (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) - this.expenseRatio) / 100;
+    } else {
+      returnRate = 1 + (assumptions.investments.returnRates.ror + (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) - this.expenseRatio) / 100;
+    }
+
+    // 2. BOY timing: Apply contributions/withdrawals BEFORE growth
+    // Calculate vesting using current year rate (tenureYears + 1)
+    const newTenure = this.tenureYears + 1;
+    const vestedPct = Math.min(1, newTenure * this.vestedPerYear);
+
+    // Start with current (pre-growth) balances
+    let preGrowthUserBalance = this.amount - this.employerBalance;
+    let preGrowthEmployerBalance = this.employerBalance;
+    let preGrowthCostBasis = this.costBasis;
+    // FIFO-drained conversion history, populated in the withdrawal branch below.
+    let newConversionHistoryFifo: { year: number; amount: number }[] | undefined;
+
+    // 3. Apply employer contribution (before growth)
+    preGrowthEmployerBalance += employerContribution;
+
+    // 4. Handle user contribution/withdrawal (before growth)
+    if (userContribution < 0) {
+      // User is withdrawing
+      const withdrawalAmount = Math.abs(userContribution);
+
+      // Check if withdrawal exceeds user's equity (using pre-growth balance)
+      if (withdrawalAmount > preGrowthUserBalance) {
+        // User is over-withdrawing - need to tap into employer funds
+        const shortfall = withdrawalAmount - preGrowthUserBalance;
+
+        // Calculate vested employer amount accessible to user
+        const vestedEmployerAmount = preGrowthEmployerBalance * vestedPct;
+
+        // Can only withdraw from vested employer funds
+        const allowedFromEmployer = Math.min(shortfall, vestedEmployerAmount);
+
+        // Apply the withdrawal
+        preGrowthEmployerBalance -= allowedFromEmployer;
+        preGrowthUserBalance = 0; // User equity depleted
+      } else {
+        // Normal withdrawal - doesn't exceed user equity
+        preGrowthUserBalance -= withdrawalAmount;
+      }
+
+      // Reduce cost basis (and, for Roth, conversion history) on withdrawal,
+      // before growth.
+      if (this.amount > 0) {
+        const isRoth = this.taxType === 'Roth IRA' || this.taxType === 'Roth 401k';
+        if (isRoth) {
+          // Roth: drain in IRS FIFO order, mirroring the WithdrawalPlanner
+          // (grossUpRoth): contribution basis first, then conversions oldest-first
+          // (preserving each layer's year for the 5-year rule), then earnings.
+          // increment() only receives a net withdrawal amount (no tranche
+          // breakdown), so we re-derive the ordering from the account's figures.
+          let remainingToWithdraw = withdrawalAmount;
+
+          // 1. Contribution basis first (penalty/tax-free, doesn't affect 5-year clock).
+          //    regularContributions = costBasis above the total conversion basis.
+          const fromContributions = Math.min(remainingToWithdraw, this.regularContributions);
+          remainingToWithdraw -= fromContributions;
+
+          // 2. Conversions next, oldest-first. Each dollar drawn reduces both the
+          //    conversion layer and costBasis (conversions are part of costBasis).
+          let fromConversions = 0;
+          if (remainingToWithdraw > 0) {
+            // Sort oldest-first so the 5-year clock is preserved per layer.
+            newConversionHistoryFifo = [...this.conversionHistory].sort((a, b) => a.year - b.year);
+            newConversionHistoryFifo = newConversionHistoryFifo
+              .map(c => {
+                if (remainingToWithdraw <= 0) return c;
+                const fromThis = Math.min(remainingToWithdraw, c.amount);
+                remainingToWithdraw -= fromThis;
+                fromConversions += fromThis;
+                return { year: c.year, amount: c.amount - fromThis };
+              })
+              .filter(c => c.amount > 0.01); // Remove negligible entries
+          } else {
+            newConversionHistoryFifo = this.conversionHistory.filter(c => c.amount > 0.01);
+          }
+
+          // 3. Any remainder comes from earnings, which carry no basis.
+          // costBasis is reduced only by the basis + conversion dollars actually drawn.
+          preGrowthCostBasis = this.costBasis - fromContributions - fromConversions;
+        } else {
+          // Non-Roth (e.g. taxable Brokerage without lot tracking): average-cost
+          // basis — costBasis reduces proportionally to the withdrawal. (Lot-based
+          // Brokerage re-derives costBasis from lots in the lifecycle block below.)
+          const withdrawalPct = withdrawalAmount / this.amount;
+          preGrowthCostBasis = this.costBasis * (1 - withdrawalPct);
+        }
+      }
+    } else {
+      // User is contributing (or no change)
+      preGrowthUserBalance += userContribution;
+
+      // Add contributions to cost basis (vested employer contributions count as basis)
+      const vestedEmployerContrib = employerContribution * vestedPct;
+      preGrowthCostBasis = this.costBasis + userContribution + vestedEmployerContrib;
+    }
+
+    // Build updated conversion history. On a withdrawal it was already drained in
+    // FIFO order above (newConversionHistoryFifo); otherwise carry it forward.
+    let newConversionHistory = newConversionHistoryFifo ?? [...this.conversionHistory];
+
+    // Add new conversion entry if applicable
+    if (conversionAmount > 0 && currentYear > 0) {
+      newConversionHistory.push({ year: currentYear, amount: conversionAmount });
+    }
+
+    // Lot lifecycle (Brokerage accounts only, simulation-internal)
+    let newLots: BrokerageLot[] = [];
+    if (this.taxType === 'Brokerage') {
+      // Seed lot: first time we see an empty lots array with existing balance
+      if (this.lots.length === 0 && this.amount > 0 && currentYear > 0) {
+        newLots = [{ purchaseYear: currentYear - 2, costBasis: this.costBasis, currentValue: this.amount }];
+      } else {
+        newLots = [...this.lots];
+      }
+
+      if (userContribution < 0 && this.amount > 0) {
+        // Withdrawal: FIFO - reduce oldest lots first
+        let remainingToWithdraw = Math.abs(userContribution);
+
+        // Sort by purchaseYear ascending (oldest first)
+        newLots.sort((a, b) => a.purchaseYear - b.purchaseYear);
+
+        // Reduce lots in FIFO order
+        newLots = newLots.map(lot => {
+          if (remainingToWithdraw <= 0) return lot;
+
+          const withdrawFromLot = Math.min(lot.currentValue, remainingToWithdraw);
+          remainingToWithdraw -= withdrawFromLot;
+
+          // Reduce basis proportionally to value withdrawn
+          const withdrawPct = lot.currentValue > 0 ? withdrawFromLot / lot.currentValue : 1;
+          return {
+            purchaseYear: lot.purchaseYear,
+            costBasis: lot.costBasis * (1 - withdrawPct),
+            currentValue: lot.currentValue - withdrawFromLot,
+          };
+        }).filter(lot => lot.currentValue >= 0.01); // Remove fully sold lots
+      } else if (userContribution > 0 && currentYear > 0) {
+        // Contribution: push a new lot
+        newLots.push({ purchaseYear: currentYear, costBasis: userContribution, currentValue: userContribution });
+      }
+
+      // Derive costBasis from lot-level truth after FIFO processing.
+      // The blended proportional reduction (line 244) diverges from FIFO lot accounting
+      // because FIFO sells high-gain lots first, removing less basis than the blended ratio.
+      if (newLots.length > 0) {
+        preGrowthCostBasis = newLots.reduce((sum, lot) => sum + lot.costBasis, 0);
+      }
+    }
+
+    // 5. Now apply growth to the adjusted (post-transaction) balances
+    const preGrowthTotal = preGrowthUserBalance + preGrowthEmployerBalance;
+    const grownTotal = preGrowthTotal * returnRate;
+    const grownEmployerBalance = preGrowthEmployerBalance * returnRate;
+    // Note: Cost basis does NOT grow with market returns - it only tracks contributions
+
+    // Grow lots proportionally (costBasis stays fixed, currentValue grows)
+    if (this.taxType === 'Brokerage' && newLots.length > 0) {
+      newLots = newLots.map(lot => ({
+        purchaseYear: lot.purchaseYear,
+        costBasis: lot.costBasis,
+        currentValue: lot.currentValue * returnRate,
+      }));
+    }
+
+    // 6. Final safety checks
+    let finalEmployerBalance = grownEmployerBalance;
+    if (finalEmployerBalance > grownTotal) {
+      finalEmployerBalance = Math.max(0, grownTotal);
+    }
+
+    // Cost basis can't exceed total amount or be negative
+    const finalCostBasis = Math.max(0, Math.min(preGrowthCostBasis, grownTotal));
+
+    return new InvestedAccount(
+      this.id,
+      this.name,
+      grownTotal,
+      finalEmployerBalance,
+      newTenure,
+      this.expenseRatio,
+      this.taxType,
+      this.isContributionEligible,
+      this.vestedPerYear,
+      finalCostBasis,
+      this.customROR,
+      newConversionHistory,
+      newLots
+    );
+  }
+}
+
+/**
+ * ESPP withdrawal preference - controls which lots are sold first
+ */
+export type ESPPWithdrawalPreference =
+  | 'fifo'                        // First-in, first-out (default)
+  | 'disqualifying_first'         // Sell disqualifying lots before qualifying
+  | 'qualifying_first'            // Sell qualifying lots first (lower ordinary income)
+  | 'dont_sell_until_qualifying'; // Skip ESPP in withdrawal order if no qualifying lots
+
+export const ESPP_WITHDRAWAL_PREFERENCE_OPTIONS = [
+  { value: 'fifo' as const, label: 'FIFO (First-In, First-Out)' },
+  { value: 'disqualifying_first' as const, label: 'Disqualifying First' },
+  { value: 'qualifying_first' as const, label: 'Qualifying First' },
+  { value: 'dont_sell_until_qualifying' as const, label: "Don't Sell Until Qualifying" },
+];
+
+/**
+ * ESPPAccount - Employee Stock Purchase Plan Account
+ *
+ * Tracks ESPP shares with lot-level detail for accurate tax treatment.
+ * ESPP has special tax rules based on holding periods:
+ * - Qualifying disposition: 2 years from grant + 1 year from purchase
+ * - Disqualifying disposition: Sold before meeting both holding periods
+ */
+export class ESPPAccount extends BaseAccount {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    public lots: ESPPLot[] = [],
+    public linkedIncomeId: string | null = null,  // Link to WorkIncome with ESPP
+    public customROR?: number, // Optional custom return rate (overrides global assumptions)
+    public stockTicker?: string,                  // Company ticker (e.g., "AAPL")
+    public currentSharePrice?: number,            // Current price per share
+    public withdrawalPreference: ESPPWithdrawalPreference = 'fifo',  // Lot selling order
+    public minimumHoldingDays: number = 0,        // Days before shares can be sold
+  ) {
+    super(id, name, amount);
+  }
+
+  /**
+   * Sort lots based on withdrawal preference
+   */
+  private sortLots(
+    lots: ESPPLot[],
+    saleDate: Date,
+    lotOrder: 'fifo' | 'disqualifying_first' | 'qualifying_first'
+  ): ESPPLot[] {
+    const byPurchaseDate = (a: ESPPLot, b: ESPPLot) =>
+      new Date(a.purchaseDate).getTime() - new Date(b.purchaseDate).getTime();
+
+    if (lotOrder === 'fifo') {
+      return [...lots].sort(byPurchaseDate);
+    }
+
+    const qualifyingFirst = lotOrder === 'qualifying_first';
+    return [...lots].sort((a, b) => {
+      const aQualifying = this.calculateDispositionType(a, saleDate) === 'qualifying';
+      const bQualifying = this.calculateDispositionType(b, saleDate) === 'qualifying';
+      if (aQualifying !== bQualifying) {
+        return qualifyingFirst
+          ? (aQualifying ? -1 : 1)
+          : (aQualifying ? 1 : -1);
+      }
+      return byPurchaseDate(a, b);
+    });
+  }
+
+  /**
+   * Determine if a lot qualifies for preferential tax treatment.
+   * Qualifying: 2 years from grant AND 1 year from purchase
+   */
+  calculateDispositionType(lot: ESPPLot, saleDate: Date): 'qualifying' | 'disqualifying' {
+    const grantDate = new Date(lot.grantDate);
+    const purchaseDate = new Date(lot.purchaseDate);
+
+    // Two years from grant date
+    const twoYearsFromGrant = new Date(grantDate);
+    twoYearsFromGrant.setFullYear(twoYearsFromGrant.getFullYear() + 2);
+
+    // One year from purchase date
+    const oneYearFromPurchase = new Date(purchaseDate);
+    oneYearFromPurchase.setFullYear(oneYearFromPurchase.getFullYear() + 1);
+
+    if (saleDate >= twoYearsFromGrant && saleDate >= oneYearFromPurchase) {
+      return 'qualifying';
+    }
+    return 'disqualifying';
+  }
+
+  /**
+   * Calculate tax implications of selling ESPP shares.
+   *
+   * For disqualifying dispositions:
+   * - Ordinary income = (FMV at purchase - purchase price) × shares = discount amount
+   * - Capital gains = sale price - FMV at purchase (per share) × shares
+   *
+   * For qualifying dispositions:
+   * - Ordinary income = lesser of: (1) discount at grant, or (2) actual gain
+   * - Capital gains = remainder is long-term capital gains
+   *
+   * @param sharesToSell - Number of shares to sell
+   * @param salePrice - Sale price per share
+   * @param saleDate - Date of sale (used to determine qualifying vs disqualifying)
+   * @param lotOrder - Order to sell lots: 'fifo', 'disqualifying_first', or 'qualifying_first'
+   * @param eligibleLots - Optional pre-filtered list of lots (e.g., after minimum holding period filter)
+   */
+  calculateSaleTax(
+    sharesToSell: number,
+    salePrice: number, // Per share
+    saleDate: Date,
+    lotOrder: 'fifo' | 'disqualifying_first' | 'qualifying_first' = 'fifo',
+    eligibleLots?: ESPPLot[]
+  ): { ordinaryIncome: number; shortTermGains: number; longTermGains: number; lotsUsed: ESPPLot[] } {
+    let ordinaryIncome = 0;
+    let shortTermGains = 0;
+    let longTermGains = 0;
+    let remainingShares = sharesToSell;
+    const lotsUsed: ESPPLot[] = [];
+
+    // Use provided eligible lots or all lots
+    const lotsToConsider = eligibleLots || this.lots;
+    const sortedLots = this.sortLots(lotsToConsider, saleDate, lotOrder);
+
+    for (const lot of sortedLots) {
+      if (remainingShares <= 0) break;
+
+      const sharesToUse = Math.min(remainingShares, lot.shares);
+      const dispositionType = this.calculateDispositionType(lot, saleDate);
+      const lotPurchaseDate = new Date(lot.purchaseDate);
+
+      // Check if held over 1 year for capital gains treatment
+      const oneYearFromPurchase = new Date(lotPurchaseDate);
+      oneYearFromPurchase.setFullYear(oneYearFromPurchase.getFullYear() + 1);
+      const isLongTerm = saleDate >= oneYearFromPurchase;
+
+      if (dispositionType === 'disqualifying') {
+        // Disqualifying: discount is ordinary income, rest is capital gain
+        const discountPerShare = lot.fmvAtPurchase - lot.purchasePrice;
+        ordinaryIncome += discountPerShare * sharesToUse;
+
+        const gainBeyondDiscount = (salePrice - lot.fmvAtPurchase) * sharesToUse;
+        if (isLongTerm) {
+          longTermGains += gainBeyondDiscount;
+        } else {
+          shortTermGains += gainBeyondDiscount;
+        }
+      } else {
+        // Qualifying: ordinary income is the lesser of (a) the actual gain, or (b) the
+        // discount measured at grant = FMV at grant × the plan's discount rate. Per IRS
+        // rules for §423 ESPP qualifying dispositions the rate is the plan's own discount
+        // (capped at the 15% statutory maximum) — not a flat 15%, since plans commonly
+        // offer less. Recover the plan rate from the lot's stored per-share discount.
+        const discountBase = lot.purchasePrice + lot.discountAmount;
+        const planDiscountRate = discountBase > 0
+          ? Math.min(lot.discountAmount / discountBase, 0.15)
+          : 0;
+        const grantDiscountPerShare = lot.fmvAtGrant * planDiscountRate;
+        const grantDiscount = grantDiscountPerShare * sharesToUse;
+        const actualGain = (salePrice - lot.purchasePrice) * sharesToUse;
+
+        if (actualGain <= 0) {
+          // Loss - no ordinary income, just capital loss
+          longTermGains += actualGain; // Will be negative
+        } else {
+          const ordinaryPortion = Math.min(grantDiscount, actualGain);
+          ordinaryIncome += ordinaryPortion;
+          longTermGains += actualGain - ordinaryPortion;
+        }
+      }
+
+      remainingShares -= sharesToUse;
+      lotsUsed.push({ ...lot, shares: sharesToUse });
+    }
+
+    return { ordinaryIncome, shortTermGains, longTermGains, lotsUsed };
+  }
+
+  /**
+   * Get total shares across all lots
+   */
+  get totalShares(): number {
+    return this.lots.reduce((sum, lot) => sum + lot.shares, 0);
+  }
+
+  /**
+   * Get total cost basis across all lots
+   */
+  get totalCostBasis(): number {
+    return this.lots.reduce((sum, lot) => sum + lot.totalCost, 0);
+  }
+
+  /**
+   * Get total unrealized gains
+   */
+  get unrealizedGains(): number {
+    return Math.max(0, this.amount - this.totalCostBasis);
+  }
+
+  /**
+   * Get count of qualifying vs disqualifying lots based on current date
+   */
+  getLotCounts(asOfDate: Date = new Date()): { qualifying: number; disqualifying: number } {
+    let qualifying = 0;
+    let disqualifying = 0;
+
+    for (const lot of this.lots) {
+      if (this.calculateDispositionType(lot, asOfDate) === 'qualifying') {
+        qualifying++;
+      } else {
+        disqualifying++;
+      }
+    }
+
+    return { qualifying, disqualifying };
+  }
+
+  /**
+   * Get lots that are eligible for sale (meet minimum holding period)
+   */
+  getEligibleLots(asOfDate: Date = new Date()): ESPPLot[] {
+    if (this.minimumHoldingDays <= 0) {
+      return this.lots;
+    }
+
+    return this.lots.filter(lot => {
+      const purchaseDate = new Date(lot.purchaseDate);
+      const daysSincePurchase = (asOfDate.getTime() - purchaseDate.getTime()) / (1000 * 60 * 60 * 24);
+      return daysSincePurchase >= this.minimumHoldingDays;
+    });
+  }
+
+  /**
+   * Get total shares that are eligible for sale (meet minimum holding period)
+   */
+  getEligibleShares(asOfDate: Date = new Date()): number {
+    return this.getEligibleLots(asOfDate).reduce((sum, lot) => sum + lot.shares, 0);
+  }
+
+  /**
+   * Check if there are any qualifying lots available for sale
+   */
+  hasQualifyingLots(asOfDate: Date = new Date()): boolean {
+    const eligibleLots = this.getEligibleLots(asOfDate);
+    return eligibleLots.some(lot => this.calculateDispositionType(lot, asOfDate) === 'qualifying');
+  }
+
+  /**
+   * Add a new lot from an ESPP purchase
+   */
+  addLot(lot: ESPPLot): ESPPAccount {
+    const newLots = [...this.lots, lot];
+    const newAmount = this.amount + (lot.fmvAtPurchase * lot.shares);
+
+    return new ESPPAccount(
+      this.id,
+      this.name,
+      newAmount,
+      newLots,
+      this.linkedIncomeId,
+      this.customROR,
+      this.stockTicker,
+      this.currentSharePrice,
+      this.withdrawalPreference,
+      this.minimumHoldingDays
+    );
+  }
+
+  /**
+   * Remove shares from lots (FIFO) after a sale
+   * @param lotOrder - Order to remove lots: 'fifo', 'disqualifying_first', or 'qualifying_first'
+   */
+  removeSoldShares(
+    sharesToRemove: number,
+    salePrice: number,
+    saleDate?: Date,
+    lotOrder: 'fifo' | 'disqualifying_first' | 'qualifying_first' = 'fifo'
+  ): ESPPAccount {
+    let remaining = sharesToRemove;
+    const newLots: ESPPLot[] = [];
+    const useSaleDate = saleDate || new Date();
+    const sortedLots = this.sortLots(this.lots, useSaleDate, lotOrder);
+
+    for (const lot of sortedLots) {
+      if (remaining >= lot.shares) {
+        // Use entire lot
+        remaining -= lot.shares;
+      } else if (remaining > 0) {
+        // Partial lot - keep the remainder
+        const remainingShares = lot.shares - remaining;
+        newLots.push({
+          ...lot,
+          shares: remainingShares,
+          totalCost: lot.purchasePrice * remainingShares,
+        });
+        remaining = 0;
+      } else {
+        // Keep the lot as-is
+        newLots.push(lot);
+      }
+    }
+
+    const saleProceeds = sharesToRemove * salePrice;
+    const newAmount = this.amount - saleProceeds;
+
+    return new ESPPAccount(
+      this.id,
+      this.name,
+      Math.max(0, newAmount),
+      newLots,
+      this.linkedIncomeId,
+      this.customROR,
+      this.stockTicker,
+      this.currentSharePrice,
+      this.withdrawalPreference,
+      this.minimumHoldingDays
+    );
+  }
+
+  /**
+   * Update a specific lot by ID
+   */
+  updateLot(lotId: string, updates: Partial<ESPPLot>): ESPPAccount {
+    const newLots = this.lots.map(lot =>
+      lot.id === lotId ? { ...lot, ...updates } : lot
+    );
+
+    // Recalculate amount based on lots if shares or FMV changed
+    const totalLotValue = newLots.reduce((sum, lot) => sum + (lot.fmvAtPurchase * lot.shares), 0);
+
+    return new ESPPAccount(
+      this.id,
+      this.name,
+      totalLotValue > 0 ? totalLotValue : this.amount,
+      newLots,
+      this.linkedIncomeId,
+      this.customROR,
+      this.stockTicker,
+      this.currentSharePrice,
+      this.withdrawalPreference,
+      this.minimumHoldingDays
+    );
+  }
+
+  /**
+   * Delete a lot by ID
+   */
+  deleteLot(lotId: string): ESPPAccount {
+    const lotToDelete = this.lots.find(lot => lot.id === lotId);
+    const newLots = this.lots.filter(lot => lot.id !== lotId);
+
+    // Reduce amount by the lot's current value
+    const lotValue = lotToDelete ? lotToDelete.fmvAtPurchase * lotToDelete.shares : 0;
+    const newAmount = Math.max(0, this.amount - lotValue);
+
+    return new ESPPAccount(
+      this.id,
+      this.name,
+      newAmount,
+      newLots,
+      this.linkedIncomeId,
+      this.customROR,
+      this.stockTicker,
+      this.currentSharePrice,
+      this.withdrawalPreference,
+      this.minimumHoldingDays
+    );
+  }
+
+  /**
+   * Increment the account value based on stock growth
+   */
+  increment(
+    assumptions: AssumptionsState,
+    overrideReturnRate?: number
+  ): ESPPAccount {
+    // Priority: overrideReturnRate (Monte Carlo) > customROR (per-account) > global assumptions
+    let returnRate: number;
+    if (overrideReturnRate !== undefined) {
+      returnRate = 1 + overrideReturnRate / 100;
+    } else if (this.customROR !== undefined) {
+      returnRate = 1 + (this.customROR + (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0)) / 100;
+    } else {
+      returnRate = 1 + (assumptions.investments.returnRates.ror + (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0)) / 100;
+    }
+
+    // Grow the overall amount
+    const newAmount = this.amount * returnRate;
+
+    // Note: Lots retain their original cost basis - only the current FMV (amount) grows
+    return new ESPPAccount(
+      this.id,
+      this.name,
+      newAmount,
+      this.lots,
+      this.linkedIncomeId,
+      this.customROR,
+      this.stockTicker,
+      this.currentSharePrice,
+      this.withdrawalPreference,
+      this.minimumHoldingDays
+    );
+  }
+}
+
+export class PropertyAccount extends BaseAccount {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    public ownershipType: 'Financed' | 'Owned',
+    public loanAmount: number,
+    public startingLoanBalance: number,
+    public linkedAccountId: string,
+    public apr: number = 0
+  ) {
+    super(id, name, amount);
+  }
+  increment(
+      assumptions: AssumptionsState, 
+      overrides?: { newLoanBalance?: number; newValue?: number }
+  ): PropertyAccount {
+    let nextValue: number;
+    if (overrides?.newValue !== undefined) {
+        nextValue = overrides.newValue;
+    } else {
+        // Home value grows nominally: real appreciation (housingAppreciation) plus
+        // general inflation when inflation-adjusted. Mirrors the linked-mortgage
+        // valuation path so owned and financed homes appreciate consistently.
+        const generalInflation = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+        nextValue = this.amount * (1 + assumptions.expenses.housingAppreciation / 100 + generalInflation);
+    }
+    let nextLoan: number;
+    if (overrides?.newLoanBalance !== undefined) {
+        nextLoan = overrides.newLoanBalance;
+    } else {
+        nextLoan = this.loanAmount; 
+    }
+
+    return new PropertyAccount(
+      this.id,
+      this.name,
+      nextValue,
+      this.ownershipType,
+      nextLoan, 
+      this.startingLoanBalance,
+      this.linkedAccountId
+    );
+  }
+}
+
+export class DebtAccount extends BaseAccount {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    public linkedAccountId: string,
+    public apr: number = 0
+  ) {
+    super(id, name, amount);
+  }
+  increment(
+      _assumptions: AssumptionsState,
+      overrideBalance?: number
+  ): DebtAccount {
+      const nextAmount = overrideBalance !== undefined
+          ? overrideBalance
+          : this.amount * (1 + this.apr / 100);
+
+      return new DebtAccount(
+          this.id,
+          this.name,
+          nextAmount,
+          this.linkedAccountId,
+          this.apr
+      );
+  }
+}
+
+/**
+ * System-generated debt account for tracking uncovered deficits.
+ * 0% APR, gets paid off before priority allocations.
+ */
+export class DeficitDebtAccount extends DebtAccount {
+  constructor(id: string, name: string, amount: number) {
+    super(id, name, amount, '', 0); // 0% APR, no linked account
+  }
+
+  increment(_assumptions: AssumptionsState, overrideBalance?: number): DeficitDebtAccount {
+    const nextAmount = overrideBalance !== undefined ? overrideBalance : this.amount;
+    return new DeficitDebtAccount(this.id, this.name, nextAmount);
+  }
+}
+
+// Union type for use in State Management
+export type AnyAccount = SavedAccount | InvestedAccount | ESPPAccount | PropertyAccount | DebtAccount | DeficitDebtAccount;
+
+export const ACCOUNT_CATEGORIES = [
+  'Cash',
+  'Invested',
+  'Property',
+  'Debt',
+] as const;
+
+export type AccountCategory = typeof ACCOUNT_CATEGORIES[number];
+
+export const ACCOUNT_COLORS_BACKGROUND: Record<AccountCategory, string> = {
+    Cash: "bg-chart-Fuchsia-50",
+    Invested: "bg-chart-Blue-50",
+    Property: "bg-chart-Yellow-50",
+    Debt: "bg-chart-Red-50",
+  };
+
+export const CLASS_TO_CATEGORY: Record<string, AccountCategory> = {
+    [SavedAccount.name]: 'Cash',
+    [InvestedAccount.name]: 'Invested',
+    [ESPPAccount.name]: 'Invested',
+    [PropertyAccount.name]: 'Property',
+    [DebtAccount.name]: 'Debt',
+    [DeficitDebtAccount.name]: 'Debt',
+};
+
+// Map Categories to their color palettes (using Tailwind classes for simplicity)
+// Uses 5-step gradients (1, 25, 50, 75, 100) defined in :root for SVG access
+const PALETTE_STEPS = [1, 25, 50, 75, 100];
+export const CATEGORY_PALETTES: Record<AccountCategory, string[]> = {
+	Cash: PALETTE_STEPS.map(i => `bg-chart-Fuchsia-${i}`),
+	Invested: PALETTE_STEPS.map(i => `bg-chart-Blue-${i}`),
+	Property: PALETTE_STEPS.map(i => `bg-chart-Yellow-${i}`),
+	Debt: PALETTE_STEPS.map(i => `bg-chart-Red-${i}`),
+};
+
+/**
+ * Robustly creates class instances from raw JSON.
+ * Maps fields explicitly and provides defaults for missing fields.
+ */
+export function reconstituteAccount(data: unknown): AnyAccount | null {
+    if (!hasClassName(data)) return null;
+
+    const id = String(data.id ?? '');
+    const name = String(data.name ?? 'Unnamed Account');
+    const amount = Number(data.amount) || 0;
+
+    switch (data.className) {
+        case 'SavedAccount':
+            return new SavedAccount(id, name, amount, Number(data.apr) || 0);
+
+        case 'InvestedAccount': {
+            const conversionHistory = Array.isArray(data.conversionHistory)
+                ? data.conversionHistory.map((c: any) => ({ year: Number(c.year), amount: Number(c.amount) }))
+                : [];
+            // Clamp persisted values to safe ranges. employerBalance > amount makes
+            // nonVestedAmount/vestedAmount go negative (RMDService then silently skips a
+            // required RMD). costBasis MAY exceed amount for an underwater position
+            // (contributions/conversions above current market value) — that is valid,
+            // so it is floored at 0 but NOT clamped to amount; clamping would erase the
+            // unrealized loss and tax later recovery as phantom gain.
+            const employerBalance = Math.max(0, Math.min(Number(data.employerBalance) || 0, amount));
+            const costBasis = Math.max(0, Number(data.costBasis ?? amount));
+            return new InvestedAccount(
+                id, name, amount,
+                employerBalance,
+                Number(data.tenureYears) || 0,
+                Number(data.expenseRatio ?? 0.1),
+                (data.taxType as TaxType) ?? 'Brokerage',
+                (data.isContributionEligible as boolean) ?? true,
+                Number(data.vestedPerYear ?? 0.2),
+                costBasis,
+                data.customROR !== undefined ? Number(data.customROR) : undefined,
+                conversionHistory
+            );
+        }
+
+        case 'ESPPAccount': {
+            const lotsData = Array.isArray(data.lots) ? data.lots : [];
+            const lots: ESPPLot[] = lotsData.map((lot: Record<string, unknown>) => ({
+                id: String(lot.id ?? ''),
+                grantDate: parseDate(lot.grantDate, new Date()) as Date,
+                purchaseDate: parseDate(lot.purchaseDate, new Date()) as Date,
+                fmvAtGrant: Number(lot.fmvAtGrant) || 0,
+                fmvAtPurchase: Number(lot.fmvAtPurchase) || 0,
+                purchasePrice: Number(lot.purchasePrice) || 0,
+                shares: Number(lot.shares) || 0,
+                totalCost: Number(lot.totalCost) || 0,
+                discountAmount: Number(lot.discountAmount) || 0,
+            }));
+            return new ESPPAccount(
+                id, name, amount, lots,
+                data.linkedIncomeId ? String(data.linkedIncomeId) : null,
+                data.customROR !== undefined ? Number(data.customROR) : undefined,
+                data.stockTicker ? String(data.stockTicker) : undefined,
+                data.currentSharePrice !== undefined ? Number(data.currentSharePrice) : undefined,
+                (data.withdrawalPreference as ESPPWithdrawalPreference) ?? 'fifo',
+                Number(data.minimumHoldingDays) || 0
+            );
+        }
+
+        case 'PropertyAccount':
+            return new PropertyAccount(
+                id, name, amount,
+                (data.ownershipType as 'Financed' | 'Owned') ?? 'Owned',
+                Number(data.loanAmount) || 0,
+                Number(data.startingLoanBalance) || 0,
+                String(data.linkedAccountId ?? '')
+            );
+
+        case 'DebtAccount':
+            return new DebtAccount(
+                id, name, amount,
+                String(data.linkedAccountId ?? ''),
+                Number(data.apr) || 0
+            );
+
+        case 'DeficitDebtAccount':
+            return new DeficitDebtAccount(id, name, amount);
+
+        default:
+            console.warn(`Unknown account type: ${data.className}`);
+            return null;
+    }
+}

--- a/src/components/Objects/Assumptions/AssumptionsContext.tsx
+++ b/src/components/Objects/Assumptions/AssumptionsContext.tsx
@@ -1,0 +1,532 @@
+// @refresh reset - This file exports both components and hooks, so full remount is needed for HMR
+import { createContext, useReducer, useContext, ReactNode, useMemo } from 'react';
+import { useDebouncedLocalStorage } from '../../../hooks/useDebouncedLocalStorage';
+import { EarningsRecord } from '../../../services/SocialSecurityCalculator';
+import { CustomMilestone } from '../../../services/simulation/types';
+
+// Built-in milestone IDs that cannot be removed
+export const BUILTIN_MILESTONE_IDS = {
+    BIRTH: 'BUILTIN_BIRTH',
+    RETIRE: 'BUILTIN_RETIRE',
+    END_OF_PLAN: 'BUILTIN_END_OF_PLAN',
+} as const;
+
+// Check if a milestone is a built-in milestone
+export const isBuiltinMilestone = (id: string): boolean =>
+    Object.values(BUILTIN_MILESTONE_IDS).includes(id as typeof BUILTIN_MILESTONE_IDS[keyof typeof BUILTIN_MILESTONE_IDS]);
+
+// Default values for built-in milestones
+const DEFAULT_BIRTH_YEAR = 1990;
+const DEFAULT_RETIREMENT_AGE = 65;
+const DEFAULT_LIFE_EXPECTANCY = 90;
+
+// Create default built-in milestones
+export const createBuiltinMilestones = (
+    birthYear: number = DEFAULT_BIRTH_YEAR,
+    retirementAge: number = DEFAULT_RETIREMENT_AGE,
+    lifeExpectancy: number = DEFAULT_LIFE_EXPECTANCY
+): CustomMilestone[] => [
+    {
+        id: BUILTIN_MILESTONE_IDS.BIRTH,
+        name: 'Birth',
+        conditions: [{ type: 'YEAR', operator: '=', value: birthYear }],
+        color: 'var(--c-accent-soft)', // blue-500
+    },
+    {
+        id: BUILTIN_MILESTONE_IDS.RETIRE,
+        name: 'Retire',
+        conditions: [{ type: 'AGE', operator: '>=', value: retirementAge }],
+        color: 'var(--c-positive-soft)', // green-500
+    },
+    {
+        id: BUILTIN_MILESTONE_IDS.END_OF_PLAN,
+        name: 'End of Plan',
+        // Trigger AFTER life expectancy year so expenses continue through it
+        conditions: [{ type: 'AGE', operator: '>=', value: lifeExpectancy}],
+        color: 'var(--c-content-subtle)', // gray-500
+    },
+];
+
+// Helper: Get the AGE value from a milestone's first AGE condition
+export const getAgeFromMilestone = (milestone: CustomMilestone | undefined, defaultValue: number): number => {
+    if (!milestone) return defaultValue;
+    const ageCondition = milestone.conditions.find(c => c.type === 'AGE');
+    return ageCondition?.value ?? defaultValue;
+};
+
+// Get birth year from the Birth milestone
+export const getBirthYear = (milestones: CustomMilestone[]): number => {
+    const birthMilestone = milestones.find(m => m.id === BUILTIN_MILESTONE_IDS.BIRTH);
+    if (!birthMilestone) return DEFAULT_BIRTH_YEAR;
+    const yearCondition = birthMilestone.conditions.find(c => c.type === 'YEAR');
+    return yearCondition?.value ?? DEFAULT_BIRTH_YEAR;
+};
+
+// Get retirement age from the Retire milestone
+export const getRetirementAge = (milestones: CustomMilestone[]): number => {
+    const retireMilestone = milestones.find(m => m.id === BUILTIN_MILESTONE_IDS.RETIRE);
+    return getAgeFromMilestone(retireMilestone, DEFAULT_RETIREMENT_AGE);
+};
+
+// Get life expectancy from the End of Plan milestone
+export const getLifeExpectancy = (milestones: CustomMilestone[]): number => {
+    const endOfPlanMilestone = milestones.find(m => m.id === BUILTIN_MILESTONE_IDS.END_OF_PLAN);
+    const rawValue = getAgeFromMilestone(endOfPlanMilestone, DEFAULT_LIFE_EXPECTANCY);
+    return rawValue;
+};
+
+export type CapType = 'MAX' | 'FIXED' | 'REMAINDER' | 'MULTIPLE_OF_EXPENSES';
+
+export interface PriorityBucket {
+  id: string;
+  name: string; // e.g., "Max out 401k"
+  type: 'DEBT' | 'INVESTMENT' | 'SAVINGS';
+  accountId?: string; // Link to your actual Account IDs
+  capType: CapType;
+  capValue?: number; // e.g., 23000 for 401k, or 500 for monthly savings
+}
+
+export interface WithdrawalBucket {
+  id: string;
+  name: string;      // e.g. "Emergency Fund", "Brokerage"
+  accountId: string; // The account to drain
+  maxAmount?: number; // Optional cap on annual withdrawal from this bucket (e.g., to stay in a tax bracket)
+}
+
+export interface AssumptionsState {
+  macro: {
+    inflationRate: number;       // e.g., 3.0
+    healthcareInflation: number; // e.g., 5.0
+    inflationAdjusted: boolean;   // usually true (pegged to inflation)
+  };
+  income: {
+    salaryGrowth: number;        // e.g., 3.0
+    qualifiesForSocialSecurity: boolean; // Whether user expects to receive SS benefits
+    socialSecurityFundingPercent: number; // Expected % of SS benefits (e.g., 75 if pessimistic about solvency)
+  };
+  expenses: {
+    lifestyleCreep: number;      // e.g., 50.0 (% of raise spent)
+    housingAppreciation: number; // e.g., 3.5
+    rentInflation: number;       // e.g., 4.0
+  };
+  investments: {
+    returnRates: {
+      ror: number;   // e.g., 10.0
+    };
+    withdrawalStrategy: 'None' | 'Needs Based' | 'Fixed Real' | 'Percentage' | 'Guyton Klinger';
+    withdrawalRate: number; // e.g., 4.0
+    // Guyton-Klinger guardrail settings
+    gkUpperGuardrail: number;     // Default 1.2 (20% above target triggers cut)
+    gkLowerGuardrail: number;     // Default 0.8 (20% below target triggers boost)
+    gkAdjustmentPercent: number;  // Default 10 (10% cut/increase per GK rules)
+    // Auto Roth conversions during retirement
+    autoRothConversions: boolean; // Automatically convert Traditional to Roth in low-tax years
+    // Which algorithm decides the per-year conversion amount when auto-conversions are on.
+    // 'rate-match' = bracket-walk that compares this year's marginal to projected RMD-age marginal.
+    // 'dp-precomputed' = experimental backward-induction DP solved once over the full horizon.
+    rothConversionStrategy?: 'rate-match' | 'dp-precomputed';
+    // Rate-match conversion: minimum percentage-point gap between current marginal
+    // rate and projected RMD-age marginal rate to justify converting that bracket.
+    // Higher = more conservative (skip conversions with smaller savings).
+    // 0.05 = "convert at 12% to dodge 22% only if savings ≥ 5pp."
+    rothConversionMinRateGap?: number;
+    // DP-precomputed conversion: per-year back-load preference (δ).
+    // V(t, b) = min over c of [tax(c) + (1 / (1 + δ)) × V(t+1, b')].
+    // δ > 0 makes future tax look slightly cheaper than present tax, biasing
+    // the optimal plan toward later conversions (SORR-friendly) at the cost of
+    // some lifetime-tax efficiency. 0 = lifetime-optimal (mildly front-loaded).
+    // 0.015 = 1.5%/yr (default). See RothConversionDP.ts for derivation.
+    rothConversionDPBackloadDelta?: number;
+    // Tax Optimization Mode
+    taxOptimizationEnabled: boolean; // When enabled, uses smart withdrawal order and auto-calculated Roth conversions
+    acaAware: boolean; // When true, limit Roth conversions to stay under ACA subsidy cliff (pre-65)
+    };
+  demographics: {
+    priorEarnings?: EarningsRecord[];  // SSA earnings history imported from XML
+    priorYearMode?: boolean;  // If true, simulation starts from last year using verified data
+    // NOTE: birthYear, retirementAge, and lifeExpectancy are derived from milestones
+    // Use getBirthYear(), getRetirementAge(), getLifeExpectancy() helpers
+  };
+  display: {
+    useCompactCurrency: boolean; // Show $1.2M instead of $1,200,000
+    showExperimentalFeatures: boolean; // Show Tax, Scenarios, Ratios tabs
+    hsaEligible: boolean; // Whether user has HDHP and is eligible for HSA
+  };
+  priorities: PriorityBucket[];
+  withdrawalStrategy: WithdrawalBucket[]; // The "Burn Order"
+  milestones: CustomMilestone[]; // User-defined milestone triggers
+}
+
+export const defaultAssumptions: AssumptionsState = {
+  macro: {
+    inflationRate: 2.6,
+    healthcareInflation: 3.9,
+    inflationAdjusted: true,
+  },
+  income: {
+    salaryGrowth: 1.0,
+    qualifiesForSocialSecurity: true,
+    socialSecurityFundingPercent: 100, // 100% = full benefits, reduce if pessimistic about SS solvency
+  },
+  expenses: {
+    lifestyleCreep: 75.0,
+    housingAppreciation: 1.4,
+    rentInflation: 1.2,
+  },
+  investments: {
+    returnRates: { ror: 5.9 },
+    withdrawalStrategy: 'Fixed Real',
+    withdrawalRate: 4.0,
+    gkUpperGuardrail: 1.2,      // Cut when rate > target * 1.2
+    gkLowerGuardrail: 0.8,      // Boost when rate < target * 0.8
+    gkAdjustmentPercent: 10,    // 10% adjustment (per actual GK rules)
+    autoRothConversions: false, // Auto-convert Traditional to Roth in retirement
+    rothConversionStrategy: 'rate-match', // 'rate-match' (default) | 'dp-precomputed' (experimental)
+    rothConversionMinRateGap: 0.05, // 5pp minimum savings to justify a non-free conversion (rate-match algorithm)
+    rothConversionDPBackloadDelta: 0.015, // 1.5%/yr default — DP-precomputed back-load preference
+    taxOptimizationEnabled: false, // Disabled by default - use manual withdrawal order
+    acaAware: true, // Limit Roth conversions to stay under ACA subsidy cliff (pre-65)
+  },
+  demographics: {
+    priorYearMode: false, // Default to current year mode
+    // birthYear, retirementAge, lifeExpectancy are now in milestones
+  },
+  display: {
+    useCompactCurrency: true,
+    showExperimentalFeatures: false,
+    hsaEligible: true,
+  },
+  priorities: [],
+  withdrawalStrategy: [],
+  milestones: createBuiltinMilestones(), // Built-in milestones with default values (birth 1990, retire 65, life 90)
+};
+
+/**
+ * Deep merge saved data with defaults, ensuring all fields exist.
+ * This handles cases where old localStorage data is missing newer fields.
+ */
+function migrateAssumptions(saved: unknown, defaults: AssumptionsState): AssumptionsState {
+  // If saved is not an object, return defaults
+  if (!saved || typeof saved !== 'object' || Array.isArray(saved)) {
+    return defaults;
+  }
+
+  const data = saved as Record<string, unknown>;
+
+  // Helper to safely merge nested objects
+  const mergeSection = <T extends Record<string, unknown>>(
+    savedSection: unknown,
+    defaultSection: T
+  ): T => {
+    if (!savedSection || typeof savedSection !== 'object' || Array.isArray(savedSection)) {
+      return defaultSection;
+    }
+    const section = savedSection as Record<string, unknown>;
+    const result = { ...defaultSection };
+
+    for (const key of Object.keys(defaultSection)) {
+      const defaultValue = defaultSection[key];
+      const savedValue = section[key];
+
+      // If savedValue exists and is the right type, use it
+      if (savedValue !== undefined && savedValue !== null) {
+        // Type check: ensure saved value matches expected type
+        if (typeof savedValue === typeof defaultValue) {
+          (result as Record<string, unknown>)[key] = savedValue;
+        } else if (typeof defaultValue === 'object' && !Array.isArray(defaultValue) && defaultValue !== null) {
+          // Recursively merge nested objects
+          (result as Record<string, unknown>)[key] = mergeSection(
+            savedValue,
+            defaultValue as Record<string, unknown>
+          );
+        }
+        // If types don't match, keep the default
+      }
+      // If savedValue is undefined/null, keep the default
+    }
+    return result;
+  };
+
+  // Build migrated state by merging each section
+  const migrated: AssumptionsState = {
+    macro: mergeSection(data.macro, defaults.macro),
+    income: mergeSection(data.income, defaults.income),
+    expenses: mergeSection(data.expenses, defaults.expenses),
+    investments: {
+      ...mergeSection(data.investments, defaults.investments),
+      // Ensure nested returnRates is also merged
+      returnRates: mergeSection(
+        (data.investments as Record<string, unknown>)?.returnRates,
+        defaults.investments.returnRates
+      ),
+    },
+    demographics: mergeSection(data.demographics, defaults.demographics),
+    display: mergeSection(data.display, defaults.display),
+    // Arrays: use saved if it's a valid array, otherwise use default
+    priorities: Array.isArray(data.priorities) ? data.priorities as PriorityBucket[] : defaults.priorities,
+    withdrawalStrategy: Array.isArray(data.withdrawalStrategy) ? data.withdrawalStrategy as WithdrawalBucket[] : defaults.withdrawalStrategy,
+    milestones: Array.isArray(data.milestones) ? data.milestones as CustomMilestone[] : defaults.milestones,
+  };
+
+  // Migration: Get legacy values from old demographics if present
+  const savedDemographics = data.demographics as Record<string, unknown> | undefined;
+
+  // priorEarnings is a saved-only demographics field (absent from the defaults
+  // object), so the mergeSection above silently drops it on every reload.
+  // Preserve the imported SSA earnings history explicitly — the SS benefit
+  // projection (IncomeProjection) depends on it.
+  if (savedDemographics?.priorEarnings !== undefined && savedDemographics?.priorEarnings !== null) {
+    migrated.demographics.priorEarnings = savedDemographics.priorEarnings as EarningsRecord[];
+  }
+
+  // Handle very old format with startAge/startYear
+  let legacyBirthYear = savedDemographics?.birthYear as number | undefined;
+  if (!legacyBirthYear && savedDemographics) {
+    const startAge = savedDemographics.startAge as number | undefined;
+    const startYear = savedDemographics.startYear as number | undefined;
+    if (startAge !== undefined && startYear !== undefined) {
+      legacyBirthYear = startYear - startAge;
+    } else if (startAge !== undefined) {
+      legacyBirthYear = new Date().getFullYear() - startAge;
+    }
+  }
+
+  const legacyRetirementAge = savedDemographics?.retirementAge as number | undefined;
+  const legacyLifeExpectancy = savedDemographics?.lifeExpectancy as number | undefined;
+
+  // Use legacy values or defaults for creating built-in milestones
+  const birthYearForMilestones = legacyBirthYear ?? DEFAULT_BIRTH_YEAR;
+  const retirementAgeForMilestones = legacyRetirementAge ?? DEFAULT_RETIREMENT_AGE;
+  const lifeExpectancyForMilestones = legacyLifeExpectancy ?? DEFAULT_LIFE_EXPECTANCY;
+
+  // Migration: Ensure built-in milestones always exist
+  const existingIds = new Set(migrated.milestones.map(m => m.id));
+
+  // If Birth milestone doesn't exist, create it with legacy or default value
+  if (!existingIds.has(BUILTIN_MILESTONE_IDS.BIRTH)) {
+    migrated.milestones.unshift({
+      id: BUILTIN_MILESTONE_IDS.BIRTH,
+      name: 'Birth',
+      conditions: [{ type: 'YEAR', operator: '=', value: birthYearForMilestones }],
+      color: 'var(--c-accent-soft)',
+    });
+  }
+
+  // If Retire milestone doesn't exist, create it with legacy or default value
+  if (!existingIds.has(BUILTIN_MILESTONE_IDS.RETIRE)) {
+    const birthIndex = migrated.milestones.findIndex(m => m.id === BUILTIN_MILESTONE_IDS.BIRTH);
+    const insertIndex = birthIndex >= 0 ? birthIndex + 1 : 0;
+    migrated.milestones.splice(insertIndex, 0, {
+      id: BUILTIN_MILESTONE_IDS.RETIRE,
+      name: 'Retire',
+      conditions: [{ type: 'AGE', operator: '>=', value: retirementAgeForMilestones }],
+      color: 'var(--c-positive-soft)',
+    });
+  }
+
+  // If End of Plan milestone doesn't exist, create it with legacy or default value
+  if (!existingIds.has(BUILTIN_MILESTONE_IDS.END_OF_PLAN)) {
+    const retireIndex = migrated.milestones.findIndex(m => m.id === BUILTIN_MILESTONE_IDS.RETIRE);
+    const insertIndex = retireIndex >= 0 ? retireIndex + 1 : 0;
+    migrated.milestones.splice(insertIndex, 0, {
+      id: BUILTIN_MILESTONE_IDS.END_OF_PLAN,
+      name: 'End of Plan',
+      // Trigger AFTER life expectancy year so expenses continue through it
+      conditions: [{ type: 'AGE', operator: '>=', value: lifeExpectancyForMilestones }],
+      color: 'var(--c-content-subtle)',
+    });
+  }
+
+  // Ensure built-in milestones have correct names and formats
+  migrated.milestones = migrated.milestones.map(m => {
+    if (m.id === BUILTIN_MILESTONE_IDS.BIRTH) {
+      return { ...m, name: 'Birth' };
+    }
+    if (m.id === BUILTIN_MILESTONE_IDS.RETIRE) {
+      return { ...m, name: 'Retire' };
+    }
+    if (m.id === BUILTIN_MILESTONE_IDS.END_OF_PLAN) {
+      // Migrate old format (operator '>') to new format (operator '>=') preserving
+      // the age value: getLifeExpectancy returns this value verbatim, so it must equal
+      // the intended life expectancy for both fresh and migrated users (no +1).
+      const ageCondition = m.conditions.find(c => c.type === 'AGE');
+      if (ageCondition && ageCondition.operator === '>') {
+        return {
+          ...m,
+          name: 'End of Plan',
+          conditions: [{ type: 'AGE' as const, operator: '>=' as const, value: ageCondition.value }],
+        };
+      }
+      return { ...m, name: 'End of Plan' };
+    }
+    return m;
+  });
+
+  // Clear deprecated fields (they're now derived from milestones)
+  delete (migrated.demographics as Record<string, unknown>).birthYear;
+  delete (migrated.demographics as Record<string, unknown>).retirementAge;
+  delete (migrated.demographics as Record<string, unknown>).lifeExpectancy;
+
+  return migrated;
+}
+
+type Action =
+  | { type: 'UPDATE_MACRO'; payload: Partial<AssumptionsState['macro']> }
+  | { type: 'UPDATE_INCOME'; payload: Partial<AssumptionsState['income']> }
+  | { type: 'UPDATE_EXPENSES'; payload: Partial<AssumptionsState['expenses']> }
+  | { type: 'UPDATE_INVESTMENTS'; payload: Partial<AssumptionsState['investments']> }
+  | { type: 'UPDATE_INVESTMENT_RATES'; payload: Partial<AssumptionsState['investments']['returnRates']> }
+  | { type: 'UPDATE_DEMOGRAPHICS'; payload: Partial<AssumptionsState['demographics']> }
+  | { type: 'UPDATE_DISPLAY'; payload: Partial<AssumptionsState['display']> }
+  | { type: 'RESET_DEFAULTS' }
+  | { type: 'SET_BULK_DATA'; payload: AssumptionsState }
+  | { type: 'SET_PRIORITIES'; payload: PriorityBucket[] }
+  | { type: 'ADD_PRIORITY'; payload: PriorityBucket }
+  | { type: 'REMOVE_PRIORITY'; payload: string }
+  | { type: 'UPDATE_PRIORITY'; payload: PriorityBucket }
+  | { type: 'SET_WITHDRAWAL_STRATEGY'; payload: WithdrawalBucket[] }
+  | { type: 'ADD_WITHDRAWAL_STRATEGY'; payload: WithdrawalBucket }
+  | { type: 'REMOVE_WITHDRAWAL_STRATEGY'; payload: string }
+  | { type: 'UPDATE_WITHDRAWAL_STRATEGY'; payload: WithdrawalBucket }
+  | { type: 'SET_PRIOR_EARNINGS'; payload: EarningsRecord[] }
+  | { type: 'CLEAR_PRIOR_EARNINGS' }
+  | { type: 'SET_MILESTONES'; payload: CustomMilestone[] }
+  | { type: 'ADD_MILESTONE'; payload: CustomMilestone }
+  | { type: 'REMOVE_MILESTONE'; payload: string }
+  | { type: 'UPDATE_MILESTONE'; payload: CustomMilestone };
+
+const assumptionsReducer = (state: AssumptionsState, action: Action): AssumptionsState => {
+  switch (action.type) {
+    case 'UPDATE_MACRO':
+      return { ...state, macro: { ...state.macro, ...action.payload } };
+    case 'UPDATE_INCOME':
+      return { ...state, income: { ...state.income, ...action.payload } };
+    case 'UPDATE_EXPENSES':
+      return { ...state, expenses: { ...state.expenses, ...action.payload } };
+    case 'UPDATE_INVESTMENTS':
+      return { ...state, investments: { ...state.investments, ...action.payload } };
+    case 'UPDATE_INVESTMENT_RATES':
+      return {
+        ...state,
+        investments: {
+          ...state.investments,
+          returnRates: { ...state.investments.returnRates, ...action.payload },
+        },
+      };
+    case 'UPDATE_DEMOGRAPHICS':
+      return { ...state, demographics: { ...state.demographics, ...action.payload } };
+    case 'UPDATE_DISPLAY':
+      return { ...state, display: { ...state.display, ...action.payload } };
+    case 'RESET_DEFAULTS':
+      // Preserve user's allocations, withdrawal order, and milestones
+      return {
+        ...defaultAssumptions,
+        priorities: state.priorities,
+        withdrawalStrategy: state.withdrawalStrategy,
+        milestones: state.milestones,
+      };
+    case 'SET_BULK_DATA':
+      return action.payload;
+    case 'SET_PRIORITIES':
+        return { ...state, priorities: action.payload };
+    case 'ADD_PRIORITY':
+        return { ...state, priorities: [...state.priorities, action.payload] };
+    case 'REMOVE_PRIORITY':
+        return { ...state, priorities: state.priorities.filter(p => p.id !== action.payload) };
+    case 'UPDATE_PRIORITY':
+        return { 
+            ...state, 
+            priorities: state.priorities.map(p => p.id === action.payload.id ? action.payload : p) 
+        };
+    case 'SET_WITHDRAWAL_STRATEGY':
+        return { ...state, withdrawalStrategy: action.payload };
+    case 'ADD_WITHDRAWAL_STRATEGY':
+        return { ...state, withdrawalStrategy: [...state.withdrawalStrategy, action.payload] };
+    case 'REMOVE_WITHDRAWAL_STRATEGY':
+        return { ...state, withdrawalStrategy: state.withdrawalStrategy.filter(p => p.id !== action.payload) };
+    case 'UPDATE_WITHDRAWAL_STRATEGY':
+        return {
+            ...state,
+            withdrawalStrategy: state.withdrawalStrategy.map(p => p.id === action.payload.id ? action.payload : p)
+        };
+    case 'SET_PRIOR_EARNINGS':
+        return {
+            ...state,
+            demographics: { ...state.demographics, priorEarnings: action.payload }
+        };
+    case 'CLEAR_PRIOR_EARNINGS':
+        return {
+            ...state,
+            demographics: { ...state.demographics, priorEarnings: undefined }
+        };
+    case 'SET_MILESTONES':
+        return { ...state, milestones: action.payload };
+    case 'ADD_MILESTONE':
+        return { ...state, milestones: [...state.milestones, action.payload] };
+    case 'REMOVE_MILESTONE':
+        // Prevent removing built-in milestones
+        if (isBuiltinMilestone(action.payload)) {
+            return state;
+        }
+        return { ...state, milestones: state.milestones.filter(m => m.id !== action.payload) };
+    case 'UPDATE_MILESTONE': {
+        // For built-in milestones, preserve the name
+        const updatedMilestone = isBuiltinMilestone(action.payload.id)
+            ? { ...action.payload, name: state.milestones.find(m => m.id === action.payload.id)?.name || action.payload.name }
+            : action.payload;
+        return {
+            ...state,
+            milestones: state.milestones.map(m => m.id === updatedMilestone.id ? updatedMilestone : m)
+        };
+    }
+    default:
+      return state;
+  }
+};
+
+interface AssumptionsContextProps {
+    state: AssumptionsState;
+    dispatch: React.Dispatch<Action>;
+}
+
+export const AssumptionsContext = createContext<AssumptionsContextProps>({
+  state: defaultAssumptions,
+  dispatch: () => null,
+})
+
+export const AssumptionsProvider = ({ children }: { children: ReactNode }) => {
+  const [state, dispatch] = useReducer(assumptionsReducer, defaultAssumptions, (initial) => {
+    const saved = localStorage.getItem('assumptions_settings');
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        // Deep merge with defaults to handle missing fields from older versions
+        return migrateAssumptions(parsed, initial);
+      } catch (e) {
+        // JSON parse failed - return defaults
+        return initial;
+      }
+    }
+    return initial;
+  });
+
+  // Debounced localStorage persistence (500ms delay to prevent main thread blocking)
+  useDebouncedLocalStorage('assumptions_settings', state);
+
+  // Memoize context value to prevent unnecessary re-renders
+  const contextValue = useMemo(() => ({
+    state,
+    dispatch
+  }), [state, dispatch]);
+
+  return <AssumptionsContext.Provider value={contextValue}>{children}</AssumptionsContext.Provider>;
+};
+
+/**
+ * Custom hook to access assumptions state
+ * @returns Object containing assumptions state and dispatch function
+ */
+export const useAssumptions = () => {
+  const { state, dispatch } = useContext(AssumptionsContext);
+  return { assumptions: state, dispatch };
+};

--- a/src/components/Objects/Assumptions/MonteCarloContext.tsx
+++ b/src/components/Objects/Assumptions/MonteCarloContext.tsx
@@ -1,0 +1,162 @@
+/* @refresh reset */
+import { createContext, useReducer, useContext, ReactNode, useMemo, useCallback } from 'react';
+import { useDebouncedLocalStorage } from '../../../hooks/useDebouncedLocalStorage';
+import {
+    MonteCarloConfig,
+    MonteCarloState,
+    MonteCarloAction,
+    defaultMonteCarloConfig,
+    initialMonteCarloState,
+} from '../../../services/MonteCarloTypes';
+import { runMonteCarloSimulation } from '../../../services/MonteCarloEngine';
+import { createRandomSeed } from '../../../services/RandomGenerator';
+import { AnyAccount } from '../Accounts/models';
+import { AnyIncome } from '../Income/models';
+import { AnyExpense } from '../Expense/models';
+import { AssumptionsState } from './AssumptionsContext';
+import { TaxState } from '../Taxes/TaxContext';
+
+function monteCarloReducer(state: MonteCarloState, action: MonteCarloAction): MonteCarloState {
+    switch (action.type) {
+        case 'UPDATE_CONFIG':
+            return { ...state, config: { ...state.config, ...action.payload } };
+        case 'START_SIMULATION':
+            return { ...state, isRunning: true, progress: 0, error: null };
+        case 'UPDATE_PROGRESS':
+            return { ...state, progress: action.payload };
+        case 'COMPLETE_SIMULATION':
+            return { ...state, isRunning: false, progress: 100, summary: action.payload, error: null };
+        case 'SIMULATION_ERROR':
+            return { ...state, isRunning: false, progress: 0, error: action.payload };
+        case 'RESET':
+            return { ...initialMonteCarloState, config: state.config };
+        default:
+            return state;
+    }
+}
+
+function loadMonteCarloConfig(initial: MonteCarloState): MonteCarloState {
+    try {
+        const saved = localStorage.getItem('monte_carlo_config');
+        if (saved) {
+            const parsed = JSON.parse(saved);
+            return { ...initial, config: { ...defaultMonteCarloConfig, ...parsed } };
+        }
+    } catch {
+        // Fall through to return initial
+    }
+    return initial;
+}
+
+interface MonteCarloContextProps {
+    state: MonteCarloState;
+    dispatch: React.Dispatch<MonteCarloAction>;
+    runSimulation: (
+        accounts: AnyAccount[],
+        incomes: AnyIncome[],
+        expenses: AnyExpense[],
+        assumptions: AssumptionsState,
+        taxState: TaxState
+    ) => Promise<void>;
+    updateConfig: (config: Partial<MonteCarloConfig>) => void;
+    resetResults: () => void;
+    generateNewSeed: () => void;
+}
+
+export const MonteCarloContext = createContext<MonteCarloContextProps>({
+    state: initialMonteCarloState,
+    dispatch: () => null,
+    runSimulation: async () => {},
+    updateConfig: () => {},
+    resetResults: () => {},
+    generateNewSeed: () => {},
+});
+
+export function MonteCarloProvider({ children }: { children: ReactNode }): React.ReactElement {
+    const [state, dispatch] = useReducer(monteCarloReducer, initialMonteCarloState, loadMonteCarloConfig);
+
+    // Persist config only (not transient simulation state)
+    useDebouncedLocalStorage('monte_carlo_config', state.config);
+
+    const runSimulation = useCallback(async (
+        accounts: AnyAccount[],
+        incomes: AnyIncome[],
+        expenses: AnyExpense[],
+        assumptions: AssumptionsState,
+        taxState: TaxState
+    ) => {
+        dispatch({ type: 'START_SIMULATION' });
+        try {
+            const summary = await runMonteCarloSimulation(
+                state.config,
+                accounts,
+                incomes,
+                expenses,
+                assumptions,
+                taxState,
+                (progress) => dispatch({ type: 'UPDATE_PROGRESS', payload: progress })
+            );
+            dispatch({ type: 'COMPLETE_SIMULATION', payload: summary });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Simulation failed';
+            dispatch({ type: 'SIMULATION_ERROR', payload: message });
+        }
+    }, [state.config]);
+
+    const updateConfig = useCallback((config: Partial<MonteCarloConfig>) => {
+        dispatch({ type: 'UPDATE_CONFIG', payload: config });
+    }, []);
+
+    const resetResults = useCallback(() => {
+        dispatch({ type: 'RESET' });
+    }, []);
+
+    const generateNewSeed = useCallback(() => {
+        dispatch({ type: 'UPDATE_CONFIG', payload: { seed: createRandomSeed() } });
+    }, []);
+
+    const contextValue = useMemo(() => ({
+        state,
+        dispatch,
+        runSimulation,
+        updateConfig,
+        resetResults,
+        generateNewSeed,
+    }), [state, runSimulation, updateConfig, resetResults, generateNewSeed]);
+
+    return (
+        <MonteCarloContext.Provider value={contextValue}>
+            {children}
+        </MonteCarloContext.Provider>
+    );
+}
+
+/**
+ * Custom hook to access Monte Carlo state and actions
+ */
+export const useMonteCarlo = () => {
+    const context = useContext(MonteCarloContext);
+    if (!context) {
+        throw new Error('useMonteCarlo must be used within a MonteCarloProvider');
+    }
+    return context;
+};
+
+/**
+ * Selector hooks for specific pieces of state
+ */
+export const useMonteCarloConfig = () => {
+    const { state, updateConfig, generateNewSeed } = useMonteCarlo();
+    return { config: state.config, updateConfig, generateNewSeed };
+};
+
+export const useMonteCarloResults = () => {
+    const { state, resetResults } = useMonteCarlo();
+    return {
+        summary: state.summary,
+        isRunning: state.isRunning,
+        progress: state.progress,
+        error: state.error,
+        resetResults,
+    };
+};

--- a/src/components/Objects/Assumptions/SimulationContext.tsx
+++ b/src/components/Objects/Assumptions/SimulationContext.tsx
@@ -1,0 +1,95 @@
+import { createContext, ReactNode, Dispatch, useMemo } from 'react';
+import { SimulationYear } from './SimulationEngine';
+import { AnyAccount, reconstituteAccount } from '../Accounts/models';
+import { AnyIncome, reconstituteIncome } from '../Income/models';
+import { AnyExpense, reconstituteExpense } from '../Expense/models';
+import { usePersistedReducer } from '../../../hooks/usePersistedReducer';
+
+const STORAGE_KEY = 'user_simulation_data';
+
+interface SimulationState {
+  simulation: SimulationYear[];
+  inputHash: string | null;
+}
+
+type Action =
+  | { type: 'SET_SIMULATION'; payload: SimulationYear[] }
+  | { type: 'SET_SIMULATION_WITH_HASH'; payload: { simulation: SimulationYear[]; inputHash: string } };
+
+const initialState: SimulationState = {
+  simulation: [],
+  inputHash: null,
+};
+
+function simulationReducer(state: SimulationState, action: Action): SimulationState {
+  switch (action.type) {
+    case 'SET_SIMULATION':
+      return { ...state, simulation: action.payload };
+    case 'SET_SIMULATION_WITH_HASH':
+      return {
+        ...state,
+        simulation: action.payload.simulation,
+        inputHash: action.payload.inputHash,
+      };
+    default:
+      return state;
+  }
+}
+
+function reconstituteSimulationYear(yearData: unknown): SimulationYear {
+  const data = yearData as {
+    accounts?: unknown[];
+    incomes?: unknown[];
+    expenses?: unknown[];
+    [key: string]: unknown;
+  };
+  return {
+    ...data,
+    accounts: (data.accounts || []).map(reconstituteAccount).filter(Boolean) as AnyAccount[],
+    incomes: (data.incomes || []).map(reconstituteIncome).filter(Boolean) as AnyIncome[],
+    expenses: (data.expenses || []).map(reconstituteExpense).filter(Boolean) as AnyExpense[],
+  } as SimulationYear;
+}
+
+function hydrateSimulationState(parsed: unknown, initial: SimulationState): SimulationState {
+  const data = parsed as { simulation?: unknown[]; inputHash?: string | null };
+  const simulation = (data.simulation || []).map(reconstituteSimulationYear);
+  return { ...initial, simulation, inputHash: data.inputHash || null };
+}
+
+function serializeSimulationState(state: SimulationState): string {
+  return JSON.stringify({
+    ...state,
+    simulation: state.simulation.map((year) => ({
+      ...year,
+      accounts: year.accounts.map((acc) => ({ ...acc, className: acc.constructor.name })),
+      incomes: year.incomes.map((inc) => ({ ...inc, className: inc.constructor.name })),
+      expenses: year.expenses.map((exp) => ({ ...exp, className: exp.constructor.name })),
+    })),
+  });
+}
+
+interface SimulationContextProps extends SimulationState {
+  dispatch: Dispatch<Action>;
+}
+
+export const SimulationContext = createContext<SimulationContextProps>({
+  ...initialState,
+  dispatch: () => null,
+});
+
+export function SimulationProvider({ children }: { children: ReactNode }): React.ReactElement {
+  const [state, dispatch] = usePersistedReducer(simulationReducer, initialState, {
+    storageKey: STORAGE_KEY,
+    hydrate: hydrateSimulationState,
+    serialize: serializeSimulationState,
+  });
+
+  const contextValue = useMemo(() => ({ ...state, dispatch }), [state, dispatch]);
+
+  return (
+    <SimulationContext.Provider value={contextValue}>
+      {children}
+    </SimulationContext.Provider>
+  );
+}

--- a/src/components/Objects/Assumptions/SimulationEngine.tsx
+++ b/src/components/Objects/Assumptions/SimulationEngine.tsx
@@ -1,0 +1,767 @@
+// src/components/Simulation/SimulationEngine.ts
+// Thin orchestrator - delegates to focused service modules.
+
+import { AnyAccount } from "../../Objects/Accounts/models";
+import { AnyExpense, MortgageExpense, LoanExpense, isLongTermGoal, isGoalDueInYear, getGoalFundAnnualSetAside } from "../Expense/models";
+import { AnyIncome, WorkIncome, PassiveIncome } from "../../Objects/Income/models";
+import { AssumptionsState, getBirthYear, BUILTIN_MILESTONE_IDS } from "./AssumptionsContext";
+import { TaxState } from "../../Objects/Taxes/TaxContext";
+import * as TaxService from "../../Objects/Taxes/TaxService";
+
+// Re-export types from the new module structure
+export type { SimulationYear } from "../../../services/simulation/types";
+import { SimulationYear, WithdrawalState, BaselineProjections } from "../../../services/simulation/types";
+
+// Re-export helper for external consumers (e.g., RothConversionService tests)
+export { calculateEffectiveConversionTax } from "../../../services/simulation/helpers";
+
+// Import service modules
+import { projectIncomes } from "../../../services/simulation/IncomeProjection";
+import { processRMDs } from "../../../services/simulation/RMDService";
+import { applyLifestyleCreep, calculateStrategyTarget, calculateTotalDiscretionary } from "../../../services/simulation/SpendingStrategy";
+import { processDeficitDebt } from "../../../services/simulation/WithdrawalService";
+import { processInflows, growAccounts } from "../../../services/simulation/AccountGrowth";
+import { evaluateAllMilestones, isActiveByMilestone, MilestoneContext } from "../../../services/simulation/MilestoneEvaluator";
+import { InvestedAccount, SavedAccount, ESPPAccount } from "../Accounts/models";
+import { solveYear, YearSolverInput } from "../../../services/simulation/YearSolver";
+import { YearPlan } from "../../../services/simulation/types";
+import { buildCashflowDetail } from "../../../services/simulation/CashflowDetailBuilder";
+
+// =============================================================================
+// YearSolver-based simulation engine
+// =============================================================================
+
+/**
+ * Execute a YearPlan by applying withdrawals and conversions to accounts.
+ * This is Phase 3 of the new engine - mutations happen here.
+ */
+function executeYearPlan(
+    plan: YearPlan,
+    accounts: AnyAccount[],
+    withdrawalState: WithdrawalState,
+    logs: string[]
+): { conversionDeposits: Record<string, number> } {
+    const conversionDeposits: Record<string, number> = {};
+
+    // Execute withdrawals
+    for (const withdrawal of plan.withdrawals) {
+        const account = accounts.find(a => a.id === withdrawal.accountId);
+        if (!account || !(account instanceof InvestedAccount || account instanceof SavedAccount || account instanceof ESPPAccount)) {
+            continue;
+        }
+
+        // Skip RMDs — RMDService.processRMDs() already deducted from the account and
+        // recorded the totals. The RMD entry is in plan.withdrawals only as a tracking
+        // record for the solver's iteration logic and consumers that filter by reason.
+        if (withdrawal.reason === 'Required Minimum Distribution') {
+            continue;
+        }
+
+        // Deduct from account (will be applied in growAccounts)
+        withdrawalState.userInflows[account.id] =
+            (withdrawalState.userInflows[account.id] || 0) - withdrawal.gross;
+
+        withdrawalState.totalWithdrawals += withdrawal.gross;
+        withdrawalState.withdrawalDetail[account.name] =
+            (withdrawalState.withdrawalDetail[account.name] || 0) + withdrawal.gross;
+
+        // Track capital gains from brokerage withdrawals
+        if (withdrawal.capitalGains) {
+            withdrawalState.longTermCapitalGains += withdrawal.capitalGains.longTerm;
+            withdrawalState.shortTermCapitalGains += withdrawal.capitalGains.shortTerm;
+        }
+
+        // Track penalties
+        withdrawalState.withdrawalPenalties += withdrawal.penalty;
+
+        // Track Traditional withdrawals for tax calculations
+        if (withdrawal.source === 'traditional_401k' || withdrawal.source === 'traditional_ira') {
+            withdrawalState.traditionalWithdrawals += withdrawal.gross;
+        }
+
+        if (withdrawal.gross > 0) {
+            logs.push(`[V2 exec] Withdrew $${withdrawal.gross.toLocaleString()} from ${withdrawal.accountName} (${withdrawal.reason})`);
+        }
+    }
+
+    // Execute Roth conversion
+    if (plan.conversion) {
+        const sourceAccount = accounts.find(a => a.id === plan.conversion!.fromAccountId);
+        const targetAccount = accounts.find(a => a.id === plan.conversion!.toAccountId);
+
+        if (sourceAccount && targetAccount &&
+            sourceAccount instanceof InvestedAccount && targetAccount instanceof InvestedAccount) {
+
+            // Deduct from source (Traditional)
+            withdrawalState.userInflows[sourceAccount.id] =
+                (withdrawalState.userInflows[sourceAccount.id] || 0) - plan.conversion.amount;
+
+            // Add to target (Roth) - userInflows drives the balance change,
+            // conversionDeposits tracks conversion history in increment()
+            withdrawalState.userInflows[targetAccount.id] =
+                (withdrawalState.userInflows[targetAccount.id] || 0) + plan.conversion.netToRoth;
+            conversionDeposits[targetAccount.id] = plan.conversion.netToRoth;
+
+            logs.push(`[V2] Roth conversion: $${plan.conversion.amount.toLocaleString()} from ${sourceAccount.name} → ${targetAccount.name}`);;
+        }
+    }
+
+    return { conversionDeposits };
+}
+
+/**
+ * Convert YearPlan tax to withdrawal state format for compatibility.
+ * Uses the split tax values from YearPlan:
+ * - capitalGainsLT: tax from brokerage/ESPP withdrawals (have w.capitalGains)
+ * - withdrawalOrdinaryTax: tax from Roth earnings (5-year rule), Traditional, HSA non-medical
+ */
+function updateWithdrawalStateFromPlan(
+    plan: YearPlan,
+    withdrawalState: WithdrawalState
+): void {
+    // Use the pre-split values from YearPlan.tax (computed by YearSolver)
+    withdrawalState.capitalGainsTaxTotal = plan.tax.capitalGainsLT;
+    withdrawalState.withdrawalOrdinaryTaxTotal = plan.tax.withdrawalOrdinaryTax;
+    withdrawalState.withdrawalTaxes = plan.tax.total - plan.tax.fica;
+}
+
+/**
+ * Simulate one year using the new YearSolver-based engine.
+ *
+ * This is the V2 engine that uses:
+ * - Conversion-before-withdrawal ordering
+ * - Algebraic gross-up formulas
+ * - Convergence loop for bracket crossings
+ */
+function simulateOneYearWithNewEngine(
+    year: number,
+    incomes: AnyIncome[],
+    expenses: AnyExpense[],
+    accounts: AnyAccount[],
+    assumptions: AssumptionsState,
+    taxState: TaxState,
+    previousSimulation: SimulationYear[] = [],
+    returnOverride?: number,
+    previousActiveMilestones: string[] = [],
+    previousMilestoneReachYears: Map<string, number> = new Map(),
+    baselineProjections?: BaselineProjections,
+    conversionMode: 'rate-match' | 'std-ded-only' = 'rate-match',
+    dpConversionPlan?: Map<number, number>,
+    dpDebugByYear?: Map<number, string[]>,
+): SimulationYear {
+    const logs: string[] = [];
+    logs.push('[V2 Engine] Using new YearSolver-based simulation');
+
+    // Calculate current age
+    const currentAge = year - getBirthYear(assumptions.milestones);
+
+    // ------------------------------------------------------------------
+    // MILESTONE EVALUATION (same as old engine)
+    // ------------------------------------------------------------------
+    const milestoneContext: MilestoneContext = {
+        accounts,
+        expenses,
+        year,
+        age: currentAge,
+        milestoneReachYears: previousMilestoneReachYears,
+        filingStatus: taxState.filingStatus,
+    };
+
+    const milestoneResult = evaluateAllMilestones(
+        assumptions.milestones || [],
+        new Set(previousActiveMilestones),
+        milestoneContext
+    );
+
+    const activeMilestoneSet = new Set(milestoneResult.activeMilestones);
+    const isRetired = activeMilestoneSet.has(BUILTIN_MILESTONE_IDS.RETIRE);
+
+    milestoneResult.newlyReached.forEach(event => {
+        const milestone = assumptions.milestones?.find(m => m.id === event.milestoneId);
+        if (milestone) {
+            logs.push(`🎯 Milestone reached: "${milestone.name}" at age ${event.ageReached}`);
+        }
+    });
+
+    const previousMilestoneSet = new Set(previousActiveMilestones);
+
+    // ------------------------------------------------------------------
+    // ROTH 401K → ROTH IRA ROLLOVER AT RETIREMENT
+    // ------------------------------------------------------------------
+    // Per IRS Notice 2014-54 and §402A(d)(4), a Roth 401k rolled into a Roth
+    // IRA carries its contribution basis as Roth IRA regular contributions
+    // (immediately tappable, no penalty) and earnings as Roth IRA earnings.
+    // This eliminates the Roth 401k pro-rata distribution rule for retirees
+    // and aligns with how the WithdrawalPlanner already orders Roth dollars
+    // (contributions → conversions → earnings).
+    const justRetired = isRetired && !previousMilestoneSet.has(BUILTIN_MILESTONE_IDS.RETIRE);
+    if (justRetired) {
+        accounts = accounts.map(acc => {
+            if (acc instanceof InvestedAccount && acc.taxType === 'Roth 401k') {
+                logs.push(`💸 Rolled over Roth 401k "${acc.name}" → Roth IRA at retirement (balance $${Math.round(acc.amount).toLocaleString()}, contributions $${Math.round(acc.regularContributions).toLocaleString()})`);
+                return new InvestedAccount(
+                    acc.id,
+                    acc.name,
+                    acc.amount,
+                    acc.employerBalance,
+                    acc.tenureYears,
+                    acc.expenseRatio,
+                    'Roth IRA',
+                    acc.isContributionEligible,
+                    acc.vestedPerYear,
+                    acc.costBasis,
+                    acc.customROR,
+                    acc.conversionHistory,
+                    acc.lots,
+                );
+            }
+            return acc;
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // FILTER INCOMES AND EXPENSES BY MILESTONE
+    // ------------------------------------------------------------------
+    const milestoneFilteredIncomes = incomes.filter(inc => {
+        if (!isActiveByMilestone(inc.startMilestoneId, inc.endMilestoneId, activeMilestoneSet, previousMilestoneSet)) {
+            return false;
+        }
+        if (isRetired && inc instanceof WorkIncome && !inc.endMilestoneId) {
+            return false;
+        }
+        return true;
+    });
+
+    const milestoneFilteredExpenses = expenses.filter(exp =>
+        isActiveByMilestone(exp.startMilestoneId, exp.endMilestoneId, activeMilestoneSet, previousMilestoneSet)
+    );
+
+    // ------------------------------------------------------------------
+    // PROJECT INCOMES (same as old engine)
+    // ------------------------------------------------------------------
+    const incomeResult = projectIncomes(
+        year, milestoneFilteredIncomes, accounts, assumptions, previousSimulation,
+        currentAge, isRetired, logs
+    );
+    const { nextIncomes: incomesWithEarningsTest, allIncomes } = incomeResult;
+
+    // ------------------------------------------------------------------
+    // LIFESTYLE CREEP (same as old engine)
+    // ------------------------------------------------------------------
+    let nextExpenses = milestoneFilteredExpenses.map(exp => {
+        const next = exp.increment(assumptions);
+        // A goal's `amount` is its total cost, funded by a nominal fixed monthly
+        // set-aside (and the budget computes that set-aside from the un-inflated
+        // amount). Inflating the cost here would make the lump outgrow the fund
+        // and silently underfund the purchase, so keep it static.
+        if (isLongTermGoal(exp)) next.amount = exp.amount;
+        return next;
+    });
+    nextExpenses = applyLifestyleCreep(nextExpenses, milestoneFilteredIncomes, assumptions, year, isRetired, logs);
+
+    // ------------------------------------------------------------------
+    // CALCULATE EXPENSES
+    // ------------------------------------------------------------------
+    // Long-term goal funding is COMMITTED, like any other expense — not a
+    // surplus-allocation priority. Each year the goal's monthly set-aside
+    // (derived live from the goal — $0 outside its saving window) is counted
+    // with living expenses so the solver covers it like a bill (withdrawing in
+    // retirement if needed), and the same dollars are credited into the goal's
+    // reserved fund account after account growth — a forced transfer, immune
+    // to priority ordering and surplus availability. Net worth is unchanged by
+    // saving (cash out, fund up); it dips when the lump is spent in the due year.
+    const goalFundCredits = new Map<string, number>(); // fund accountId → annual set-aside
+    for (const e of expenses) {
+        if (!isLongTermGoal(e) || !e.goalAccountId) continue;
+        // Months-prorated: a goal starting in June commits 7 months this year,
+        // and the target year commits only the months before the target.
+        const annual = getGoalFundAnnualSetAside(expenses, e.goalAccountId, year) ?? 0;
+        if (annual > 0) goalFundCredits.set(e.goalAccountId, (goalFundCredits.get(e.goalAccountId) ?? 0) + annual);
+    }
+    const totalGoalFunding = [...goalFundCredits.values()].reduce((s, v) => s + v, 0);
+
+    const totalLivingExpenses = nextExpenses.reduce((sum, exp) => {
+        if (exp instanceof MortgageExpense) {
+            return sum + exp.calculateAnnualAmortization(year).totalPayment;
+        }
+        if (exp instanceof LoanExpense) {
+            return sum + exp.calculateAnnualAmortization(year).totalPayment;
+        }
+        return sum + exp.getAnnualAmount(year);
+    }, 0) + totalGoalFunding;
+
+    // ------------------------------------------------------------------
+    // WITHDRAWAL STRATEGY TARGET (for GK, Fixed Real, etc.)
+    // ------------------------------------------------------------------
+    const strategyWithdrawalResult = isRetired
+        ? calculateStrategyTarget(accounts, assumptions, previousSimulation, year, currentAge, logs)
+        : undefined;
+
+    // ------------------------------------------------------------------
+    // PROCESS RMDs
+    // ------------------------------------------------------------------
+    const totalGrossIncome = TaxService.getGrossIncome(allIncomes, year);
+    const preTaxDeductions = TaxService.getPreTaxExemptions(incomesWithEarningsTest, year);
+
+    const withdrawalState: WithdrawalState = {
+        userInflows: {},
+        employerInflows: {},
+        withdrawalTaxes: 0,
+        capitalGainsTaxTotal: 0,
+        withdrawalOrdinaryTaxTotal: 0,
+        strategyWithdrawalExecuted: 0,
+        totalWithdrawals: 0,
+        withdrawalDetail: {},
+        withdrawalPenalties: 0,
+        totalGrossIncome,
+        traditionalWithdrawals: 0,
+        longTermCapitalGains: 0,
+        shortTermCapitalGains: 0,
+        stateCapitalGainsTax: 0,
+    };
+
+    const rmdResult = processRMDs(
+        year, accounts, assumptions,
+        previousSimulation, currentAge, totalGrossIncome,
+        withdrawalState, logs
+    );
+
+    const rmdDetails = rmdResult.rmdDetails;
+    const rmdIncomes = rmdResult.rmdIncomes;
+    const rmdAmount = rmdDetails?.totalWithdrawn || 0;
+
+    // Add RMD incomes to allIncomes
+    allIncomes.push(...rmdIncomes);
+
+    // ------------------------------------------------------------------
+    // CALL YEAR SOLVER (Phase 2)
+    // ------------------------------------------------------------------
+    // Calculate fixed vs discretionary expenses for GK budget handling
+    const discretionaryExpenses = calculateTotalDiscretionary(nextExpenses, year);
+    const fixedExpenses = totalLivingExpenses - discretionaryExpenses;
+
+    // Legacy cleanup: goals used to create a savings-priority bucket and fund
+    // from surplus. Funding now flows as a committed transfer (see
+    // goalFundCredits above), so any remaining bucket pointing at a goal fund
+    // is zeroed to prevent double-funding old data. Neutralized rather than
+    // dropped: an empty bucket list trips the surplus allocator's
+    // smart-default, which would refill the reserved fund anyway.
+    const goalFundIds = new Set(
+        expenses.filter(e => isLongTermGoal(e) && e.goalAccountId).map(e => e.goalAccountId!)
+    );
+    const effectiveAssumptions = goalFundIds.size > 0
+        ? {
+            ...assumptions,
+            priorities: (assumptions.priorities || []).map(p =>
+                p.accountId && goalFundIds.has(p.accountId)
+                    ? { ...p, capType: 'FIXED' as const, capValue: 0 }
+                    : p
+            ),
+        }
+        : assumptions;
+
+    const solverInput: YearSolverInput = {
+        year,
+        currentAge,
+        isRetired,
+        incomes: allIncomes,
+        expenses: nextExpenses,
+        totalLivingExpenses,
+        rmdAmount,
+        // RMD shortfall excise (25% of unmet required distribution) — solver folds
+        // it into the year's tax/penalties so it reduces cash (Bug #4).
+        rmdPenalty: rmdDetails?.penalty ?? 0,
+        accounts,
+        withdrawalOrder: assumptions.withdrawalStrategy.map(w => ({ accountId: w.accountId })),
+        // Goal funds are reserved: funded directly via goalFundCredits, so the
+        // surplus allocator must not pick them as general savings targets.
+        reservedAccountIds: [...goalFundIds],
+        taxState,
+        assumptions: effectiveAssumptions,
+        strategyResult: strategyWithdrawalResult,
+        taxOptimizationEnabled: assumptions.investments.taxOptimizationEnabled,
+        acaAware: currentAge < 65 && (assumptions.investments.acaAware !== false),
+        previousSimulation: previousSimulation.map(s => ({ year: s.year, accounts: s.accounts })),
+        // GK Guardrails: Pass budget and expense breakdown when strategy is active
+        gkBudget: strategyWithdrawalResult?.amount,
+        fixedExpenses,
+        discretionaryExpenses,
+        // Per-year sub-sim baseline projections. Used by the conversion ceiling
+        // calculator so SS / pension / passive / Trad-balance at RMD come from a
+        // forward sub-simulation that does only std-ded-headroom conversions —
+        // rather than rough estimates or naive forward-compounding.
+        baselineProjections,
+        conversionMode,
+        dpConversionPlan,
+        dpDebugByYear,
+    };
+
+    const yearPlan = solveYear(solverInput);
+
+    // Log decisions from solver (planning phase)
+    yearPlan.decisions.forEach(d => {
+        if (d.category === 'warning') {
+            logs.push(`⚠️ ${d.description}`);
+        } else if (d.category === 'conversion' || d.category === 'withdrawal') {
+            // Always log conversion/withdrawal decisions (skip, reduce, execute)
+            if (d.amount) {
+                logs.push(`[V2 plan] ${d.category}: $${d.amount.toLocaleString()} - ${d.description}`);
+            } else {
+                logs.push(`[V2 plan] ${d.category}: ${d.description}`);
+            }
+        } else if (d.amount) {
+            logs.push(`[V2 plan] ${d.category}: $${d.amount.toLocaleString()} - ${d.description}`);
+        }
+    });
+
+    // ------------------------------------------------------------------
+    // ADJUST EXPENSES FOR GK TRIMMING + BUILD STRATEGY ADJUSTMENT RESULT
+    // ------------------------------------------------------------------
+    // When GK guardrails trim discretionary spending, the solver uses a reduced
+    // effectiveLivingExpenses but the expense objects still report full amounts.
+    // Adjust discretionary expense objects so their getAnnualAmount() values
+    // match the actual trimmed spending. This ensures downstream consumers
+    // (like the Sankey chart) get consistent data without needing corrections.
+    let strategyAdjustmentResult: SimulationYear['strategyAdjustment'] = undefined;
+
+    if (yearPlan.totalExpenses < totalLivingExpenses) {
+        const trimAmount = totalLivingExpenses - yearPlan.totalExpenses;
+        const totalDiscretionary = calculateTotalDiscretionary(nextExpenses, year);
+        if (totalDiscretionary > 0) {
+            const cutRatio = 1 - Math.min(trimAmount, totalDiscretionary) / totalDiscretionary;
+            nextExpenses = nextExpenses.map(exp =>
+                exp.isDiscretionary ? exp.adjustAmount(cutRatio) : exp
+            );
+        }
+
+        // Populate strategyAdjustment so the UI can show warning banners.
+        // This fires for any withdrawal strategy budget cap — including the first
+        // retirement year where guardrailTriggered is 'none' (just the base 4% withdrawal).
+        if (strategyWithdrawalResult) {
+            strategyAdjustmentResult = {
+                guardrailTriggered: strategyWithdrawalResult.guardrailTriggered,
+                requiredAdjustment: trimAmount,
+                actualAdjustment: Math.min(trimAmount, totalDiscretionary),
+                discretionaryAvailable: totalDiscretionary,
+                warning: totalDiscretionary < trimAmount
+                    ? `Fixed expenses exceed budget. Only $${totalDiscretionary.toLocaleString()} of $${trimAmount.toLocaleString()} could be cut.`
+                    : undefined,
+            };
+        }
+    } else if (strategyWithdrawalResult && strategyWithdrawalResult.guardrailTriggered === 'prosperity'
+        && yearPlan.totalExpenses > totalLivingExpenses) {
+        // Prosperity: solver increased spending above original expenses
+        strategyAdjustmentResult = {
+            guardrailTriggered: 'prosperity',
+            requiredAdjustment: 0,
+            actualAdjustment: yearPlan.totalExpenses - totalLivingExpenses,
+            discretionaryAvailable: discretionaryExpenses,
+        };
+    }
+
+    // ------------------------------------------------------------------
+    // EXECUTE YEAR PLAN (Phase 3)
+    // ------------------------------------------------------------------
+    const { conversionDeposits } = executeYearPlan(yearPlan, accounts, withdrawalState, logs);
+    updateWithdrawalStateFromPlan(yearPlan, withdrawalState);
+
+    // ------------------------------------------------------------------
+    // SURPLUS ALLOCATION (from YearPlan - computed by YearSolver)
+    // ------------------------------------------------------------------
+    // Track surplus allocations for Sankey display and account growth
+    // Note: YearSolver already computed the allocations - we just apply them here
+    const surplusBucketDetail: Record<string, number> = {};
+
+    if (yearPlan.surplusAllocations.length > 0) {
+        // Apply surplus allocations to withdrawal state (for account growth) and bucket detail (for Sankey)
+        yearPlan.surplusAllocations.forEach(alloc => {
+            logs.push(`[V2] Surplus allocated: $${alloc.amount.toLocaleString()} to ${alloc.reason}`);
+
+            // Add to userInflows so growAccounts() will deposit the surplus
+            withdrawalState.userInflows[alloc.accountId] =
+                (withdrawalState.userInflows[alloc.accountId] || 0) + alloc.amount;
+
+            // Track in bucket detail for Sankey display
+            surplusBucketDetail[alloc.accountId] =
+                (surplusBucketDetail[alloc.accountId] || 0) + alloc.amount;
+        });
+    }
+
+    // Compute totalSurplusAllocations early so we can subtract it from trueUserSaved
+    // (bucket allocations are counted separately, so they shouldn't also be in "invested")
+    const totalSurplusAllocations = Object.values(surplusBucketDetail).reduce((sum, amt) => sum + amt, 0);
+
+    // ------------------------------------------------------------------
+    // DEFICIT DEBT TRACKING
+    // ------------------------------------------------------------------
+    // V2 path: Use unfundedDeficit from YearSolver to track when expenses
+    // couldn't be covered by income + withdrawals (portfolio failure).
+    // Pass as negative because processDeficitDebt expects negative = deficit.
+    let discretionaryCash = -yearPlan.unfundedDeficit;
+    const deficitDebtResult = processDeficitDebt(discretionaryCash, accounts, logs);
+    const existingDeficitDebt = deficitDebtResult.existingDeficitDebt;
+    discretionaryCash = deficitDebtResult.discretionaryCash;
+
+    // ------------------------------------------------------------------
+    // PROCESS INFLOWS (contributions, matching, etc.)
+    // ------------------------------------------------------------------
+    const inflowResult = processInflows(
+        incomesWithEarningsTest, accounts, assumptions, year, withdrawalState,
+        discretionaryCash, existingDeficitDebt, totalLivingExpenses, currentAge, logs
+    );
+    discretionaryCash = inflowResult.discretionaryCash;
+
+    // ------------------------------------------------------------------
+    // GROW ACCOUNTS (Phase 4)
+    // ------------------------------------------------------------------
+    const nextAccounts = growAccounts(
+        accounts, nextExpenses, withdrawalState, conversionDeposits,
+        inflowResult.esppLots, yearPlan.deficitDebtPayment, existingDeficitDebt,
+        assumptions, year, returnOverride, logs
+    );
+
+    // ------------------------------------------------------------------
+    // LONG-TERM GOAL FUNDING (committed transfer)
+    // The set-aside was counted with living expenses above (cash already left
+    // the budget); deposit the same dollars into each goal's reserved fund so
+    // it's a transfer, not spending. Credited after growth (no growth on the
+    // current year's contributions), before the purchase check below so the
+    // due year's own set-aside counts toward the lump.
+    // ------------------------------------------------------------------
+    for (const [fundId, annual] of goalFundCredits) {
+        const fund = nextAccounts.find(a => a.id === fundId);
+        if (!fund) continue;
+        fund.amount += annual;
+        logs.push(`🎯 Goal funding: set aside $${Math.round(annual).toLocaleString()} into "${fund.name}" (balance now $${Math.round(fund.amount).toLocaleString()})`);
+    }
+
+    // ------------------------------------------------------------------
+    // LONG-TERM GOAL PURCHASES
+    // In a goal's due year, spend the lump from its reserved sinking-fund
+    // account. Net worth dips by what's available in the fund; recurring goals
+    // keep accruing toward the next cycle afterward.
+    // ------------------------------------------------------------------
+    for (const exp of expenses) {
+        if (!isLongTermGoal(exp) || !exp.goalAccountId || !isGoalDueInYear(exp, year)) continue;
+        // A recurring goal can carry an end date (when to stop replacing it);
+        // don't fire the lump after it.
+        if (exp.endDate && new Date(exp.endDate).getUTCFullYear() < year) continue;
+        const fund = nextAccounts.find(a => a.id === exp.goalAccountId);
+        if (!fund) continue;
+        const spent = Math.min(fund.amount, exp.amount);
+        fund.amount -= spent;
+        logs.push(`🎯 Goal "${exp.name}" came due: spent $${Math.round(spent).toLocaleString()} from its fund (balance now $${Math.round(fund.amount).toLocaleString()})`);
+    }
+
+    // ------------------------------------------------------------------
+    // BUILD ROTH CONVERSION RESULT (for output compatibility)
+    // ------------------------------------------------------------------
+    let rothConversionResult: SimulationYear['rothConversion'] = undefined;
+    if (yearPlan.conversion) {
+        const sourceAccount = accounts.find(a => a.id === yearPlan.conversion!.fromAccountId);
+        const targetAccount = accounts.find(a => a.id === yearPlan.conversion!.toAccountId);
+
+        if (sourceAccount && targetAccount) {
+            rothConversionResult = {
+                amount: yearPlan.conversion.amount,
+                taxCost: yearPlan.conversion.taxAmount,
+                federalTaxCost: yearPlan.conversion.federalTaxCost,
+                stateTaxCost: yearPlan.conversion.stateTaxCost,
+                taxAfter: yearPlan.tax.federal + yearPlan.conversion.taxAmount,
+                fromAccounts: { [sourceAccount.name]: yearPlan.conversion.amount },
+                toAccounts: { [targetAccount.name]: yearPlan.conversion.netToRoth },
+                fromAccountIds: { [sourceAccount.id]: yearPlan.conversion.amount },
+                toAccountIds: { [targetAccount.id]: yearPlan.conversion.netToRoth },
+            };
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // CALCULATE FINAL STATS
+    // ------------------------------------------------------------------
+    const totalInsuranceCost = incomesWithEarningsTest.reduce((sum, inc) => {
+        if (inc instanceof WorkIncome) {
+            return sum + inc.getProratedAnnual(inc.insurance, year);
+        }
+        return sum;
+    }, 0);
+
+    const postTaxDeductions = TaxService.getPostTaxExemptions(incomesWithEarningsTest, year);
+    const totalTax = yearPlan.tax.total;
+
+    // ------------------------------------------------------------------
+    // SANKEY CASH ACCOUNTING (Fix A + Fix B + Fix C)
+    // ------------------------------------------------------------------
+    // Fix A: Use solver's spendable income (excludes reinvested dividends which aren't cash)
+    // Fix B: Subtract bucket allocations (counted separately in Sankey outflows)
+    // Fix C: Subtract the planner's LTCG tax baked into the brokerage gross-up.
+    //
+    // Sankey equation: inflows = outflows
+    //   inflows = spendableIncome + withdrawals - brokerageLTCGFromGross
+    //   outflows = expenses + taxes + invested + bucketAllocations + discretionary
+    //
+    // The solver's spendable income correctly excludes reinvested dividends (taxable but not cash).
+    const spendableIncome = yearPlan.income.spendable;
+    //
+    // LTCG NOTE: planner's LTCG (sum of w.tax for brokerage/ESPP) is paid directly to the
+    // government from the brokerage gross-up — it never reaches user cash. Subtracting it
+    // here mirrors YearSolver Step F's `actualLTCGTax` subtraction in `cashIn`. Without this,
+    // a phantom surplus equal to the LTCG tax appears in `trueUserSaved` (showing up as
+    // "investedUser" during retirement years even when there's $0 income).
+    //
+    // When planner rate is 0% (low ordinary income) there's no gross-up, sum is 0, no
+    // change. Auth LTCG in that case is captured by `unfundedDeficit` instead.
+    const brokerageLTCGFromGross = yearPlan.withdrawals
+        .filter(w => w.capitalGains !== undefined)
+        .reduce((sum, w) => sum + w.tax, 0);
+    const totalCashAvailable =
+        spendableIncome
+        + withdrawalState.totalWithdrawals
+        - brokerageLTCGFromGross;
+    const totalBucketAllocationsForSankey = totalSurplusAllocations + inflowResult.totalBucketAllocations;
+    // Use solver's actual expenses (yearPlan.totalExpenses) which reflects GK budget trimming,
+    // not the pre-trim totalLivingExpenses. Otherwise the Sankey equation is unbalanced when
+    // GK cuts discretionary spending — withdrawals cover the trimmed amount but this formula
+    // subtracts the full (untrimmed) expenses, creating a phantom negative "invested" amount.
+    const actualLivingExpenses = yearPlan.totalExpenses;
+    const trueUserSaved = totalCashAvailable - totalTax - totalInsuranceCost - actualLivingExpenses - discretionaryCash - totalBucketAllocationsForSankey;
+
+    // Filter out RMD incomes from returned array
+    const returnedIncomes = allIncomes.filter(inc =>
+        !(inc instanceof PassiveIncome && inc.sourceType === 'RMD')
+    );
+
+    // ------------------------------------------------------------------
+    // MERGE BUCKET DETAILS (surplus allocations + inflow allocations)
+    // ------------------------------------------------------------------
+    const mergedBucketDetail: Record<string, number> = { ...inflowResult.bucketDetail };
+    for (const [accountId, amount] of Object.entries(surplusBucketDetail)) {
+        mergedBucketDetail[accountId] = (mergedBucketDetail[accountId] || 0) + amount;
+    }
+    // Note: totalSurplusAllocations was already computed earlier for trueUserSaved calculation
+    const totalBucketAllocations = inflowResult.totalBucketAllocations + totalSurplusAllocations;
+
+    // ------------------------------------------------------------------
+    // BUILD CASHFLOW DETAIL (for Sankey chart - avoids re-deriving
+    // per-source income, contribution splits, mortgage breakdown, and
+    // expense categories from scratch in the chart layer)
+    // ------------------------------------------------------------------
+    // Use allIncomes so reinvested interest (created in projectIncomes) is
+    // included, and so RMD-sourced PassiveIncomes are surfaced as income (they
+    // drain the Traditional account via userInflows but are not in
+    // withdrawalDetail, so income is their single Sankey representation).
+    const cashflowDetail = buildCashflowDetail({
+        incomes: allIncomes,
+        expenses: nextExpenses,
+        accounts: nextAccounts,
+        insurance: totalInsuranceCost,
+        year,
+        brokerageLTCGFromGross,
+        employerInflows: withdrawalState.employerInflows,
+    });
+
+    // ------------------------------------------------------------------
+    // RETURN SIMULATION YEAR
+    // ------------------------------------------------------------------
+    return {
+        year,
+        incomes: returnedIncomes,
+        expenses: nextExpenses,
+        accounts: nextAccounts,
+        cashflow: {
+            // Use spendableIncome for Sankey (excludes reinvested dividends which aren't cash)
+            totalIncome: spendableIncome,
+            totalExpense: actualLivingExpenses + totalTax + preTaxDeductions + postTaxDeductions,
+            livingExpenses: actualLivingExpenses,
+            discretionary: discretionaryCash,
+            investedUser: trueUserSaved,
+            investedMatch: inflowResult.totalEmployerMatch,
+            totalInvested: trueUserSaved + inflowResult.totalEmployerMatch,
+            bucketAllocations: totalBucketAllocations,
+            bucketDetail: mergedBucketDetail,
+            withdrawals: withdrawalState.totalWithdrawals,
+            withdrawalDetail: withdrawalState.withdrawalDetail,
+        },
+        cashflowDetail,
+        taxDetails: {
+            fed: yearPlan.tax.federal + withdrawalState.withdrawalPenalties,
+            state: yearPlan.tax.state,
+            fica: yearPlan.tax.fica,
+            preTax: preTaxDeductions - totalInsuranceCost,
+            insurance: totalInsuranceCost,
+            postTax: postTaxDeductions,
+            capitalGains: withdrawalState.capitalGainsTaxTotal,
+            withdrawalOrdinaryTax: withdrawalState.withdrawalOrdinaryTaxTotal,
+            niit: yearPlan.tax.niit,
+            earlyWithdrawalPenalty: withdrawalState.withdrawalPenalties,
+            longTermCapitalGains: withdrawalState.longTermCapitalGains,
+        },
+        logs,
+        strategyWithdrawal: strategyWithdrawalResult,
+        strategyAdjustment: strategyAdjustmentResult,
+        rothConversion: rothConversionResult,
+        rmdDetails,
+        milestoneEvents: milestoneResult.newlyReached,
+        activeMilestones: milestoneResult.activeMilestones,
+        taxOptimizationTarget: yearPlan.taxOptimizationTarget,
+    };
+}
+
+/**
+ * Runs the simulation for a single timestep (1 year).
+ * Takes "Year N" data and returns "Year N+1" data.
+ *
+ * ARCHITECTURE NOTE: Tax/Withdrawal Circular Dependency
+ * =====================================================
+ *
+ * There is a circular dependency in tax calculation:
+ *   Deficit → Withdrawals → LTCG → Tax → Deficit
+ *
+ * Current approach (Option B - Post-hoc correction):
+ * - Calculate preliminary tax with LTCG=0 to estimate deficit
+ * - Execute withdrawals, which determines actual LTCG/STCG from brokerage sales
+ * - Recalculate final tax with actual LTCG/STCG
+ * - Do NOT iterate — accept any shortfall/surplus in discretionary cash
+ *
+ * Tradeoffs:
+ * - Shortfall: If LTCG triggers more tax than estimated (e.g., NIIT), the
+ *   shortfall reduces discretionary cash or rolls to next year
+ * - Magnitude: Typically <$1k/year; could be $5-10k in years with large
+ *   brokerage liquidation
+ * - Over full simulation: Total taxes are correct, just slightly misallocated
+ *   between years
+ *
+ * TODO: Future SimulationEngine rewrite should consider:
+ * 1. Iteration with convergence cap (max 3 passes, accept <$500 difference)
+ * 2. Predictive LTCG estimation based on withdrawal plan before execution
+ * 3. Full constraint-based solver that handles all circular dependencies
+ *
+ * Related issues this affects:
+ * - NIIT calculation (3.8% on investment income when MAGI > $200k/$250k)
+ * - LTCG stacking (LTCG rate depends on ordinary taxable income)
+ * - SS torpedo (withdrawal amount affects SS taxability, but we handle this
+ *   correctly since Traditional withdrawals are known before tax calc)
+ */
+export function simulateOneYear(
+    year: number,
+    incomes: AnyIncome[],
+    expenses: AnyExpense[],
+    accounts: AnyAccount[],
+    assumptions: AssumptionsState,
+    taxState: TaxState,
+    previousSimulation: SimulationYear[] = [],
+    returnOverride?: number,
+    previousActiveMilestones: string[] = [],
+    previousMilestoneReachYears: Map<string, number> = new Map(),
+    baselineProjections?: BaselineProjections,
+    conversionMode: 'rate-match' | 'std-ded-only' = 'rate-match',
+    dpConversionPlan?: Map<number, number>,
+    dpDebugByYear?: Map<number, string[]>,
+): SimulationYear {
+    return simulateOneYearWithNewEngine(
+        year, incomes, expenses, accounts, assumptions, taxState,
+        previousSimulation, returnOverride, previousActiveMilestones,
+        previousMilestoneReachYears, baselineProjections, conversionMode,
+        dpConversionPlan, dpDebugByYear,
+    );
+}

--- a/src/components/Objects/Assumptions/useSimulation.tsx
+++ b/src/components/Objects/Assumptions/useSimulation.tsx
@@ -1,0 +1,709 @@
+import { simulateOneYear, SimulationYear } from './SimulationEngine';
+import * as TaxService from '../../Objects/Taxes/TaxService';
+import { WorkIncome, getIncomeActiveMultiplier } from '../Income/models';
+import { AnyAccount, InvestedAccount, SavedAccount, DebtAccount, DeficitDebtAccount } from '../Accounts/models';
+import { AnyIncome } from '../Income/models';
+import { AnyExpense, MortgageExpense } from '../Expense/models';
+import { AssumptionsState, getLifeExpectancy, getBirthYear, getRetirementAge } from './AssumptionsContext';
+import { TaxState } from '../Taxes/TaxContext';
+import { BaselineProjections } from '../../../services/simulation/types';
+import { getRMDStartAge } from '../../../data/RMDData';
+import { buildDPYearContexts, planConversionsViaDP, DPPlan } from '../../../services/simulation/RothConversionDP';
+
+/**
+ * Extract baseline projections from a simulation run WITHOUT Roth conversions.
+ * These projections capture the actual simulated values at RMD age, including:
+ * - Traditional balance with all contributions, growth, and withdrawals
+ * - SS income with COLA applied
+ * - Pension income with COLA applied
+ */
+export function extractBaselineProjections(
+    simulation: SimulationYear[],
+    birthYear: number
+): BaselineProjections | null {
+    const rmdStartAge = getRMDStartAge(birthYear);
+    const rmdYear = birthYear + rmdStartAge;
+
+    const rmdYearData = simulation.find(y => y.year === rmdYear);
+    if (!rmdYearData) {
+        // RMD year is beyond simulation range
+        return null;
+    }
+
+    // Sum Traditional balances from all Traditional accounts
+    const traditionalBalanceAtRMD = rmdYearData.accounts
+        .filter(acc => acc instanceof InvestedAccount &&
+            (acc.taxType === 'Traditional 401k' || acc.taxType === 'Traditional IRA'))
+        .reduce((sum, acc) => sum + (acc as InvestedAccount).amount, 0);
+
+    // Get SS at RMD year (already has COLA applied by simulation)
+    const ssAtRMD = TaxService.getSocialSecurityBenefits(rmdYearData.incomes, rmdYear);
+
+    // Get pension at RMD year (already has COLA applied)
+    const pensionAtRMD = rmdYearData.incomes
+        .filter(inc =>
+            (inc as any).className === 'FERSPensionIncome' ||
+            (inc as any).className === 'CSRSPensionIncome')
+        .reduce((sum, inc) => sum + (inc.getAnnualAmount?.(rmdYear) ?? 0), 0);
+
+    // Get passive income at RMD year (rental, dividends, interest — excludes RMD-sourced).
+    // This matches the filter YearSolver uses for current-year passive, so the projection
+    // is consistent with what the ceiling calculator expects.
+    const passiveAtRMD = rmdYearData.incomes
+        .filter(inc =>
+            (inc as any).className === 'PassiveIncome' &&
+            (inc as any).sourceType !== 'RMD')
+        .reduce((sum, inc) => sum + (inc.getAnnualAmount?.(rmdYear) ?? 0), 0);
+
+    return { traditionalBalanceAtRMD, ssAtRMD, pensionAtRMD, passiveAtRMD, rmdYear };
+}
+
+/**
+ * Per-year forward projection sub-simulation.
+ *
+ * Runs from `currentSimYear` forward to the user's RMD year, doing only
+ * standard-deduction-headroom (0% bracket) Roth conversions. Returns the
+ * BaselineProjections snapshot at RMD year, which the main sim feeds into
+ * the rate-match algorithm so that "future marginal rate at RMD" is
+ * decoupled from the live, depleting Traditional balance.
+ *
+ * Capped at the RMD year per user direction — only `traditionalBalanceAtRMD`
+ * (and SS/pension/passive at RMD) feed back into the main sim, so projecting
+ * past that point is wasted work.
+ *
+ * Recursion guard: this sub-sim runs in 'std-ded-only' mode, which makes
+ * `calculateDynamicConversionCeiling` short-circuit and never re-enter
+ * `runProjectionSubsim`.
+ */
+function runProjectionSubsim(
+    currentSimYear: number,
+    currentAccounts: AnyAccount[],
+    currentIncomes: AnyIncome[],
+    currentExpenses: AnyExpense[],
+    timelineSoFar: SimulationYear[],
+    previousActiveMilestones: string[],
+    milestoneReachYears: Map<string, number>,
+    assumptions: AssumptionsState,
+    taxState: TaxState,
+    birthYear: number,
+): BaselineProjections | undefined {
+    const rmdYear = birthYear + getRMDStartAge(birthYear);
+    const yearsToProject = rmdYear - currentSimYear;
+    if (yearsToProject <= 0) return undefined;
+
+    // Shallow-copy in-flight collections so the sub-sim doesn't mutate main-sim
+    // state (account `amount` etc. are mutated in place by simulateOneYear).
+    const subTimeline: SimulationYear[] = [...timelineSoFar];
+    runSimulationLoop({
+        previousSimYear: currentSimYear,
+        yearsToRun: yearsToProject,
+        currentAccounts: [...currentAccounts],
+        currentIncomes: [...currentIncomes],
+        currentExpenses: [...currentExpenses],
+        timeline: subTimeline,
+        previousActiveMilestones: [...previousActiveMilestones],
+        milestoneReachYears: new Map(milestoneReachYears),
+        assumptions,
+        taxState,
+        conversionMode: 'std-ded-only',
+        // No baselineProvider — std-ded-only mode short-circuits rate-match,
+        // so a baseline projection would be unused. This also breaks any
+        // theoretical recursion.
+    });
+
+    return extractBaselineProjections(subTimeline, birthYear) ?? undefined;
+}
+
+/**
+ * Per-year loop body extracted from `runSimulation`. Lets the main sim and
+ * `runProjectionSubsim` share the same iteration logic without re-running
+ * year-0 setup (year-0 synthesis, partial-year payroll, EOY projection
+ * injection) on mid-trajectory state.
+ */
+function runSimulationLoop(args: {
+    previousSimYear: number;
+    yearsToRun: number;
+    currentAccounts: AnyAccount[];
+    currentIncomes: AnyIncome[];
+    currentExpenses: AnyExpense[];
+    timeline: SimulationYear[];
+    previousActiveMilestones: string[];
+    milestoneReachYears: Map<string, number>;
+    assumptions: AssumptionsState;
+    taxState: TaxState;
+    yearlyReturns?: number[];
+    conversionMode: 'rate-match' | 'std-ded-only';
+    baselineProvider?: (
+        simulationYear: number,
+        currentAccounts: AnyAccount[],
+        currentIncomes: AnyIncome[],
+        currentExpenses: AnyExpense[],
+        timeline: SimulationYear[],
+        previousActiveMilestones: string[],
+        milestoneReachYears: Map<string, number>,
+    ) => BaselineProjections | undefined;
+    /** Pre-solved DP conversion plan; keyed by simulation year. */
+    dpConversionPlan?: Map<number, number>;
+    /** Per-year DP solver debug strings; keyed by simulation year. */
+    dpDebugByYear?: Map<number, string[]>;
+}): void {
+    let { currentAccounts, currentIncomes, currentExpenses, previousActiveMilestones } = args;
+    const { milestoneReachYears, timeline, assumptions, taxState, yearlyReturns,
+            previousSimYear, yearsToRun, conversionMode, baselineProvider, dpConversionPlan, dpDebugByYear } = args;
+
+    for (let i = 1; i <= yearsToRun; i++) {
+        const simulationYear = previousSimYear + i;
+        const returnOverride = yearlyReturns ? yearlyReturns[i - 1] : undefined;
+
+        const baseline = baselineProvider?.(
+            simulationYear, currentAccounts, currentIncomes, currentExpenses,
+            timeline, previousActiveMilestones, milestoneReachYears,
+        );
+
+        const result = simulateOneYear(
+            simulationYear,
+            currentIncomes,
+            currentExpenses,
+            currentAccounts,
+            assumptions,
+            taxState,
+            timeline,
+            returnOverride,
+            previousActiveMilestones,
+            milestoneReachYears,
+            baseline,
+            conversionMode,
+            dpConversionPlan,
+            dpDebugByYear,
+        );
+
+        timeline.push(result);
+
+        currentIncomes = result.incomes;
+        currentExpenses = result.expenses;
+        currentAccounts = result.accounts;
+        previousActiveMilestones = result.activeMilestones || [];
+
+        result.milestoneEvents?.forEach(event => {
+            if (!milestoneReachYears.has(event.milestoneId)) {
+                milestoneReachYears.set(event.milestoneId, event.yearReached);
+            }
+        });
+    }
+}
+
+export const runSimulation = (
+    yearsToRun: number = 30,
+    accounts: AnyAccount[],
+    incomes: AnyIncome[],
+    expenses: AnyExpense[],
+    assumptions: AssumptionsState,
+    taxState: TaxState,
+    yearlyReturns?: number[],
+    referenceDate?: Date,
+    conversionMode: 'rate-match' | 'std-ded-only' = 'rate-match',
+    useRollingBaseline: boolean = false,
+    dpConversionPlan?: Map<number, number>,
+    dpDebugByYear?: Map<number, string[]>,
+    /** accountId → extra dollars to add to the synthetic EOY projection row.
+     *  Populated by callers from `computeEOYBudgetContributions` so that
+     *  non-payroll priority contributions (Brokerage / IRA / HSA / Savings)
+     *  show up in the Projected Dec point. */
+    eoyContributionAdditions?: Record<string, number>,
+    /** DebtAccount id → principal $ to subtract from the synthetic EOY row,
+     *  so loan balances reflect amortization through year-end. */
+    eoyDebtReductions?: Record<string, number>,
+    /** MortgageExpense id → principal $ to subtract from its loan_balance on
+     *  the synthetic EOY row (mortgages don't live on a DebtAccount). */
+    eoyMortgageReductions?: Record<string, number>,
+): SimulationYear[] => {
+        
+    // Calculate start year and current age from birth year
+    // If priorYearMode is enabled, start simulation from last year (for verified data entry)
+    const currentYear = new Date().getFullYear();
+    const startYear = assumptions.demographics.priorYearMode
+        ? currentYear - 1
+        : currentYear;
+    const birthYear = getBirthYear(assumptions.milestones);
+    const startAge = startYear - birthYear;
+
+    // --- LIFE EXPECTANCY CAP ---
+    // Calculate how many years the user actually has left (derived from End of Plan milestone)
+    const lifeExpectancy = getLifeExpectancy(assumptions.milestones);
+    const yearsUntilDeath = Math.max(0, lifeExpectancy - startAge);
+
+    // Run for the requested time, OR until death—whichever comes first.
+    const effectiveYearsToRun = Math.min(yearsToRun, yearsUntilDeath);
+
+    const timeline: SimulationYear[] = [];
+
+    // --- STEP 0.5: RESOLVE autoMax401k ON WORK INCOMES ---
+    // When autoMax401k is 'traditional' or 'roth', the stored preTax401k/roth401k values
+    // are the user's custom values, not the IRS-limit-capped values. Resolve them now
+    // so Year 0 incomes have effective values for Sankey charts and partial-year adjustments.
+    const resolvedIncomes: AnyIncome[] = incomes.map(inc => {
+        if (inc instanceof WorkIncome && inc.autoMax401k !== 'custom') {
+            const effective = inc.getEffective401k(startYear, startAge);
+            if (effective.preTax !== inc.preTax401k || effective.roth !== inc.roth401k) {
+                return new WorkIncome(
+                    inc.id, inc.name, inc.amount, inc.frequency,
+                    inc.earned_income, effective.preTax, inc.insurance,
+                    effective.roth, inc.employerMatch, inc.matchAccountId,
+                    inc.taxType, inc.contributionGrowthStrategy,
+                    inc.startDate, inc.end_date, inc.hsaContribution,
+                    inc.autoMax401k, inc.esppContributionType,
+                    inc.esppContributionAmount, inc.esppDiscountPercent,
+                    inc.esppHasLookback, inc.esppOfferingPeriodMonths,
+                    inc.esppAccountId, inc.esppExpectedStockGrowth,
+                    inc.pensionSystem, inc.startMilestoneId, inc.endMilestoneId
+                );
+            }
+        }
+        return inc;
+    });
+
+    // --- STEP 1: CREATE YEAR 0 (Baseline) ---
+    // Note: Interest income is NOT included in Year 0 to allow users to match
+    // their actual tax situation. Interest is generated starting in Year 1.
+
+    // Calculate current baseline metrics using existing TaxService logic
+    // Resolved incomes have effective 401k values baked in, so useStoredValue=true is safe
+    const currentGross = TaxService.getGrossIncome(resolvedIncomes, startYear);
+    const currentPreTax = TaxService.getPreTaxExemptions(resolvedIncomes, startYear, startAge, true);
+    const currentPostTax = TaxService.getPostTaxExemptions(resolvedIncomes, startYear, startAge, true);
+    const currentInsurance = resolvedIncomes.reduce((sum, inc) =>
+        inc instanceof WorkIncome ? sum + inc.getProratedAnnual(inc.insurance, startYear) : sum, 0
+    );
+
+    const currentFed = TaxService.calculateFederalTaxFromIncomes(taxState, resolvedIncomes, expenses, 0, startYear, assumptions);
+    const currentState = TaxService.calculateStateTax(taxState, resolvedIncomes, expenses, startYear, assumptions);
+    const currentFica = TaxService.calculateFicaTax(taxState, resolvedIncomes, startYear, assumptions);
+    const currentTotalTax = currentFed + currentState + currentFica;
+
+    const currentLivingExpenses = expenses.reduce((sum, exp) => sum + exp.getAnnualAmount(startYear), 0);
+
+    // For Year 0, discretionary is what's left over from your current input data
+    const currentDiscretionary = currentGross - currentPreTax - currentPostTax - currentTotalTax - currentLivingExpenses;
+
+    const yearZero: SimulationYear = {
+        year: startYear,
+        incomes: [...resolvedIncomes],
+        expenses: [...expenses],
+        accounts: [...accounts],
+        cashflow: {
+            totalIncome: currentGross,
+            totalExpense: currentLivingExpenses + currentTotalTax + currentPreTax + currentPostTax,
+            livingExpenses: currentLivingExpenses,
+            discretionary: currentDiscretionary,
+            // In Year 0, we treat the input as "Static", so invested is effectively 0 or the sum of payroll deductions
+            investedUser: currentPreTax + currentPostTax - currentInsurance,
+            investedMatch: resolvedIncomes.reduce((sum, inc) => inc instanceof WorkIncome ? sum + inc.getEffectiveAnnualEmployerMatch() : sum, 0),
+            totalInvested: (currentPreTax + currentPostTax - currentInsurance) +
+                            resolvedIncomes.reduce((sum, inc) => inc instanceof WorkIncome ? sum + inc.getEffectiveAnnualEmployerMatch() : sum, 0),
+            bucketAllocations: 0,
+            bucketDetail: {}, // Initialize empty for Year 0
+            withdrawals: 0,
+            withdrawalDetail: {}
+        },
+        taxDetails: {
+            fed: currentFed,
+            state: currentState,
+            fica: currentFica,
+            preTax: currentPreTax - currentInsurance,
+            insurance: currentInsurance,
+            postTax: currentPostTax,
+            capitalGains: 0,
+            withdrawalOrdinaryTax: 0,
+            niit: 0
+        },
+        logs: ["Baseline Year 0 initialized from current context data."]
+    };
+
+    timeline.push(yearZero);
+
+    // --- STEP 1.5: PARTIAL-YEAR ADJUSTMENT ---
+    // Apply remaining fraction of current year's growth and contributions
+    // so Year 1 starts from projected end-of-year balances, not today's balances.
+    const refDate = referenceDate ?? new Date();
+    const currentMonth = refDate.getMonth(); // 0=Jan, 11=Dec
+    const remainingFraction = (11 - currentMonth) / 12; // Jan→11/12, Dec→0/12
+
+    let adjustedAccounts: AnyAccount[] = [...yearZero.accounts];
+
+    if (remainingFraction > 0 && !assumptions.demographics.priorYearMode) {
+        // Calculate partial-year payroll contributions per account
+        const partialContributions: Record<string, { user: number; employer: number }> = {};
+
+        yearZero.incomes.forEach(inc => {
+            if (inc instanceof WorkIncome && inc.matchAccountId) {
+                const activeMultiplier = getIncomeActiveMultiplier(inc, startYear);
+                // Overlap between remaining months and income's active period
+                const effectiveFraction = Math.min(remainingFraction, activeMultiplier);
+                if (effectiveFraction <= 0) return;
+
+                // preTax401k/roth401k are per pay period; annualize before applying the
+                // partial-year fraction so non-annual frequencies aren't under-counted.
+                const userContrib = inc.getProratedAnnual(inc.preTax401k + inc.roth401k) * effectiveFraction;
+                const employerContrib = inc.getEffectiveAnnualEmployerMatch() * effectiveFraction;
+
+                const existing = partialContributions[inc.matchAccountId] || { user: 0, employer: 0 };
+                partialContributions[inc.matchAccountId] = {
+                    user: existing.user + userContrib,
+                    employer: existing.employer + employerContrib,
+                };
+            }
+        });
+
+        // Apply partial-year contributions (no growth — Year 1 handles full-year growth)
+        adjustedAccounts = adjustedAccounts.map(acc => {
+            if (acc instanceof InvestedAccount) {
+                const contribs = partialContributions[acc.id] || { user: 0, employer: 0 };
+                if (contribs.user === 0 && contribs.employer === 0) return acc;
+
+                const newAmount = acc.amount + contribs.user + contribs.employer;
+                const newEmployerBalance = acc.employerBalance + contribs.employer;
+                const newCostBasis = acc.costBasis + contribs.user + contribs.employer;
+
+                return new InvestedAccount(
+                    acc.id, acc.name, newAmount, newEmployerBalance,
+                    acc.tenureYears, acc.expenseRatio, acc.taxType,
+                    acc.isContributionEligible, acc.vestedPerYear, newCostBasis, acc.customROR,
+                    acc.conversionHistory
+                );
+            }
+
+            return acc;
+        });
+
+        // Layer on budget-tracked priority contributions (Brokerage / IRA / HSA /
+        // Savings). Without this, the Projected Dec point only reflects payroll
+        // and ignores everything the user is actively budgeting toward.
+        if (eoyContributionAdditions) {
+            adjustedAccounts = adjustedAccounts.map(acc => {
+                const extra = eoyContributionAdditions[acc.id] || 0;
+                if (extra <= 0) return acc;
+                if (acc instanceof InvestedAccount) {
+                    return new InvestedAccount(
+                        acc.id, acc.name, acc.amount + extra, acc.employerBalance,
+                        acc.tenureYears, acc.expenseRatio, acc.taxType,
+                        acc.isContributionEligible, acc.vestedPerYear, acc.costBasis + extra, acc.customROR,
+                        acc.conversionHistory
+                    );
+                }
+                if (acc instanceof SavedAccount) {
+                    return new SavedAccount(acc.id, acc.name, acc.amount + extra, acc.apr);
+                }
+                return acc;
+            });
+        }
+
+        // Layer on expected debt principal pay-down for the remainder of the
+        // year so mortgage / loan balances at the Projected Dec point reflect
+        // amortization through year-end rather than today's balance.
+        if (eoyDebtReductions) {
+            adjustedAccounts = adjustedAccounts.map(acc => {
+                if (!(acc instanceof DebtAccount) || acc instanceof DeficitDebtAccount) return acc;
+                const reduction = eoyDebtReductions[acc.id] || 0;
+                if (reduction <= 0) return acc;
+                const nextAmount = Math.max(0, acc.amount - reduction);
+                return new DebtAccount(acc.id, acc.name, nextAmount, acc.linkedAccountId, acc.apr);
+            });
+        }
+    }
+
+    // --- STEP 1.75: INSERT END-OF-YEAR PROJECTION ---
+    // Insert a synthetic data point representing projected balances at December 31 of the current year.
+    // This prevents the "big jump" confusion between Year 0 (today) and Year 1 (end of next year).
+    if (remainingFraction > 0 && !assumptions.demographics.priorYearMode) {
+        // Layer on expected mortgage principal pay-down so MortgageExpense.loan_balance
+        // on the synthetic EOY row reflects amortization through year-end.
+        let adjustedExpenses = yearZero.expenses;
+        if (eoyMortgageReductions) {
+            adjustedExpenses = yearZero.expenses.map(exp => {
+                if (!(exp instanceof MortgageExpense)) return exp;
+                const reduction = eoyMortgageReductions[exp.id] || 0;
+                if (reduction <= 0) return exp;
+                const nextBalance = Math.max(0, exp.loan_balance - reduction);
+                return new MortgageExpense(
+                    exp.id, exp.name, exp.frequency,
+                    exp.valuation, nextBalance, exp.starting_loan_balance,
+                    exp.apr, exp.term_length, exp.property_taxes, exp.valuation_deduction,
+                    exp.maintenance, exp.utilities, exp.home_owners_insurance, exp.pmi, exp.hoa_fee,
+                    exp.is_tax_deductible, exp.tax_deductible, exp.linkedAccountId,
+                    exp.startDate, exp.payment, exp.extra_payment, exp.endDate,
+                    exp.startMilestoneId, exp.endMilestoneId,
+                );
+            });
+        }
+        const eoyYear: SimulationYear = {
+            ...yearZero,
+            accounts: adjustedAccounts,
+            expenses: adjustedExpenses,
+            cashflow: {
+                ...yearZero.cashflow,
+                totalIncome: yearZero.cashflow.totalIncome * remainingFraction,
+                totalExpense: yearZero.cashflow.totalExpense * remainingFraction,
+                livingExpenses: yearZero.cashflow.livingExpenses * remainingFraction,
+                investedUser: yearZero.cashflow.investedUser * remainingFraction,
+                investedMatch: yearZero.cashflow.investedMatch * remainingFraction,
+                totalInvested: yearZero.cashflow.totalInvested * remainingFraction,
+                discretionary: yearZero.cashflow.discretionary * remainingFraction,
+            },
+            taxDetails: {
+                ...yearZero.taxDetails,
+                fed: yearZero.taxDetails.fed * remainingFraction,
+                state: yearZero.taxDetails.state * remainingFraction,
+                fica: yearZero.taxDetails.fica * remainingFraction,
+                earlyWithdrawalPenalty: (yearZero.taxDetails.earlyWithdrawalPenalty ?? 0) * remainingFraction,
+                longTermCapitalGains: (yearZero.taxDetails.longTermCapitalGains ?? 0) * remainingFraction,
+            },
+            isEndOfYearProjection: true,
+            logs: [],
+        };
+        timeline.push(eoyYear);
+    }
+
+    // --- STEP 2: RUN FUTURE SIMULATION ---
+    // Build the rolling baseline provider when in rate-match mode and rolling
+    // baselines are requested (used by `runSimulationWithOptimization`). Each
+    // year, the provider runs a forward sub-sim from the in-flight state to RMD
+    // year doing only std-ded-headroom conversions, then extracts baseline
+    // projections to feed into the rate-match conversion ceiling. This decouples
+    // "future marginal at RMD" from the live, depleting Trad balance.
+    const rmdYear = birthYear + getRMDStartAge(birthYear);
+    const baselineProvider = useRollingBaseline
+        && conversionMode === 'rate-match'
+        && assumptions.investments.taxOptimizationEnabled
+        ? (
+            simulationYear: number,
+            subAccounts: AnyAccount[],
+            subIncomes: AnyIncome[],
+            subExpenses: AnyExpense[],
+            subTimeline: SimulationYear[],
+            subActiveMilestones: string[],
+            subReachYears: Map<string, number>,
+        ) => {
+            if (simulationYear >= rmdYear) return undefined;
+            return runProjectionSubsim(
+                simulationYear - 1, // sub-sim starts AFTER previous year, ends at rmdYear
+                subAccounts, subIncomes, subExpenses,
+                subTimeline, subActiveMilestones, subReachYears,
+                assumptions, taxState, birthYear,
+            );
+        }
+        : undefined;
+
+    runSimulationLoop({
+        previousSimYear: startYear,
+        yearsToRun: effectiveYearsToRun,
+        currentAccounts: adjustedAccounts,
+        currentIncomes: yearZero.incomes,
+        currentExpenses: yearZero.expenses,
+        timeline,
+        previousActiveMilestones: [],
+        milestoneReachYears: new Map(),
+        assumptions,
+        taxState,
+        yearlyReturns,
+        conversionMode,
+        baselineProvider,
+        dpConversionPlan,
+        dpDebugByYear,
+    });
+
+    return timeline;
+};
+
+/**
+ * Run simulation with rolling per-year baseline sub-simulations for accurate
+ * Roth conversion decisions.
+ *
+ * For each year of the main run, before deciding the conversion ceiling, a
+ * forward sub-simulation projects from the in-flight state to RMD year doing
+ * only standard-deduction-headroom (0% bracket) conversions. The resulting
+ * `traditionalBalanceAtRMD` (and SS/pension/passive at RMD) feed into the
+ * rate-match algorithm, decoupling "future marginal rate at RMD" from the
+ * live, depleting Trad balance. This replaces the older two-pass approach
+ * that used a single zero-conversion baseline for the entire run.
+ *
+ * When tax optimization is disabled, this falls through to a plain
+ * single-pass `runSimulation` with no baselines and no conversions.
+ */
+export const runSimulationWithOptimization = (
+    yearsToRun: number = 30,
+    accounts: AnyAccount[],
+    incomes: AnyIncome[],
+    expenses: AnyExpense[],
+    assumptions: AssumptionsState,
+    taxState: TaxState,
+    yearlyReturns?: number[],
+    referenceDate?: Date,
+    eoyContributionAdditions?: Record<string, number>,
+    eoyDebtReductions?: Record<string, number>,
+    eoyMortgageReductions?: Record<string, number>,
+): SimulationYear[] => {
+    const strategy = assumptions.investments.rothConversionStrategy ?? 'rate-match';
+    const taxOptOn = assumptions.investments.taxOptimizationEnabled;
+
+    // Always run a full-horizon std-ded-only baseline up front. Used for:
+    //   1. Live "your strategy vs free-conversions only" comparison in
+    //      WithdrawalTab — no extra sim needed at comparison time.
+    //   2. Context-building input for the DP solver (DP path only).
+    // Override strategy to rate-match so std-ded conversions actually fire —
+    // otherwise selectConversionStrategy dispatches to planConversionDP,
+    // which sees no dpConversionPlan and skips conversion entirely. We want
+    // std-ded-only conversions (what conversionMode='std-ded-only' inside
+    // the rate-match path produces), not zero conversions.
+    const baselineAssumptions: AssumptionsState = {
+        ...assumptions,
+        investments: { ...assumptions.investments, rothConversionStrategy: 'rate-match' },
+    };
+    const stdDedBaselineTimeline = runSimulation(
+        yearsToRun, accounts, incomes, expenses, baselineAssumptions, taxState,
+        yearlyReturns, referenceDate,
+        /* conversionMode */ 'std-ded-only',
+        /* useRollingBaseline */ false,
+        /* dpConversionPlan */ undefined,
+        /* dpDebugByYear */ undefined,
+        eoyContributionAdditions,
+        eoyDebtReductions,
+        eoyMortgageReductions,
+    );
+    const stdDedBaselineLifetimeTax = stdDedBaselineTimeline.reduce((total, year) => {
+        return total
+            + (year.taxDetails.fed ?? 0)
+            + (year.taxDetails.state ?? 0)
+            + (year.taxDetails.fica ?? 0)
+            + (year.taxDetails.capitalGains ?? 0);
+    }, 0);
+
+    if (strategy === 'dp-precomputed' && taxOptOn) {
+        // DP path: reuse the std-ded baseline above (already computed) for
+        // context building and the DP forward sweep.
+        const baselineTimeline = stdDedBaselineTimeline;
+
+        // Pass 2 — solve the DP over the baseline trajectory.
+        const birthYear = getBirthYear(assumptions.milestones);
+        const retirementYear = birthYear + getRetirementAge(assumptions.milestones);
+
+        // Brokerage balance entering retirementYear (= end of retirementYear − 1).
+        // buildDPYearContexts looks this up from baseline when available; this
+        // fallback handles the already-retired-today case where no prior baseline
+        // year exists. Mirrors the trad/roth fallback below.
+        const preRetirementSimYearForBrokerage = baselineTimeline.find(y => y.year === retirementYear - 1);
+        const startingBrokerageBalance = preRetirementSimYearForBrokerage
+            ? preRetirementSimYearForBrokerage.accounts
+                .filter((a): a is InvestedAccount =>
+                    a instanceof InvestedAccount && a.taxType === 'Brokerage')
+                .reduce((sum, a) => sum + a.vestedAmount, 0)
+            : accounts
+                .filter((a): a is InvestedAccount =>
+                    a instanceof InvestedAccount && a.taxType === 'Brokerage')
+                .reduce((sum, a) => sum + a.vestedAmount, 0);
+
+        const contexts = buildDPYearContexts(
+            baselineTimeline, assumptions, taxState, retirementYear, startingBrokerageBalance,
+        );
+
+        // Critical: the DP only solves retirement years onward, so its forward
+        // sweep needs the trad balance AT RETIREMENT, not today. Pulling
+        // accounts.vestedAmount here would feed today's balance into year 0
+        // of the contexts (= retirement year), missing pre-retirement growth
+        // and 401k contributions. Pull from the baseline timeline instead —
+        // that's already simulated through the full pre-retirement period.
+        //
+        // SimulationYear records END-of-year state, so we look up
+        // (retirementYear - 1) to get end-of-(year-before-retirement), which
+        // equals start-of-retirement-year — the correct t=0 state for the DP
+        // forward sweep. Looking up retirementYear directly produces an
+        // off-by-one (DP starts from end-of-retirement-year, double-counts
+        // year 0's flows). If the user retires in the very first sim year
+        // (no pre-retirement records), fall back to today's account balances.
+        const preRetirementSimYear = baselineTimeline.find(y => y.year === retirementYear - 1);
+        let startingTradBalance: number;
+        let startingRothBalance: number;
+        if (preRetirementSimYear) {
+            startingTradBalance = preRetirementSimYear.accounts
+                .filter((a): a is InvestedAccount =>
+                    a instanceof InvestedAccount &&
+                    (a.taxType === 'Traditional 401k' || a.taxType === 'Traditional IRA'))
+                .reduce((sum, a) => sum + a.vestedAmount, 0);
+            startingRothBalance = preRetirementSimYear.accounts
+                .filter((a): a is InvestedAccount =>
+                    a instanceof InvestedAccount && a.taxType === 'Roth IRA')
+                .reduce((sum, a) => sum + a.vestedAmount, 0);
+        } else {
+            // Already retired (or retiring in year 0): no prior baseline year
+            // exists. Use today's actual balances.
+            startingTradBalance = accounts
+                .filter((a): a is InvestedAccount =>
+                    a instanceof InvestedAccount &&
+                    (a.taxType === 'Traditional 401k' || a.taxType === 'Traditional IRA'))
+                .reduce((sum, a) => sum + a.vestedAmount, 0);
+            startingRothBalance = accounts
+                .filter((a): a is InvestedAccount =>
+                    a instanceof InvestedAccount && a.taxType === 'Roth IRA')
+                .reduce((sum, a) => sum + a.vestedAmount, 0);
+        }
+        const dpPlan: DPPlan = planConversionsViaDP({
+            contexts,
+            currentTradBalance: startingTradBalance,
+            currentRothBalance: startingRothBalance,
+            backloadDelta: assumptions.investments.rothConversionDPBackloadDelta,
+        });
+
+        // Pass 3 — final sim with the DP plan. The DP strategy in YearSolver
+        // looks up `input.dpConversionPlan` per year. conversionMode is moot
+        // for DP (it does not use the rate-match bracket walker).
+        const finalTimeline = runSimulation(
+            yearsToRun, accounts, incomes, expenses, assumptions, taxState,
+            yearlyReturns, referenceDate,
+            /* conversionMode */ 'rate-match',
+            /* useRollingBaseline */ false,
+            /* dpConversionPlan */ dpPlan.conversionsByYear,
+            /* dpDebugByYear */ dpPlan.diagnostics.perYearDebug,
+            eoyContributionAdditions,
+            eoyDebtReductions,
+            eoyMortgageReductions,
+        );
+
+        // Append solver summary to year-0 logs so the user can see DP setup
+        // (grid, totals) in the year inspector for the simulation start year.
+        if (finalTimeline.length > 0) {
+            finalTimeline[0].logs.push(...dpPlan.diagnostics.summaryLogs);
+        }
+
+        // Attach structured per-year DP traces to their matching SimulationYear
+        // records so the Roth debug screen can render the cost-curve, waterfall,
+        // and balance-flow sections without re-parsing log text.
+        for (const year of finalTimeline) {
+            const trace = dpPlan.diagnostics.perYearTraces.get(year.year);
+            if (trace) year.dpTrace = trace;
+        }
+
+        // Stash the std-ded baseline lifetime tax on year 0 for the live
+        // Withdrawal-tab comparison panel.
+        if (finalTimeline.length > 0) {
+            finalTimeline[0].stdDedBaselineLifetimeTax = stdDedBaselineLifetimeTax;
+        }
+
+        return finalTimeline;
+    }
+
+    // Default: rate-match with rolling per-year sub-sim baselines.
+    const finalTimeline = runSimulation(
+        yearsToRun, accounts, incomes, expenses, assumptions, taxState,
+        yearlyReturns, referenceDate,
+        /* conversionMode */ 'rate-match',
+        /* useRollingBaseline */ true,
+        /* dpConversionPlan */ undefined,
+        /* dpDebugByYear */ undefined,
+        eoyContributionAdditions,
+        eoyDebtReductions,
+        eoyMortgageReductions,
+    );
+    if (finalTimeline.length > 0) {
+        finalTimeline[0].stdDedBaselineLifetimeTax = stdDedBaselineLifetimeTax;
+    }
+    return finalTimeline;
+};

--- a/src/components/Objects/Expense/models.tsx
+++ b/src/components/Objects/Expense/models.tsx
@@ -1,0 +1,1231 @@
+import { AssumptionsState } from "../Assumptions/AssumptionsContext";
+import { parseDate, parseDateRequired, hasClassName } from "../modelUtils";
+
+export type ExpenseFrequency = 'Weekly' | 'Monthly' | 'Annually';
+
+/**
+ * How an `Annually` expense is spread across the budget's monthly view:
+ * - 'lump'        – the full amount is budgeted only in its `dueMonth`.
+ * - 'sinkingFund' – amount/12 is budgeted every month (save up for it).
+ * Only meaningful when `frequency === 'Annually'`. Ignored by the simulation
+ * engine, which is year-granular.
+ */
+export type AnnualBudgetMode = 'lump' | 'sinkingFund';
+
+/**
+ * A long-term savings goal — the "Longer term" cadence. Either:
+ * - 'recurring'  – a big-ticket item replaced on a long cycle (roof every N
+ *   years); `intervalYears` set; recurs forever.
+ * - 'targetDate' – a one-time goal saved up by its `endDate`; done afterward.
+ * In both cases `amount` is the total cost, funded by a steady monthly
+ * set-aside (a sinking fund) over the horizon. There is intentionally no
+ * separate "target date" field — the expense's own `endDate` IS the target,
+ * so editing the end date automatically moves the goal.
+ */
+export type GoalType = 'recurring' | 'targetDate';
+
+export interface Expense {
+  id: string;
+  name: string;
+  amount: number;
+  frequency: ExpenseFrequency;
+  startDate?: Date;
+  endDate?: Date;
+  isDiscretionary?: boolean; // If true, can be cut during Guyton-Klinger guardrail triggers
+  dueMonth?: number;          // 1-12; month an `Annually` expense is actually due
+  annualMode?: AnnualBudgetMode; // how an `Annually` expense spreads across the budget
+  goalType?: GoalType;        // marks a long-term goal ("Longer term" cadence)
+  intervalYears?: number;     // recurrence (years) for a 'recurring' goal
+  goalAccountId?: string;     // linked sinking-fund SavedAccount
+}
+
+// 2. Base Abstract Class
+export abstract class BaseExpense implements Expense {
+  constructor(
+    public id: string,
+    public name: string,
+    public amount: number,
+    public frequency: ExpenseFrequency,
+    public startDate?: Date,
+    public endDate?: Date,
+    public isDiscretionary: boolean = false, // Can be cut during Guyton-Klinger guardrail triggers
+    public startMilestoneId?: string,  // Start expense when this milestone is reached
+    public endMilestoneId?: string,    // End expense when this milestone is reached
+  ) { }
+
+  // Cross-cutting cadence metadata for `Annually` expenses. Declared as plain
+  // fields (not constructor params) so they don't have to thread through every
+  // subclass constructor; set after construction and copied on clone via
+  // `copyMetaTo`, exactly like `isDiscretionary`.
+  public dueMonth?: number;
+  public annualMode: AnnualBudgetMode = 'lump';
+
+  // Long-term goal metadata ("Longer term" cadence). Presence of `goalType`
+  // marks an expense as a goal. `amount` holds the total cost.
+  public goalType?: GoalType;
+  public intervalYears?: number;   // for 'recurring' goals
+  public goalAccountId?: string;   // linked sinking-fund SavedAccount
+
+  /**
+   * Copy cross-cutting metadata not passed through constructors onto a freshly
+   * cloned expense (used by increment/adjustAmount). Returns the target for
+   * convenient `return this.copyMetaTo(clone)`.
+   */
+  protected copyMetaTo<T extends BaseExpense>(target: T): T {
+    target.isDiscretionary = this.isDiscretionary;
+    target.dueMonth = this.dueMonth;
+    target.annualMode = this.annualMode;
+    target.goalType = this.goalType;
+    target.intervalYears = this.intervalYears;
+    target.goalAccountId = this.goalAccountId;
+    return target;
+  }
+
+  getProratedAnnual(value: number, year?: number): number {
+    let annual = 0;
+    switch (this.frequency) {
+      case 'Weekly': annual = value * 52; break;
+      case 'Monthly': annual = value * 12; break;
+      case 'Annually': annual = value; break;
+      default: annual = 0;
+    }
+
+    if (year !== undefined) {
+      return annual * getExpenseActiveMultiplier(this, year);
+    }
+
+    return annual;
+  }
+
+  getProratedMonthly(value: number, year?: number): number {
+    return this.getProratedAnnual(value, year) / 12;
+  }
+
+  // --- REFACTORED MAIN METHODS ---
+
+  getAnnualAmount(year?: number): number {
+    // Long-term goals are funded as a savings set-aside, not spent as a
+    // recurring expense — so `amount` (the total cost) must not be read as an
+    // annual outflow. The budget shows the set-aside via getExpenseMonthlyBudget,
+    // and the simulation handles accrue-and-lump separately; here a goal
+    // contributes 0 to ordinary expense totals.
+    if (this.goalType) return 0;
+    return this.getProratedAnnual(this.amount, year);
+  }
+
+  getMonthlyAmount(year?: number): number {
+    if (this.goalType) return 0;
+    return this.getProratedMonthly(this.amount, year);
+  }
+
+  /**
+   * Returns a new expense with the amount adjusted by the given ratio.
+   * Used for Guyton-Klinger guardrail adjustments.
+   * @param ratio - Multiplier for the amount (e.g., 0.9 for 10% cut, 1.1 for 10% increase)
+   */
+  abstract adjustAmount(ratio: number): AnyExpense;
+
+  /**
+   * Helper to get the general inflation rate from assumptions.
+   * Returns 0 if inflationAdjusted is false.
+   */
+  protected getGeneralInflation(assumptions: AssumptionsState): number {
+    return (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+  }
+}
+
+/**
+ * SimpleExpense - Base class for expenses that only need general inflation adjustment.
+ *
+ * This consolidates the common pattern shared by: VacationExpense, SubscriptionExpense,
+ * EmergencyExpense, TransportExpense, FoodExpense, and OtherExpense.
+ */
+abstract class SimpleExpense extends BaseExpense {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: ExpenseFrequency,
+    startDate?: Date,
+    endDate?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, amount, frequency, startDate, endDate, false, startMilestoneId, endMilestoneId);
+  }
+
+  /**
+   * Clone this instance as the same concrete subclass, with `amount` scaled
+   * by the given factor. Uses `this.constructor` so each subclass inherits the
+   * behavior without having to implement its own factory.
+   */
+  private cloneWithAmount(newAmount: number): AnyExpense {
+    type SimpleExpenseCtor = new (
+      id: string,
+      name: string,
+      amount: number,
+      frequency: ExpenseFrequency,
+      startDate?: Date,
+      endDate?: Date,
+      startMilestoneId?: string,
+      endMilestoneId?: string,
+    ) => AnyExpense;
+    const Ctor = this.constructor as SimpleExpenseCtor;
+    const result = new Ctor(
+      this.id,
+      this.name,
+      newAmount,
+      this.frequency,
+      this.startDate,
+      this.endDate,
+      this.startMilestoneId,
+      this.endMilestoneId,
+    );
+    return this.copyMetaTo(result);
+  }
+
+  increment(assumptions: AssumptionsState): AnyExpense {
+    const generalInflation = this.getGeneralInflation(assumptions);
+    return this.cloneWithAmount(this.amount * (1 + generalInflation));
+  }
+
+  adjustAmount(ratio: number): AnyExpense {
+    return this.cloneWithAmount(this.amount * ratio);
+  }
+}
+
+// 3. Concrete Classes
+
+export class RentExpense extends BaseExpense {
+  constructor(
+    id: string,
+    name: string,
+    public payment: number,
+    public utilities: number,
+    frequency: ExpenseFrequency,
+    startDate?: Date,
+    endDate?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, payment + utilities, frequency, startDate, endDate, false, startMilestoneId, endMilestoneId);
+  }
+
+  increment(assumptions: AssumptionsState): RentExpense {
+    const rentInflation = assumptions.expenses.rentInflation / 100;
+    const generalInflation = this.getGeneralInflation(assumptions);
+
+    const newPayment = this.payment * (1 + rentInflation + generalInflation);
+    const newUtilities = this.utilities * (1 + rentInflation + generalInflation);
+
+    const result = new RentExpense(
+      this.id, this.name, newPayment, newUtilities, this.frequency, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+
+  adjustAmount(ratio: number): RentExpense {
+    const result = new RentExpense(
+      this.id, this.name, this.payment * ratio, this.utilities * ratio, this.frequency, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+}
+
+export class MortgageExpense extends BaseExpense {
+  constructor(
+    id: string,
+    name: string,
+    frequency: ExpenseFrequency,
+    public valuation: number,
+    public loan_balance: number,
+    public starting_loan_balance: number,
+    public apr: number,
+    public term_length: number,
+    public property_taxes: number,
+    public valuation_deduction: number,
+    public maintenance: number,
+    public utilities: number,
+    public home_owners_insurance: number,
+    public pmi: number,
+    public hoa_fee: number,
+    public is_tax_deductible: 'Yes' | 'No' | 'Itemized',
+    public tax_deductible: number,
+    public linkedAccountId: string,
+    startDate?: Date,
+    public payment: number = 0,
+    public extra_payment: number = 0,
+    endDate?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    const r = apr / 100 / 12;
+    const n = term_length * 12;
+    // Guard against 0% APR: the standard amortization formula is 0/0 = NaN when r === 0,
+    // which would poison the entire payment. Fall back to straight-line principal / n.
+    const fixed_amortization = r === 0
+      ? (n > 0 ? starting_loan_balance / n : 0)
+      : starting_loan_balance * ((r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1));
+
+    const interest_payment = loan_balance * r;
+    const principal_payment = (loan_balance > 0 ? fixed_amortization : 0) - interest_payment;
+
+    const property_tax_payment = (valuation - valuation_deduction) * property_taxes / 100 / 12;
+    // PMI applies while loan-to-value is ABOVE 80% (low equity) and drops off once LTV <= 80%.
+    const pmi_payment = (loan_balance/valuation) > .8 ? valuation * pmi / 100 / 12 : 0;
+    const repair_payment = maintenance / 100 / 12 * valuation;
+    const home_owners_insurance_payment = home_owners_insurance / 100 / 12 * valuation;
+
+    payment = principal_payment + property_tax_payment + pmi_payment + hoa_fee + repair_payment + utilities + home_owners_insurance_payment + interest_payment + extra_payment;
+    tax_deductible = interest_payment;
+
+    super(id, name, payment, frequency, startDate, endDate, false, startMilestoneId, endMilestoneId);
+    this.payment = payment;
+    this.tax_deductible = tax_deductible;
+  }
+
+  increment(assumptions: AssumptionsState): MortgageExpense {
+    const monthlyRate = this.apr / 100 / 12;
+    let balance = this.loan_balance;
+    let totalInterestPaid = 0;
+
+    // Simulate 12 monthly payments
+    const standardPI = this.calculatePrincipalAndInterest();
+
+    for (let i = 0; i < 12; i++) {
+      if (balance <= 0) break;
+
+      const interest = balance * monthlyRate;
+      const totalMonthlyPay = standardPI + this.extra_payment;
+      const principal = Math.min(balance, totalMonthlyPay - interest);
+
+      balance -= principal;
+      totalInterestPaid += interest;
+    }
+
+    const generalInflation = this.getGeneralInflation(assumptions);
+    const housingAppreciation = assumptions.expenses.housingAppreciation / 100;
+
+    const newValuation = this.valuation * (1 + housingAppreciation + generalInflation);
+    const newUtilities = this.utilities * (1 + generalInflation);
+    const newHoa = this.hoa_fee * (1 + generalInflation);
+    const newDeduction = this.valuation_deduction * (1 + housingAppreciation + generalInflation);
+
+    if (balance < 0.005) {
+      balance = 0;
+    }
+
+    // Auto-remove PMI when equity reaches 20%
+    let nextPmi = this.pmi;
+    if (newValuation > 0 && balance > 0) {
+      const equity = (newValuation - balance) / newValuation;
+      if (equity >= 0.2) {
+        nextPmi = 0;
+      }
+    } else if (balance <= 0) {
+      nextPmi = 0;
+    }
+
+    const nextYearMortgage = new MortgageExpense(
+      this.id, this.name, this.frequency,
+      newValuation, balance, this.starting_loan_balance,
+      this.apr, this.term_length, this.property_taxes, newDeduction,
+      this.maintenance, newUtilities, this.home_owners_insurance, nextPmi, newHoa,
+      this.is_tax_deductible, this.tax_deductible, this.linkedAccountId,
+      this.startDate, this.payment, this.extra_payment, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+
+    nextYearMortgage.tax_deductible = totalInterestPaid;
+    this.copyMetaTo(nextYearMortgage);
+
+    return nextYearMortgage;
+  }
+
+  // Helper method required for the grow calculation
+  private calculatePrincipalAndInterest(): number {
+    if (this.apr === 0) return this.starting_loan_balance / (this.term_length * 12);
+
+    const r = this.apr / 100 / 12;
+    const n = this.term_length * 12;
+    return this.starting_loan_balance * ((r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1));
+  }
+
+
+  calculateAnnualAmortization(year: number): { totalInterest: number, totalPrincipal: number, totalPayment: number } {
+    const purchaseYear = this.startDate != null ? this.startDate.getUTCFullYear() : new Date().getFullYear();
+    const purchaseMonth = this.startDate != null ? this.startDate.getUTCMonth() : new Date().getMonth();
+
+    if (year < purchaseYear) {
+      return { totalInterest: 0, totalPrincipal: 0, totalPayment: 0 };
+    }
+
+    // FIX 1: Trust that 'this.loan_balance' is already the correct starting balance for this year.
+    // We DO NOT skip months based on (year - purchaseYear) because the simulation 
+    // has already incremented/reduced the balance for previous years.
+    let balance = this.loan_balance;
+
+    const monthlyRate = this.apr / 100 / 12;
+    const numPayments = this.term_length * 12;
+
+    // Calculate the Standard P&I + Extra Payment Target (Same as before)
+    // Guard against 0% APR: the amortization formula is 0/0 = NaN when monthlyRate === 0.
+    // Fall back to straight-line principal / numPayments (matches constructor & calculatePrincipalAndInterest).
+    const standardMonthlyPI = monthlyRate === 0
+      ? (numPayments > 0 ? this.starting_loan_balance / numPayments : 0)
+      : this.starting_loan_balance * (monthlyRate * Math.pow(1 + monthlyRate, numPayments)) / (Math.pow(1 + monthlyRate, numPayments) - 1);
+    const targetMonthlyPayment = standardMonthlyPI + this.extra_payment;
+
+    // Isolate the Escrow Amount (Taxes, HOA, Insurance)
+    // We assume 'this.amount' is the Total Monthly Payment (P&I + Escrow)
+    let monthlyEscrow = 0;
+    if (this.loan_balance <= 0) {
+      monthlyEscrow = this.amount; // If loan is paid off, entire payment is escrow
+    }
+    else {
+      monthlyEscrow = this.amount - targetMonthlyPayment;
+    }
+
+    // Handle partial first year
+    const startMonth = (year === purchaseYear) ? purchaseMonth : 0;
+
+    let totalInterest = 0;
+    let totalPrincipal = 0;
+    let totalPayment = 0;
+
+    for (let month = startMonth; month < 12; month++) {
+      if (balance <= 0) {
+        totalPayment += monthlyEscrow * (12 - month); // Pay only escrow for remaining months
+        break;
+      }
+      const interest = balance * monthlyRate;
+      
+      // Calculate Principal (Cap at remaining balance)
+      const expectedPrincipal = targetMonthlyPayment - interest;
+      const principal = Math.min(balance, expectedPrincipal);
+      
+      // FIX 2: Calculate the ACTUAL payment for this specific month.
+      // If it's the final month, we only pay Principal + Interest + Escrow, 
+      // NOT the full 'this.amount'.
+      const actualPayment = principal + interest + monthlyEscrow;
+
+      balance -= principal;
+      
+      totalPayment += actualPayment;
+      totalInterest += interest;
+      totalPrincipal += principal;
+    }
+
+    return { totalInterest, totalPrincipal, totalPayment };
+  }
+
+  calculatePayment(): number {
+    const r = this.apr / 100 / 12;
+    const n = this.term_length * 12;
+
+    // Fixed P&I Calculation (Always use starting_loan_balance)
+    // Guard 0% APR: formula is 0/0 = NaN when r === 0; fall back to straight-line.
+    const fixed_amortization = r === 0
+      ? (n > 0 ? this.starting_loan_balance / n : 0)
+      : this.starting_loan_balance * ((r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1));
+
+    // Interest (Based on current balance)
+    const interest_payment = this.loan_balance * r;
+
+    // Principal (The remainder)
+    const principal_payment = fixed_amortization - interest_payment;
+
+    const property_tax_payment = (this.valuation - this.valuation_deduction) * this.property_taxes / 100 / 12;
+    const pmi_payment = this.valuation * this.pmi / 100 / 12;
+    const repair_payment = this.maintenance / 100 / 12 * this.valuation;
+    const home_owners_insurance_payment = this.home_owners_insurance / 100 / 12 * this.valuation;
+
+    return principal_payment + property_tax_payment + pmi_payment + this.hoa_fee + repair_payment + this.utilities + home_owners_insurance_payment + interest_payment + this.extra_payment;
+  }
+
+  calculateDeductible(): number {
+    const interest_payment = this.loan_balance * (this.apr / 100 / 12);
+    return interest_payment;
+  }
+
+  /**
+   * Mortgages are contractual obligations and cannot be adjusted.
+   * Returns the same mortgage unchanged.
+   */
+  adjustAmount(_ratio: number): MortgageExpense {
+    // Mortgages are fixed contractual obligations - cannot scale them
+    // If someone marks a mortgage as discretionary, we just ignore the adjustment
+    return this;
+  }
+
+  getPrincipalPayment(): number {
+    const r = this.apr / 100 / 12;
+    const n = this.term_length * 12;
+
+    // Fixed P&I Calculation (Always use starting_loan_balance)
+    // FIX: Switched from this.loan_balance to this.starting_loan_balance
+    // Guard 0% APR: formula is 0/0 = NaN when r === 0; fall back to straight-line.
+    const fixed_amortization = r === 0
+      ? (n > 0 ? this.starting_loan_balance / n : 0)
+      : this.starting_loan_balance * ((r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1));
+
+    const interest_payment = this.loan_balance * r;
+
+    // Result is the Principal portion of the *Standard* payment
+    return fixed_amortization - interest_payment;
+  }
+
+  getBalanceAtDate(dateStr: string): number {
+    const targetDate = new Date(dateStr);
+    const start = new Date(this.startDate != null ? this.startDate : new Date());
+
+    // If target is before purchase, the loan didn't exist yet (return 0)
+    if (targetDate < start) return 0;
+
+    // Calculate months elapsed
+    const monthsElapsed =
+      (targetDate.getUTCFullYear() - start.getUTCFullYear()) * 12 +
+      (targetDate.getUTCMonth() - start.getUTCMonth());
+
+    if (monthsElapsed <= 0) return this.starting_loan_balance;
+
+    // Calculate Monthly P&I Payment (Principal + Interest only)
+    const r = this.apr / 100 / 12;
+    const n = this.term_length * 12;
+
+    // Standard Formula for Fixed Monthly Payment using Starting Balance
+    // Guard 0% APR: formula is 0/0 = NaN when r === 0; fall back to straight-line.
+    const piPayment = r === 0
+      ? (n > 0 ? this.starting_loan_balance / n : 0)
+      : this.starting_loan_balance * ((r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1));
+
+    let balance = this.starting_loan_balance;
+
+    // Iterate to find balance at specific month
+    for (let i = 0; i < monthsElapsed; i++) {
+      if (balance <= 0) return 0;
+      const interest = balance * r;
+      // We assume the payment made was the calculated PI payment + any defined extra payment
+      const principal = (piPayment + this.extra_payment) - interest;
+      balance -= principal;
+    }
+
+    return balance > 0 ? balance : 0;
+  }
+}
+
+export class LoanExpense extends BaseExpense {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: ExpenseFrequency,
+    public apr: number,
+    public interest_type: 'Compounding' | 'Simple',
+    public payment: number,
+    public is_tax_deductible: 'Yes' | 'No' | 'Itemized',
+    public tax_deductible: number,
+    public linkedAccountId: string,
+    startDate?: Date,
+    endDate?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    const effectiveStartDate = startDate || new Date();
+    const effectiveEndDate = endDate || (() => {
+      const end = new Date(effectiveStartDate);
+      end.setFullYear(end.getFullYear() + 10);
+      return end;
+    })();
+
+    super(id, name, amount, frequency, effectiveStartDate, effectiveEndDate, false, startMilestoneId, endMilestoneId);
+
+    if (!this.payment) {
+      this.payment = this.calculatePaymentFromEndDate();
+    }
+  }
+  increment(_assumptions: AssumptionsState): LoanExpense {
+    let balance = this.amount; // In LoanExpense, 'amount' tracks the current balance
+    const monthlyRate = this.apr / 100 / 12;
+
+    // 1. Internal Loop: 12 Months
+    for (let i = 0; i < 12; i++) {
+      if (balance <= 0) break;
+
+      // Accrue interest on the outstanding balance for both Simple and Compounding loans.
+      // (Previously 'Simple' loans skipped this branch and accrued zero interest, so the
+      // entire payment went to principal and the loan effectively cost nothing.)
+      let interest = 0;
+      if (this.apr > 0) {
+        interest = balance * monthlyRate;
+      }
+
+      // Logic: Payment covers interest first, then principal
+      // this.payment is the total monthly payment
+      const principal = Math.min(balance, this.payment - interest);
+
+      // If payment is too low to cover interest, balance grows (negative amortization)
+      // Otherwise balance shrinks
+      balance = balance - principal;
+    }
+
+    // 2. Return new state
+    const result = new LoanExpense(
+      this.id,
+      this.name,
+      balance, // New Balance
+      this.frequency,
+      this.apr,
+      this.interest_type,
+      this.payment, // Payment stays fixed
+      this.is_tax_deductible,
+      this.tax_deductible,
+      this.linkedAccountId,
+      this.startDate,
+      this.endDate,
+      this.startMilestoneId,
+      this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+
+  calculateAnnualAmortization(year: number): { totalInterest: number, totalPrincipal: number, totalPayment: number } {
+    const loanStartYear = this.startDate ? this.startDate.getUTCFullYear() : new Date().getFullYear();
+    if (year < loanStartYear) {
+        return { totalInterest: 0, totalPrincipal: 0, totalPayment: 0 };
+    }
+
+    const loanEndYear = this.endDate ? this.endDate.getUTCFullYear() : null;
+    if (loanEndYear !== null && year > loanEndYear) {
+        return { totalInterest: 0, totalPrincipal: 0, totalPayment: 0 };
+    }
+
+    let balance = this.amount; // Balance at start of the year
+    let totalInterest = 0;
+    let totalPrincipal = 0;
+
+    const monthlyRate = this.apr / 100 / 12;
+
+    const startMonth = (year === loanStartYear) ? (this.startDate ? this.startDate.getUTCMonth() : 0) : 0;
+    const endMonth = (loanEndYear === year) ? (this.endDate ? this.endDate.getUTCMonth() : 11) : 11;
+
+    for (let month = startMonth; month <= endMonth; month++) {
+        if (balance <= 0) {
+            break;
+        }
+
+        const interest = this.apr > 0 ? balance * monthlyRate : 0;
+        
+        // Determine the payment for this month
+        // It's either the full payment, or just enough to clear the balance
+        const paymentThisMonth = Math.min(this.payment, balance + interest);
+        
+        let principalPaid = paymentThisMonth - interest;
+        
+        // Ensure we don't overpay principal
+        if (principalPaid > balance) {
+            principalPaid = balance;
+        }
+        
+        totalInterest += interest;
+        totalPrincipal += principalPaid;
+        balance -= principalPaid;
+    }
+    
+    const totalPayment = totalPrincipal + totalInterest;
+
+    return { totalInterest, totalPrincipal, totalPayment };
+  }
+  
+  calculatePaymentFromEndDate(): number {
+    const months = this.getMonthsUntilPaidOff();
+    if (months <= 0) return this.amount;
+
+    if (this.apr === 0) {
+      return this.amount / months;
+    }
+    const monthlyRate = this.apr / 100 / 12;
+    const payment = this.amount * (monthlyRate * Math.pow(1 + monthlyRate, months)) / (Math.pow(1 + monthlyRate, months) - 1);
+    return parseFloat(payment.toFixed(2));
+  }
+
+  calculateEndDateFromPayment(payment: number): Date {
+    const months = this.calculateMonthsFromPayment(payment);
+    const newEndDate = new Date(this.startDate!);
+    newEndDate.setMonth(newEndDate.getMonth() + months);
+    return newEndDate;
+  }
+
+  calculateMonthsFromPayment(payment: number): number {
+    if (this.apr === 0) {
+      return payment > 0 ? this.amount / payment : Infinity;
+    }
+    const monthlyRate = this.apr / 100 / 12;
+    if (payment <= this.amount * monthlyRate) {
+      return Infinity;
+    }
+    const months = -Math.log(1 - (this.amount * monthlyRate) / payment) / Math.log(1 + monthlyRate);
+    return Math.round(months);
+  }
+
+  getMonthsUntilPaidOff(): number {
+    if (!this.endDate || !this.startDate) return 0;
+    const start = new Date(this.startDate);
+    const end = new Date(this.endDate);
+    // startDate/endDate are UTC-midnight date-only values; read with getUTC* to
+    // avoid a one-month shift in negative-UTC timezones.
+    return (end.getUTCFullYear() - start.getUTCFullYear()) * 12 + (end.getUTCMonth() - start.getUTCMonth());
+  }
+
+  getAnnualAmount(year?: number): number {
+    return this.getProratedAnnual(this.payment, year);
+  }
+
+  getMonthlyAmount(year?: number): number {
+    return this.getProratedAnnual(this.payment, year) / 12;
+  }
+
+  /**
+   * Loans are contractual obligations and cannot be adjusted.
+   * Returns the same loan unchanged.
+   */
+  adjustAmount(_ratio: number): LoanExpense {
+    // Loans are fixed contractual obligations - cannot scale them
+    return this;
+  }
+}
+
+export class DependentExpense extends BaseExpense {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: ExpenseFrequency,
+    public is_tax_deductible: 'Yes' | 'No' | 'Itemized',
+    public tax_deductible: number,
+    startDate?: Date,
+    endDate?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, amount, frequency, startDate, endDate, false, startMilestoneId, endMilestoneId);
+  }
+
+  increment(assumptions: AssumptionsState): DependentExpense {
+    const generalInflation = this.getGeneralInflation(assumptions);
+    const result = new DependentExpense(
+      this.id, this.name, this.amount * (1 + generalInflation), this.frequency,
+      this.is_tax_deductible, this.tax_deductible, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+
+  adjustAmount(ratio: number): DependentExpense {
+    const result = new DependentExpense(
+      this.id, this.name, this.amount * ratio, this.frequency,
+      this.is_tax_deductible, this.tax_deductible, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+}
+
+export class HealthcareExpense extends BaseExpense {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: ExpenseFrequency,
+    public is_tax_deductible: 'Yes' | 'No' | 'Itemized',
+    public tax_deductible: number,
+    startDate?: Date,
+    endDate?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, amount, frequency, startDate, endDate, false, startMilestoneId, endMilestoneId);
+  }
+
+  increment(assumptions: AssumptionsState): HealthcareExpense {
+    const inflation = assumptions.macro.healthcareInflation / 100;
+    const result = new HealthcareExpense(
+      this.id, this.name, this.amount * (1 + inflation), this.frequency,
+      this.is_tax_deductible, this.tax_deductible, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+
+  adjustAmount(ratio: number): HealthcareExpense {
+    const result = new HealthcareExpense(
+      this.id, this.name, this.amount * ratio, this.frequency,
+      this.is_tax_deductible, this.tax_deductible, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+}
+
+// Each of these is a SimpleExpense — they exist as named classes so production
+// code can pattern-match via `instanceof` and so saved data round-trips through
+// className. Inflation + adjustAmount behavior lives on the parent.
+export class VacationExpense extends SimpleExpense {}
+export class SubscriptionExpense extends SimpleExpense {}
+export class EmergencyExpense extends SimpleExpense {}
+export class TransportExpense extends SimpleExpense {}
+export class FoodExpense extends SimpleExpense {}
+export class OtherExpense extends SimpleExpense {}
+
+export class CharityExpense extends BaseExpense {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: ExpenseFrequency,
+    public is_tax_deductible: 'Yes' | 'No' | 'Itemized',
+    public tax_deductible: number,
+    startDate?: Date,
+    endDate?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, amount, frequency, startDate, endDate, true, startMilestoneId, endMilestoneId);
+    // Charity is typically discretionary - already set via super call
+  }
+
+  increment(assumptions: AssumptionsState): CharityExpense {
+    const generalInflation = this.getGeneralInflation(assumptions);
+    const result = new CharityExpense(
+      this.id, this.name, this.amount * (1 + generalInflation), this.frequency,
+      this.is_tax_deductible, this.tax_deductible, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+
+  adjustAmount(ratio: number): CharityExpense {
+    const result = new CharityExpense(
+      this.id, this.name, this.amount * ratio, this.frequency,
+      this.is_tax_deductible, this.tax_deductible, this.startDate, this.endDate,
+      this.startMilestoneId, this.endMilestoneId
+    );
+    return this.copyMetaTo(result);
+  }
+}
+
+export type AnyExpense = RentExpense | MortgageExpense | LoanExpense | DependentExpense | HealthcareExpense | VacationExpense | EmergencyExpense | TransportExpense | FoodExpense | OtherExpense | CharityExpense | SubscriptionExpense;
+
+export function getExpenseActiveMultiplier(expense: BaseExpense, year: number): number {
+  const expenseStartDate = expense.startDate ? new Date(expense.startDate) : new Date();
+  // Date-only values come from parseDate, which returns UTC dates (see modelUtils
+  // contract). Read with getUTC* so the active window doesn't shift by a month/year
+  // in negative timezones.
+  const startYear = expenseStartDate.getUTCFullYear();
+
+  const safeEndDate = expense.endDate ? new Date(expense.endDate) : null;
+  const endYear = safeEndDate ? safeEndDate.getUTCFullYear() : null;
+
+  if (startYear > year) return 0;
+  if (endYear !== null && endYear < year) return 0;
+
+  const startMonthIndex = (startYear < year) ? 0 : expenseStartDate.getUTCMonth();
+
+  const endMonthIndex = (safeEndDate && endYear === year)
+    ? safeEndDate.getUTCMonth()
+    : 11;
+
+  const monthsActive = endMonthIndex - startMonthIndex + 1;
+
+  return Math.max(0, monthsActive) / 12;
+}
+
+export function isExpenseActiveInCurrentMonth(expense: AnyExpense): boolean {
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  const currentMonth = today.getMonth();
+
+  const expenseStartDate = expense.startDate != null ? expense.startDate : new Date();
+  // Stored date-only values are UTC-midnight; read them with getUTC* (today stays
+  // local since it's a true instant). Both sides feed local new Date(y, m, 1)
+  // month-boundary comparisons, so the bases stay consistent.
+  const expenseStartYear = expenseStartDate.getUTCFullYear();
+  const expenseStartMonth = expenseStartDate.getUTCMonth();
+
+  const currentMonthStart = new Date(currentYear, currentMonth, 1);
+  const expenseEffectiveStart = new Date(expenseStartYear, expenseStartMonth, 1);
+
+  if (expenseEffectiveStart > currentMonthStart) {
+    return false;
+  }
+
+  if (expense.endDate) {
+    const expenseEndDate = new Date(expense.endDate);
+    const expenseEndYear = expenseEndDate.getUTCFullYear();
+    const expenseEndMonth = expenseEndDate.getUTCMonth();
+
+    const expenseEffectiveEnd = new Date(expenseEndYear, expenseEndMonth + 1, 0);
+
+    if (expenseEffectiveEnd < currentMonthStart) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * An expense is "done" when it no longer applies going forward:
+ * - its end date is in the past, or
+ * - it's a loan whose balance has been paid off.
+ * Done expenses are hidden from the active list by default (but kept for the
+ * record). Mortgages are intentionally excluded — even with the loan paid off
+ * they carry ongoing escrow costs (taxes, insurance, HOA).
+ */
+export function isExpenseDone(expense: AnyExpense): boolean {
+  const now = new Date();
+  if (expense.endDate && new Date(expense.endDate) < now) return true;
+  if (expense instanceof LoanExpense && expense.amount <= 0) return true;
+  // A one-time goal is done once its target (endDate) has passed — covered by
+  // the endDate check above. Recurring goals never finish.
+  return false;
+}
+
+/** True if the expense is a long-term savings goal ("Longer term" cadence). */
+export function isLongTermGoal(expense: AnyExpense): boolean {
+  return expense.goalType != null;
+}
+
+/** Whole months between two dates (>= 0). */
+function monthsBetween(from: Date, to: Date): number {
+  const months = (to.getUTCFullYear() - from.getUTCFullYear()) * 12 + (to.getUTCMonth() - from.getUTCMonth());
+  return Math.max(0, months);
+}
+
+/**
+ * Steady monthly set-aside that funds a goal over its horizon (a sinking fund).
+ * - recurring: total / (intervalYears * 12)
+ * - targetDate: total / months from start to target (the goal's endDate)
+ * Returns 0 for non-goals or ill-defined horizons.
+ */
+export function getGoalMonthlySetAside(expense: AnyExpense): number {
+  if (expense.goalType === 'recurring' && expense.intervalYears && expense.intervalYears > 0) {
+    return expense.amount / (expense.intervalYears * 12);
+  }
+  if (expense.goalType === 'targetDate' && expense.endDate) {
+    const start = expense.startDate ? new Date(expense.startDate) : new Date();
+    const months = monthsBetween(start, new Date(expense.endDate));
+    return months > 0 ? expense.amount / months : 0;
+  }
+  return 0;
+}
+
+/**
+ * Whether a goal's lump comes due in the given calendar year.
+ * - targetDate: the year of the target (the goal's endDate).
+ * - recurring: anchor year (start date) + k*intervalYears for k >= 1, so the
+ *   first purchase is one full interval after you start saving.
+ */
+export function isGoalDueInYear(expense: AnyExpense, year: number): boolean {
+  if (expense.goalType === 'targetDate' && expense.endDate) {
+    return new Date(expense.endDate).getUTCFullYear() === year;
+  }
+  if (expense.goalType === 'recurring' && expense.intervalYears && expense.intervalYears > 0) {
+    const anchorYear = (expense.startDate ? new Date(expense.startDate) : new Date()).getUTCFullYear();
+    const diff = year - anchorYear;
+    return diff > 0 && diff % expense.intervalYears === 0;
+  }
+  return false;
+}
+
+/**
+ * Live monthly cap for a goal's sinking-fund savings priority in a given year,
+ * or undefined when the account isn't a goal fund.
+ *
+ * Goal funding is DERIVED, never trusted from storage: the priority created
+ * alongside a goal stores a capValue snapshot, but editing the goal's amount,
+ * dates, or interval would leave that snapshot stale. Both the simulation and
+ * the budget projection call this instead, so goal edits propagate
+ * automatically. Returns 0 outside the active saving window — before the
+ * goal's start year, and (for one-time goals) after the purchase year.
+ *
+ * Years are extracted with getUTCFullYear to match isGoalDueInYear: goal dates
+ * are stored as UTC-midnight, so local accessors in a negative-UTC timezone
+ * would shift a YYYY-01-01 target back a year.
+ */
+export function getGoalFundMonthlyCap(
+  expenses: AnyExpense[],
+  accountId: string | undefined,
+  year: number,
+): number | undefined {
+  if (!accountId) return undefined;
+  const goal = expenses.find(e => isLongTermGoal(e) && e.goalAccountId === accountId);
+  if (!goal) return undefined;
+  const startYear = (goal.startDate ? new Date(goal.startDate) : new Date()).getUTCFullYear();
+  if (year < startYear) return 0; // not saving yet
+  if (goal.goalType === 'targetDate' && goal.endDate
+      && new Date(goal.endDate).getUTCFullYear() < year) return 0; // already purchased
+  return getGoalMonthlySetAside(goal);
+}
+
+/**
+ * Months of a calendar year during which a goal is actively saving: from its
+ * start month through the month before its end/target (a January target means
+ * no saving months in that final year — the lump is due then). Summed across
+ * years this equals monthsBetween(start, end) exactly, so a goal funded at its
+ * monthly set-aside lands on its total by the target — mid-year starts and the
+ * partial final year are handled instead of charging a full 12 months. UTC
+ * accessors match the rest of the goal math.
+ */
+function goalMonthsActiveInYear(goal: AnyExpense, year: number): number {
+  const start = goal.startDate ? new Date(goal.startDate) : new Date();
+  const startYear = start.getUTCFullYear();
+  if (year < startYear) return 0;
+  const from = year === startYear ? start.getUTCMonth() : 0;
+  let to = 12;
+  if (goal.endDate) {
+    const end = new Date(goal.endDate);
+    const endYear = end.getUTCFullYear();
+    if (year > endYear) return 0;
+    if (year === endYear) to = end.getUTCMonth();
+  }
+  return Math.max(0, to - from);
+}
+
+/**
+ * Annual committed set-aside for a goal's fund in a calendar year — the
+ * monthly set-aside × months active that year — or undefined when the account
+ * isn't a goal fund. This is what the simulation counts with living expenses
+ * and credits into the fund; budget projections use it for per-year totals.
+ */
+export function getGoalFundAnnualSetAside(
+  expenses: AnyExpense[],
+  accountId: string | undefined,
+  year: number,
+): number | undefined {
+  if (!accountId) return undefined;
+  const goal = expenses.find(e => isLongTermGoal(e) && e.goalAccountId === accountId);
+  if (!goal) return undefined;
+  return getGoalMonthlySetAside(goal) * goalMonthsActiveInYear(goal, year);
+}
+
+/**
+ * Merge synthetic goal-fund buckets into a priority list for budget tracking.
+ *
+ * Goals don't carry a savings-priority bucket — their funding is a committed
+ * transfer inside the simulation, derived from the goal itself. But the budget
+ * views still track contribution pacing per fund account, so they synthesize
+ * one bucket per goal here (capValue 0 — consumers derive the live value via
+ * getGoalFundMonthlyCap). Legacy goal buckets from pre-migration data are
+ * dropped so a fund never appears twice.
+ */
+export function mergeGoalFundBuckets<T extends { accountId?: string }>(
+  priorities: T[],
+  expenses: AnyExpense[],
+): (T | {
+  id: string; name: string; type: 'SAVINGS';
+  accountId: string; capType: 'FIXED'; capValue: number;
+})[] {
+  const goals = expenses.filter(e => isLongTermGoal(e) && e.goalAccountId);
+  if (goals.length === 0) return priorities;
+  const goalFundIds = new Set(goals.map(e => e.goalAccountId!));
+  return [
+    ...priorities.filter(p => !(p.accountId && goalFundIds.has(p.accountId))),
+    ...goals.map(e => ({
+      id: `goal-${e.id}`,
+      name: `${e.name} fund`,
+      type: 'SAVINGS' as const,
+      accountId: e.goalAccountId!,
+      capType: 'FIXED' as const,
+      capValue: 0,
+    })),
+  ];
+}
+
+export const EXPENSE_CATEGORIES = [
+  'Rent',
+  'Mortgage',
+  'Loan',
+  'Dependent',
+  'Healthcare',
+  'Vacation',
+  'Subscription',
+  'Emergency',
+  'Transport',
+  'Food',
+  'Charity',
+  'Other'
+] as const;
+
+export type ExpenseCategory = typeof EXPENSE_CATEGORIES[number];
+
+export const EXPENSE_COLORS_BACKGROUND: Record<ExpenseCategory, string> = {
+  Rent: "bg-chart-Fuchsia-50",
+  Mortgage: "bg-chart-Blue-50",
+  Loan: "bg-chart-Blue-50",
+  Dependent: "bg-chart-Yellow-50",
+  Healthcare: "bg-chart-Red-50",
+  Vacation: "bg-chart-Green-50",
+  Subscription: "bg-chart-Cyan-50",
+  Emergency: "bg-chart-Fuchsia-50",
+  Transport: "bg-chart-Blue-50",
+  Food: "bg-chart-Yellow-50",
+  Charity: "bg-chart-Orange-50",
+  Other: "bg-chart-Red-50",
+};
+
+export const CLASS_TO_CATEGORY: Record<string, ExpenseCategory> = {
+  [RentExpense.name]: 'Rent',
+  [MortgageExpense.name]: 'Mortgage',
+  [LoanExpense.name]: 'Loan',
+  [DependentExpense.name]: 'Dependent',
+  [HealthcareExpense.name]: 'Healthcare',
+  [VacationExpense.name]: 'Vacation',
+  [SubscriptionExpense.name]: 'Subscription',
+  [EmergencyExpense.name]: 'Emergency',
+  [TransportExpense.name]: 'Transport',
+  [FoodExpense.name]: 'Food',
+  [CharityExpense.name]: 'Charity',
+  [OtherExpense.name]: 'Other',
+};
+
+// Map Categories to their color palettes (using Tailwind classes)
+// Uses 5-step gradients (1, 25, 50, 75, 100) defined in :root for SVG access
+const PALETTE_STEPS = [1, 25, 50, 75, 100];
+export const CATEGORY_PALETTES: Record<ExpenseCategory, string[]> = {
+  Rent: PALETTE_STEPS.map(i => `bg-chart-Fuchsia-${i}`),
+  Mortgage: PALETTE_STEPS.map(i => `bg-chart-Fuchsia-${i}`),
+  Loan: PALETTE_STEPS.map(i => `bg-chart-Blue-${i}`),
+  Dependent: PALETTE_STEPS.map(i => `bg-chart-Yellow-${i}`),
+  Healthcare: PALETTE_STEPS.map(i => `bg-chart-Red-${i}`),
+  Vacation: PALETTE_STEPS.map(i => `bg-chart-Green-${i}`),
+  Subscription: PALETTE_STEPS.map(i => `bg-chart-Cyan-${i}`),
+  Emergency: PALETTE_STEPS.map(i => `bg-chart-Fuchsia-${i}`),
+  Transport: PALETTE_STEPS.map(i => `bg-chart-Blue-${i}`),
+  Food: PALETTE_STEPS.map(i => `bg-chart-Yellow-${i}`),
+  Charity: PALETTE_STEPS.map(i => `bg-chart-Orange-${i}`),
+  Other: PALETTE_STEPS.map(i => `bg-chart-Red-${i}`),
+};
+
+export function reconstituteExpense(data: unknown): AnyExpense | null {
+    if (!hasClassName(data)) return null;
+
+    const startDate = parseDateRequired(data.startDate);
+    // Legacy migration: 'targetDate' goals used to store the target in a
+    // separate `goalTargetDate` field (a duplicate of endDate that could
+    // drift). endDate is now the single source of truth; absorb the old field
+    // when endDate is missing so pre-migration backups still load.
+    const endDate = parseDate(data.endDate) ?? parseDate(data.goalTargetDate);
+    const frequency = (data.frequency as ExpenseFrequency) || 'Monthly';
+    const id = String(data.id ?? '');
+    const name = String(data.name ?? 'Unnamed Expense');
+    const amount = Number(data.amount) || 0;
+    const isDiscretionary = (data.isDiscretionary as boolean) ?? false;
+    const startMilestoneId = data.startMilestoneId ? String(data.startMilestoneId) : undefined;
+    const endMilestoneId = data.endMilestoneId ? String(data.endMilestoneId) : undefined;
+    const dueMonth = data.dueMonth != null ? Number(data.dueMonth) : undefined;
+    const annualMode: AnnualBudgetMode = data.annualMode === 'sinkingFund' ? 'sinkingFund' : 'lump';
+    const goalType: GoalType | undefined =
+        data.goalType === 'recurring' || data.goalType === 'targetDate' ? data.goalType : undefined;
+    const intervalYears = data.intervalYears != null ? Number(data.intervalYears) : undefined;
+    const goalAccountId = data.goalAccountId ? String(data.goalAccountId) : undefined;
+
+    let expense: AnyExpense | null = null;
+
+    switch (data.className) {
+        case 'HousingExpense':
+        case 'RentExpense':
+            expense = new RentExpense(
+                id, name, Number(data.payment) || 0, Number(data.utilities) || 0,
+                frequency, startDate, endDate, startMilestoneId, endMilestoneId
+            );
+            break;
+        case 'MortgageExpense':
+            expense = new MortgageExpense(
+                id, name, frequency,
+                Number(data.valuation) || 0, Number(data.loan_balance) || 0,
+                Number(data.starting_loan_balance) || 0, Number(data.apr) || 0,
+                Number(data.term_length) || 0, Number(data.property_taxes) || 0,
+                Number(data.valuation_deduction) || 0, Number(data.maintenance) || 0,
+                Number(data.utilities) || 0, Number(data.home_owners_insurance) || 0,
+                Number(data.pmi) || 0, Number(data.hoa_fee) || 0,
+                (data.is_tax_deductible as 'Yes' | 'No' | 'Itemized') || 'No',
+                Number(data.tax_deductible) || 0, String(data.linkedAccountId ?? ''),
+                startDate, Number(data.payment) || 0, Number(data.extra_payment) || 0, endDate,
+                startMilestoneId, endMilestoneId
+            );
+            break;
+        case 'LoanExpense':
+            expense = new LoanExpense(
+                id, name, amount, frequency, Number(data.apr) || 0,
+                (data.interest_type as 'Compounding' | 'Simple') || 'Simple',
+                Number(data.payment) || 0,
+                (data.is_tax_deductible as 'Yes' | 'No' | 'Itemized') || 'No',
+                Number(data.tax_deductible) || 0, String(data.linkedAccountId ?? ''),
+                startDate, endDate, startMilestoneId, endMilestoneId
+            );
+            break;
+        case 'DependentExpense':
+            expense = new DependentExpense(
+                id, name, amount, frequency,
+                (data.is_tax_deductible as 'Yes' | 'No' | 'Itemized') || 'No',
+                Number(data.tax_deductible) || 0, startDate, endDate,
+                startMilestoneId, endMilestoneId
+            );
+            break;
+        case 'HealthcareExpense':
+            expense = new HealthcareExpense(
+                id, name, amount, frequency,
+                (data.is_tax_deductible as 'Yes' | 'No' | 'Itemized') || 'No',
+                Number(data.tax_deductible) || 0, startDate, endDate,
+                startMilestoneId, endMilestoneId
+            );
+            break;
+        case 'VacationExpense':
+            expense = new VacationExpense(id, name, amount, frequency, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+            break;
+        case 'SubscriptionExpense':
+            expense = new SubscriptionExpense(id, name, amount, frequency, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+            break;
+        case 'EmergencyExpense':
+            expense = new EmergencyExpense(id, name, amount, frequency, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+            break;
+        case 'TransportExpense':
+            expense = new TransportExpense(id, name, amount, frequency, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+            break;
+        case 'FoodExpense':
+            expense = new FoodExpense(id, name, amount, frequency, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+            break;
+        case 'OtherExpense':
+            expense = new OtherExpense(id, name, amount, frequency, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+            break;
+        case 'CharityExpense':
+            expense = new CharityExpense(
+                id, name, amount, frequency,
+                (data.is_tax_deductible as 'Yes' | 'No' | 'Itemized') || 'Itemized',
+                Number(data.tax_deductible) || 0, startDate, endDate,
+                startMilestoneId, endMilestoneId
+            );
+            break;
+        default:
+            return null;
+    }
+
+    if (expense) {
+        expense.isDiscretionary = isDiscretionary;
+        expense.dueMonth = dueMonth;
+        expense.annualMode = annualMode;
+        expense.goalType = goalType;
+        expense.intervalYears = intervalYears;
+        expense.goalAccountId = goalAccountId;
+    }
+
+    return expense;
+}

--- a/src/components/Objects/Income/models.tsx
+++ b/src/components/Objects/Income/models.tsx
@@ -1,0 +1,992 @@
+import { TaxType } from "../../Objects/Accounts/models";
+import { AssumptionsState } from '../Assumptions/AssumptionsContext';
+import { get401kLimit, getHSALimit } from '../../../data/ContributionLimits';
+import {
+  calculateFERSBasicBenefit,
+  calculateCSRSBasicBenefit,
+  getFERSCOLA,
+  getCSRSCOLA,
+  checkFERSEligibility,
+  checkCSRSEligibility,
+  calculateFERSSupplement,
+} from '../../../data/PensionData';
+import { parseDate, parseDateRequired, hasClassName } from "../modelUtils";
+
+export type ContributionGrowthStrategy = 'FIXED' | 'GROW_WITH_SALARY' | 'TRACK_ANNUAL_MAX';
+export type AutoMax401kOption = 'disabled' | 'custom' | 'traditional' | 'roth';
+export type ESPPContributionType = 'NONE' | 'PERCENTAGE' | 'FIXED';
+export type PensionSystem = 'NONE' | 'FERS' | 'CSRS';
+export type EmployerMatchType = 'fixed' | 'percent';
+
+export type IncomeFrequency = 'Weekly' | 'Bi-Weekly' | 'Semi-Monthly' | 'Monthly' | 'Annually';
+
+export interface Income {
+  id: string;
+  name: string;
+  amount: number;
+  frequency: IncomeFrequency;
+  earned_income: "Yes" | "No";
+  startDate?: Date;
+  end_date?: Date;
+}
+
+// 2. Base Abstract Class
+export abstract class BaseIncome implements Income {
+  /** Discriminator for type checking that survives minification and serialization */
+  public className: string = '';
+  constructor(
+    public id: string,
+    public name: string,
+    public amount: number,
+    public frequency: IncomeFrequency,
+    public earned_income: "Yes" | "No",
+    public startDate?: Date,
+    public end_date?: Date,
+    public annualGrowthRate: number = 0.03,
+    public startMilestoneId?: string,  // Start income when this milestone is reached
+    public endMilestoneId?: string,    // End income when this milestone is reached
+  ) {}
+  // Number of pay periods per year implied by this income's frequency.
+  getPeriodsPerYear(): number {
+    switch (this.frequency) {
+      case 'Weekly': return 52;
+      case 'Bi-Weekly': return 26;
+      case 'Semi-Monthly': return 24;
+      case 'Monthly': return 12;
+      case 'Annually': return 1;
+      default: return 0;
+    }
+  }
+
+  // Convert an annual figure (e.g. an IRS contribution limit) into the per-period
+  // unit that per-period fields like preTax401k are stored in.
+  annualToPerPeriod(annualValue: number): number {
+    const periods = this.getPeriodsPerYear();
+    return periods > 0 ? annualValue / periods : annualValue;
+  }
+
+  getProratedAnnual(value: number, year?: number): number {
+    const annual = value * this.getPeriodsPerYear();
+
+    // Apply the time-based multiplier if a year is requested
+    if (year !== undefined) {
+        return annual * getIncomeActiveMultiplier(this as unknown as AnyIncome, year);
+    }
+
+    return annual;
+  }
+
+  getProratedMonthly(value: number, year?: number): number {
+    return this.getProratedAnnual(value, year) / 12;
+  }
+
+  // --- REFACTORED MAIN METHODS ---
+
+  getAnnualAmount(year?: number): number {
+    // Just reuse the generic helper with the main amount
+    return this.getProratedAnnual(this.amount, year);
+  }
+
+  getMonthlyAmount(year?: number): number {
+    return this.getProratedMonthly(this.amount, year);
+  }
+}
+
+// 3. Concrete Classes
+
+export class WorkIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: IncomeFrequency,
+    earned_income: "Yes" | "No",
+    public preTax401k: number = 0,
+    public insurance: number = 0,
+    public roth401k: number = 0,
+    public employerMatch: number = 0,
+    public matchAccountId: string,
+    public taxType: TaxType | null = null,
+    public contributionGrowthStrategy: ContributionGrowthStrategy = 'FIXED',
+    startDate?: Date,
+    end_date?: Date,
+    public hsaContribution: number = 0,  // HSA contribution (pre-tax + FICA-exempt)
+    public autoMax401k: AutoMax401kOption = 'custom',  // Auto-max 401k: disabled, custom, traditional, or roth
+    // ESPP configuration
+    public esppContributionType: ESPPContributionType = 'NONE',
+    public esppContributionAmount: number = 0,      // % of salary (1-15) or fixed $/period
+    public esppDiscountPercent: number = 15,        // Typical ESPP discount (5-15%)
+    public esppHasLookback: boolean = true,         // Lookback provision (purchase at lower of grant/purchase price)
+    public esppOfferingPeriodMonths: number = 6,    // Typical is 6 months
+    public esppAccountId: string | null = null,     // Linked ESPP account
+    public esppExpectedStockGrowth: number = 7,     // Expected annual stock growth for lookback modeling
+    public pensionSystem: PensionSystem = 'NONE',   // Which pension system this job is covered by
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+    public employerMatchType: EmployerMatchType = 'fixed',
+    public employerMatchPercent: number = 0,
+    public employerMatchMax: number = 0,  // Annual cap in dollars (0 = no cap)
+  ) {
+    super(id, name, amount, frequency, earned_income, startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'WorkIncome';
+  }
+
+  getEffectiveAnnualEmployerMatch(year?: number): number {
+    if (this.employerMatchType === 'percent') {
+      const annualSalary = this.getProratedAnnual(this.amount, year);
+      const matchAmount = annualSalary * (this.employerMatchPercent / 100);
+      if (this.employerMatchMax > 0) {
+        const activeMult = year !== undefined ? getIncomeActiveMultiplier(this as unknown as AnyIncome, year) : 1;
+        return Math.min(matchAmount, this.employerMatchMax * activeMult);
+      }
+      return matchAmount;
+    }
+    return this.getProratedAnnual(this.employerMatch, year);
+  }
+  increment (assumptions: AssumptionsState, year?: number, age?: number): WorkIncome {
+    const salaryGrowth = assumptions.income.salaryGrowth / 100;
+    const generalInflation = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+
+    // 1. Grow Salary
+    const newAmount = this.amount * (1 + salaryGrowth + generalInflation);
+
+    // 2. Grow Employer Match
+    // (Assuming match is a % of salary, so it grows at the same rate as salary)
+    const newMatch = this.employerMatch * (1 + salaryGrowth + generalInflation);
+
+    // 3. Grow Contributions (401k, Roth, HSA)
+    let newPreTax = this.preTax401k;
+    let newRoth = this.roth401k;
+    let newHSA = this.hsaContribution;
+
+    switch (this.contributionGrowthStrategy) {
+      case 'GROW_WITH_SALARY':
+        newPreTax = this.preTax401k * (1 + salaryGrowth + generalInflation);
+        newRoth = this.roth401k * (1 + salaryGrowth + generalInflation);
+        newHSA = this.hsaContribution * (1 + salaryGrowth + generalInflation);
+        break;
+      case 'TRACK_ANNUAL_MAX':
+        // Cap contributions at IRS annual limits
+        if (year !== undefined && age !== undefined) {
+          // Get annual limits (includes catch-up for age 50+/55+)
+          const inflationAdjusted = assumptions.macro.inflationAdjusted;
+          // Contributions are stored per pay period, so cap against per-period limits.
+          const limit401k = this.annualToPerPeriod(get401kLimit(year, age, inflationAdjusted));
+          const limitHSA = this.annualToPerPeriod(getHSALimit(year, age, 'individual', inflationAdjusted));
+
+          // Combined 401k limit (pre-tax + Roth share same limit)
+          // Grow current values first, then cap at limit
+          const grownPreTax = this.preTax401k * (1 + salaryGrowth + generalInflation);
+          const grownRoth = this.roth401k * (1 + salaryGrowth + generalInflation);
+          const grownTotal401k = grownPreTax + grownRoth;
+
+          if (grownTotal401k > limit401k) {
+            // Cap at limit, maintaining ratio between pre-tax and Roth
+            const ratio = grownTotal401k > 0 ? grownPreTax / grownTotal401k : 0.5;
+            newPreTax = limit401k * ratio;
+            newRoth = limit401k * (1 - ratio);
+          } else {
+            newPreTax = grownPreTax;
+            newRoth = grownRoth;
+          }
+
+          // Cap HSA at limit
+          const grownHSA = this.hsaContribution * (1 + salaryGrowth + generalInflation);
+          newHSA = Math.min(grownHSA, limitHSA);
+        } else {
+          // Fallback to grow with salary if year/age not provided
+          newPreTax = this.preTax401k * (1 + salaryGrowth + generalInflation);
+          newRoth = this.roth401k * (1 + salaryGrowth + generalInflation);
+          newHSA = this.hsaContribution * (1 + salaryGrowth + generalInflation);
+        }
+        break;
+      case 'FIXED':
+      default:
+        // Values remain the same
+        break;
+    }
+
+    // 3b. Apply auto-max 401k if enabled (overrides the above logic)
+    if (this.autoMax401k === 'disabled') {
+      // No 401k contributions
+      newPreTax = 0;
+      newRoth = 0;
+    } else if ((this.autoMax401k === 'traditional' || this.autoMax401k === 'roth') && year !== undefined && age !== undefined) {
+      // The IRS limit is annual; store it per pay period to match the field's unit.
+      const perPeriodLimit = this.annualToPerPeriod(get401kLimit(year, age, assumptions.macro.inflationAdjusted));
+      if (this.autoMax401k === 'traditional') {
+        newPreTax = perPeriodLimit;
+        newRoth = 0;
+      } else {
+        newPreTax = 0;
+        newRoth = perPeriodLimit;
+      }
+    }
+
+    // 4. Grow Insurance Cost
+    // Insurance grows with salary (it's a payroll deduction)
+    const newInsurance = this.insurance * (1 + salaryGrowth + generalInflation);
+
+    // ESPP contribution grows with salary if percentage-based
+    let newESPPAmount = this.esppContributionAmount;
+    if (this.esppContributionType === 'PERCENTAGE') {
+      // Percentage stays the same, effective amount grows with salary
+      newESPPAmount = this.esppContributionAmount;
+    } else if (this.esppContributionType === 'FIXED' && this.contributionGrowthStrategy === 'GROW_WITH_SALARY') {
+      // Fixed amount can optionally grow with salary
+      newESPPAmount = this.esppContributionAmount * (1 + salaryGrowth + generalInflation);
+    }
+
+    return new WorkIncome(
+      this.id,
+      this.name,
+      newAmount,
+      this.frequency,
+      this.earned_income,
+      newPreTax,
+      newInsurance,
+      newRoth,
+      newMatch,
+      this.matchAccountId,
+      this.taxType,
+      this.contributionGrowthStrategy,
+      this.startDate,
+      this.end_date,
+      newHSA,
+      this.autoMax401k,
+      this.esppContributionType,
+      newESPPAmount,
+      this.esppDiscountPercent,
+      this.esppHasLookback,
+      this.esppOfferingPeriodMonths,
+      this.esppAccountId,
+      this.esppExpectedStockGrowth,
+      this.pensionSystem,
+      this.startMilestoneId,
+      this.endMilestoneId,
+      this.employerMatchType,
+      this.employerMatchPercent,
+      this.employerMatchMax,
+    );
+  }
+
+  /**
+   * Get the effective 401k contributions for a given year/age, applying autoMax401k if enabled
+   * @param inflationAdjusted - If true, projects limits for future years with inflation. Defaults to true.
+   */
+  getEffective401k(year: number, age: number, inflationAdjusted: boolean = true): { preTax: number; roth: number } {
+    if (this.autoMax401k === 'disabled') {
+      return { preTax: 0, roth: 0 };
+    }
+    if (this.autoMax401k === 'custom') {
+      return { preTax: this.preTax401k, roth: this.roth401k };
+    }
+    // The IRS limit is annual; preTax401k/roth401k are stored per pay period, so spread
+    // the limit across the income's pay periods. Consumers re-annualize via getProratedAnnual.
+    const perPeriodLimit = this.annualToPerPeriod(get401kLimit(year, age, inflationAdjusted));
+    if (this.autoMax401k === 'traditional') {
+      return { preTax: perPeriodLimit, roth: 0 };
+    } else {
+      return { preTax: 0, roth: perPeriodLimit };
+    }
+  }
+
+  /**
+   * Get the annual ESPP contribution based on contribution type and salary
+   */
+  getAnnualESPPContribution(year?: number): number {
+    if (this.esppContributionType === 'NONE') {
+      return 0;
+    }
+
+    const annualSalary = this.getAnnualAmount(year);
+
+    if (this.esppContributionType === 'PERCENTAGE') {
+      // esppContributionAmount is a percentage (e.g., 10 for 10%)
+      return annualSalary * (this.esppContributionAmount / 100);
+    } else {
+      // FIXED: esppContributionAmount is per-period, convert to annual
+      return this.getProratedAnnual(this.esppContributionAmount, year);
+    }
+  }
+}
+
+export class SocialSecurityIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: IncomeFrequency,
+    public claimingAge: number,
+    public fullRetirementAgeBenefit?: number, // Optional: store FRA benefit for reference
+    startDate?: Date,
+    end_date?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, amount, frequency, "No", startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'SocialSecurityIncome';
+  }
+
+  /**
+   * Calculate the benefit adjustment factor based on claiming age
+   * Full Retirement Age (FRA) is 67 for people born in 1960 or later
+   * @param claimingAge Age when benefits are claimed (62-70)
+   * @returns Adjustment factor (e.g., 0.70 for age 62, 1.24 for age 70)
+   */
+  static calculateBenefitAdjustment(claimingAge: number): number {
+    // Claiming before FRA (67) reduces benefits by ~6.67% per year
+    // Claiming after FRA increases benefits by 8% per year (up to age 70)
+    const FRA = 67;
+
+    if (claimingAge < 62) return 0.70; // Minimum is age 62
+    if (claimingAge >= 70) return 1.24; // Maximum is age 70
+
+    if (claimingAge < FRA) {
+      // Early claiming: ~6.67% reduction per year before FRA
+      // Age 62: 70%, Age 63: 75%, Age 64: 80%, Age 65: 86.7%, Age 66: 93.3%, Age 67: 100%
+      const yearsEarly = FRA - claimingAge;
+      const reductionFactor = 0.0667; // ~6.67% per year (simplified)
+      return Math.max(0.70, 1.0 - (yearsEarly * reductionFactor));
+    } else {
+      // Delayed claiming: 8% increase per year after FRA
+      // Age 68: 108%, Age 69: 116%, Age 70: 124%
+      const yearsDelayed = claimingAge - FRA;
+      return 1.0 + (yearsDelayed * 0.08);
+    }
+  }
+
+  /**
+   * Calculate benefit amount based on FRA benefit and claiming age
+   * @param fraBenefit Benefit amount at Full Retirement Age (67)
+   * @param claimingAge Age when claiming (62-70)
+   * @returns Adjusted benefit amount
+   */
+  static calculateBenefitFromFRA(fraBenefit: number, claimingAge: number): number {
+    const adjustmentFactor = SocialSecurityIncome.calculateBenefitAdjustment(claimingAge);
+    return fraBenefit * adjustmentFactor;
+  }
+
+  increment (assumptions: AssumptionsState): SocialSecurityIncome {
+    const generalInflation = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+
+    return new SocialSecurityIncome(
+      this.id,
+      this.name,
+      this.amount * (1 + generalInflation),
+      this.frequency,
+      this.claimingAge,
+      this.fullRetirementAgeBenefit ? this.fullRetirementAgeBenefit * (1 + generalInflation) : undefined,
+      this.startDate,
+      this.end_date,
+      this.startMilestoneId,
+      this.endMilestoneId
+    );
+  }
+}
+
+export class PassiveIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: IncomeFrequency,
+    earned_income: "Yes" | "No",
+    public sourceType: 'Dividend' | 'Rental' | 'Royalty' | 'Interest' | 'RMD' | 'Other',
+    startDate?: Date,
+    end_date?: Date,
+    public isReinvested: boolean = false,  // If true, income is taxable but not available as spendable cash (e.g., savings interest that stays in the account)
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, amount, frequency, earned_income, startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'PassiveIncome';
+  }
+  increment (assumptions: AssumptionsState): PassiveIncome {
+    let growthRate = 0;
+
+    // Smart defaults based on source
+    switch (this.sourceType) {
+      case 'Rental':
+        // Rents tend to grow faster than general inflation
+        growthRate = (assumptions.expenses.rentInflation + (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0)) / 100;
+        break;
+      case 'Interest':
+        // Interest income is generated fresh each year based on account balance
+        // It doesn't grow independently - the growth comes from the account balance increasing
+        growthRate = 0;
+        break;
+      case 'RMD':
+        // RMD income is regenerated each year based on account balance and age
+        // It doesn't grow independently - the amount is recalculated each year
+        growthRate = 0;
+        break;
+      case 'Dividend':
+      case 'Royalty':
+      case 'Other':
+      default:
+        // Default to general inflation to maintain purchasing power
+        growthRate = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+        break;
+    }
+
+    return new PassiveIncome(
+      this.id,
+      this.name,
+      this.amount * (1 + growthRate),
+      this.frequency,
+      this.earned_income,
+      this.sourceType,
+      this.startDate,
+      this.end_date,
+      this.isReinvested,
+      this.startMilestoneId,
+      this.endMilestoneId
+    );
+  }
+}
+
+export class WindfallIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: IncomeFrequency,
+    earned_income: "Yes" | "No",
+    startDate?: Date,
+    end_date?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    super(id, name, amount, frequency, earned_income, startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'WindfallIncome';
+  }
+  increment (assumptions: AssumptionsState): WindfallIncome {
+    const inflation = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+
+    // Only grow if the user marked it as inflation adjusted
+
+    return new WindfallIncome(
+      this.id,
+      this.name,
+      this.amount * (1 + inflation),
+      this.frequency,
+      this.earned_income,
+      this.startDate,
+      this.end_date,
+      this.startMilestoneId,
+      this.endMilestoneId
+    );
+  }
+}
+
+/**
+ * CurrentSocialSecurityIncome
+ *
+ * For users who are already receiving Social Security benefits:
+ * - Disability (SSDI)
+ * - Survivor benefits
+ * - Retirement benefits (already claimed)
+ *
+ * Amount is manually entered and grows with COLA (Cost of Living Adjustment).
+ * COLA typically tracks inflation rate.
+ */
+export class CurrentSocialSecurityIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    amount: number,
+    frequency: IncomeFrequency,
+    startDate?: Date,
+    end_date?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    // Social Security is never considered "earned income" for tax purposes
+    super(id, name, amount, frequency, "No", startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'CurrentSocialSecurityIncome';
+  }
+
+  increment(assumptions: AssumptionsState): CurrentSocialSecurityIncome {
+    // COLA (Cost of Living Adjustment) tracks inflation
+    const cola = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+
+    return new CurrentSocialSecurityIncome(
+      this.id,
+      this.name,
+      this.amount * (1 + cola),
+      this.frequency,
+      this.startDate,
+      this.end_date,
+      this.startMilestoneId,
+      this.endMilestoneId
+    );
+  }
+}
+
+/**
+ * FutureSocialSecurityIncome
+ *
+ * For future retirement benefits that will be automatically calculated
+ * based on earnings history using SSA's AIME/PIA formula.
+ *
+ * Key features:
+ * - Amount is calculated by SimulationEngine (not user-entered)
+ * - Calculation triggered when user reaches claiming age
+ * - Uses 35 highest earning years with wage indexing
+ * - Start date = claiming age (auto-computed)
+ * - End date = life expectancy (auto-set)
+ *
+ * calculatedPIA stores the monthly benefit amount.
+ * When calculatedPIA = 0, the benefit hasn't been calculated yet.
+ */
+export class FutureSocialSecurityIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    public claimingAge: number,
+    public calculatedPIA: number = 0,  // Monthly benefit at claiming (feeds amount)
+    public calculationYear: number = 0,  // Year when PIA was calculated
+    startDate?: Date,
+    end_date?: Date,
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+    public projectedPIA: number = 0,  // Monthly benefit for planning (does NOT feed amount)
+  ) {
+    // Amount is annual (calculatedPIA × 12)
+    // Social Security is never considered "earned income" for tax purposes
+    super(id, name, calculatedPIA * 12, 'Annually', "No", startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'FutureSocialSecurityIncome';
+  }
+
+  increment(assumptions: AssumptionsState): FutureSocialSecurityIncome {
+    // After benefits start, grow with COLA (inflation)
+    const cola = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+
+    return new FutureSocialSecurityIncome(
+      this.id,
+      this.name,
+      this.claimingAge,
+      this.calculatedPIA * (1 + cola),
+      this.calculationYear,
+      this.startDate,
+      this.end_date,
+      this.startMilestoneId,
+      this.endMilestoneId,
+      this.projectedPIA * (1 + cola)  // Keep projectedPIA in sync with COLA
+    );
+  }
+}
+
+/**
+ * FERSPensionIncome
+ *
+ * Federal Employees Retirement System pension for federal employees hired after 1983.
+ * FERS is a three-part retirement plan: Basic Benefit + Social Security + TSP.
+ *
+ * This class models the Basic Benefit component:
+ * - Formula: Years of Service × High-3 × Multiplier (1% or 1.1%)
+ * - COLA: Reduced (CPI-1% if inflation > 3%)
+ * - FERS Supplement: Bridge payment from MRA to age 62
+ *
+ * The pension is auto-calculated when the user reaches retirement age.
+ */
+export class FERSPensionIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    public yearsOfService: number,
+    public high3Salary: number,
+    public retirementAge: number,
+    public birthYear: number,
+    public calculatedBenefit: number = 0,  // Annual benefit, calculated by simulation
+    public fersSupplement: number = 0,      // Annual FERS Supplement (ends at 62)
+    public estimatedSSAt62: number = 0,     // For calculating FERS Supplement
+    startDate?: Date,
+    end_date?: Date,
+    public autoCalculateHigh3: boolean = false,  // If true, calculate High-3 from linked income
+    public linkedIncomeId: string | null = null,  // Work income to track for High-3 calculation
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    // Amount is the calculated annual benefit
+    super(id, name, calculatedBenefit, 'Annually', "No", startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'FERSPensionIncome';
+  }
+
+  /**
+   * Calculate the FERS pension benefit
+   * Called by SimulationEngine when retirement is reached
+   */
+  calculateBenefit(): number {
+    const baseBenefit = calculateFERSBasicBenefit(
+      this.yearsOfService,
+      this.high3Salary,
+      this.retirementAge
+    );
+
+    // Check for early retirement reduction (MRA+10)
+    const eligibility = checkFERSEligibility(
+      this.retirementAge,
+      this.yearsOfService,
+      this.birthYear
+    );
+
+    const reductionFactor = 1 - (eligibility.reductionPercent / 100);
+    return baseBenefit * reductionFactor;
+  }
+
+  /**
+   * Calculate FERS Supplement amount
+   * Only available if retiring before age 62 with immediate unreduced retirement
+   */
+  calculateSupplement(): number {
+    if (this.retirementAge >= 62) return 0;
+    if (this.estimatedSSAt62 <= 0) return 0;
+
+    // Check eligibility (MRA+10 retirees generally don't get supplement)
+    const eligibility = checkFERSEligibility(
+      this.retirementAge,
+      this.yearsOfService,
+      this.birthYear
+    );
+
+    // Only full retirees (no reduction) get the supplement
+    if (eligibility.reductionPercent > 0) return 0;
+
+    return calculateFERSSupplement(this.yearsOfService, this.estimatedSSAt62 / 12);
+  }
+
+  increment(assumptions: AssumptionsState, _year?: number, age?: number): FERSPensionIncome {
+    const inflation = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+    const currentAge = age || this.retirementAge;
+
+    // FERS COLA is reduced compared to full CPI
+    const cola = getFERSCOLA(inflation, currentAge);
+
+    // FERS Supplement ends at age 62
+    const newSupplement = currentAge >= 62 ? 0 : this.fersSupplement * (1 + cola);
+
+    return new FERSPensionIncome(
+      this.id,
+      this.name,
+      this.yearsOfService,
+      this.high3Salary * (1 + inflation), // High-3 doesn't grow after retirement, but keep for reference
+      this.retirementAge,
+      this.birthYear,
+      this.calculatedBenefit * (1 + cola),
+      newSupplement,
+      this.estimatedSSAt62 * (1 + inflation),
+      this.startDate,
+      this.end_date,
+      this.autoCalculateHigh3,
+      this.linkedIncomeId,
+      this.startMilestoneId,
+      this.endMilestoneId
+    );
+  }
+
+  /**
+   * Get total annual income including FERS Supplement
+   */
+  getTotalAnnualAmount(year?: number): number {
+    const base = this.getAnnualAmount(year);
+    if (base <= 0) return 0;
+    // Prorate the FERS supplement with the same active-year multiplier as the base
+    // benefit, so a mid-year start prorates both identically (matches getProratedAnnual).
+    const activeMult = year !== undefined ? getIncomeActiveMultiplier(this as unknown as AnyIncome, year) : 1;
+    return base + (this.fersSupplement || 0) * activeMult;
+  }
+}
+
+/**
+ * CSRSPensionIncome
+ *
+ * Civil Service Retirement System pension for federal employees hired before 1984.
+ * CSRS is a standalone pension system with no Social Security coverage.
+ *
+ * Formula:
+ * - 1.5% × High-3 × first 5 years
+ * - 1.75% × High-3 × years 6-10
+ * - 2.0% × High-3 × years 11+
+ * - Maximum: 80% of High-3
+ *
+ * COLA: Full CPI adjustment
+ */
+export class CSRSPensionIncome extends BaseIncome {
+  constructor(
+    id: string,
+    name: string,
+    public yearsOfService: number,
+    public high3Salary: number,
+    public retirementAge: number,
+    public calculatedBenefit: number = 0,  // Annual benefit, calculated by simulation
+    startDate?: Date,
+    end_date?: Date,
+    public autoCalculateHigh3: boolean = false,  // If true, calculate High-3 from linked income
+    public linkedIncomeId: string | null = null,  // Work income to track for High-3 calculation
+    startMilestoneId?: string,
+    endMilestoneId?: string,
+  ) {
+    // Amount is the calculated annual benefit
+    super(id, name, calculatedBenefit, 'Annually', "No", startDate, end_date, 0.03, startMilestoneId, endMilestoneId);
+    this.className = 'CSRSPensionIncome';
+  }
+
+  /**
+   * Calculate the CSRS pension benefit
+   * Called by SimulationEngine when retirement is reached
+   */
+  calculateBenefit(): number {
+    const baseBenefit = calculateCSRSBasicBenefit(
+      this.yearsOfService,
+      this.high3Salary
+    );
+
+    // Check for early retirement reduction
+    const eligibility = checkCSRSEligibility(
+      this.retirementAge,
+      this.yearsOfService
+    );
+
+    const reductionFactor = 1 - (eligibility.reductionPercent / 100);
+    return baseBenefit * reductionFactor;
+  }
+
+  increment(assumptions: AssumptionsState): CSRSPensionIncome {
+    const inflation = (assumptions.macro.inflationAdjusted ? assumptions.macro.inflationRate : 0) / 100;
+
+    // CSRS gets full COLA
+    const cola = getCSRSCOLA(inflation);
+
+    return new CSRSPensionIncome(
+      this.id,
+      this.name,
+      this.yearsOfService,
+      this.high3Salary, // Doesn't grow after retirement
+      this.retirementAge,
+      this.calculatedBenefit * (1 + cola),
+      this.startDate,
+      this.end_date,
+      this.autoCalculateHigh3,
+      this.linkedIncomeId,
+      this.startMilestoneId,
+      this.endMilestoneId
+    );
+  }
+}
+
+export type AnyIncome = WorkIncome | SocialSecurityIncome | CurrentSocialSecurityIncome | FutureSocialSecurityIncome | FERSPensionIncome | CSRSPensionIncome | PassiveIncome | WindfallIncome;
+
+/**
+ * Calculate the year when Social Security benefits should start
+ * @param birthYear User's birth year
+ * @param claimingAge Age when claiming SS (62-70)
+ * @returns Year when SS benefits begin
+ */
+export function calculateSocialSecurityStartYear(
+    birthYear: number,
+    claimingAge: number
+): number {
+    return birthYear + claimingAge;
+}
+
+/**
+ * Calculate the start date for Social Security income
+ * @param birthYear User's birth year
+ * @param claimingAge Age when claiming SS (62-70)
+ * @param claimingMonth Month when claiming (0-11, defaults to 0 for January)
+ * @returns Date object for when SS benefits begin
+ */
+export function calculateSocialSecurityStartDate(
+    birthYear: number,
+    claimingAge: number,
+    claimingMonth: number = 0
+): Date {
+    const year = calculateSocialSecurityStartYear(birthYear, claimingAge);
+    return new Date(Date.UTC(year, claimingMonth, 1));
+}
+
+export function getIncomeActiveMultiplier(income: AnyIncome, year: number): number {
+    const incomeStartDate = income.startDate ? new Date(income.startDate) : new Date();
+    // Date-only values come from parseDate, which returns UTC dates (see modelUtils
+    // contract). Read with getUTC* so the active window doesn't shift by a month/year
+    // in negative timezones.
+    const startYear = incomeStartDate.getUTCFullYear();
+
+    const safeEndDate = income.end_date ? new Date(income.end_date) : null;
+    const endYear = safeEndDate ? safeEndDate.getUTCFullYear() : null;
+
+    if (startYear > year) return 0;
+    if (endYear !== null && endYear < year) return 0;
+
+    const startMonthIndex = (startYear < year) ? 0 : incomeStartDate.getUTCMonth();
+
+    const endMonthIndex = (safeEndDate && endYear === year)
+        ? safeEndDate.getUTCMonth()
+        : 11;
+
+    const monthsActive = endMonthIndex - startMonthIndex + 1;
+
+    return Math.max(0, monthsActive) / 12;
+}
+
+export function isIncomeActiveInCurrentMonth(income: AnyIncome): boolean {
+    const today = new Date();
+    const currentYear = today.getFullYear();
+    const currentMonth = today.getMonth(); // 0-indexed
+
+    const incomeStartDate = income.startDate != null ? income.startDate : new Date();
+    // Stored date-only values are UTC-midnight; read them with getUTC* (today stays
+    // local since it's a true instant). Both sides feed local new Date(y, m, 1)
+    // month-boundary comparisons, so the bases stay consistent.
+    const incomeStartYear = incomeStartDate.getUTCFullYear();
+    const incomeStartMonth = incomeStartDate.getUTCMonth();
+
+    const currentMonthStart = new Date(currentYear, currentMonth, 1);
+    const incomeEffectiveStart = new Date(incomeStartYear, incomeStartMonth, 1);
+
+    if (incomeEffectiveStart > currentMonthStart) {
+        return false;
+    }
+
+    if (income.end_date) {
+        const incomeEndDate = new Date(income.end_date);
+        const incomeEndYear = incomeEndDate.getUTCFullYear();
+        const incomeEndMonth = incomeEndDate.getUTCMonth();
+
+        const incomeEffectiveEnd = new Date(incomeEndYear, incomeEndMonth + 1, 0);
+
+        if (incomeEffectiveEnd < currentMonthStart) {
+            return false;
+        }
+    }
+    return true;
+};
+
+export const INCOME_CATEGORIES = [
+  'Work',
+  'SocialSecurity',
+  'Pension',
+  'Passive',
+  'Windfall',
+] as const;
+
+export type IncomeCategory = typeof INCOME_CATEGORIES[number];
+
+export const INCOME_COLORS_BACKGROUND: Record<IncomeCategory, string> = {
+    Work: "bg-chart-Fuchsia-50",
+    SocialSecurity: "bg-chart-Blue-50",
+    Pension: "bg-chart-Green-50",
+    Passive: "bg-chart-Yellow-50",
+    Windfall: "bg-chart-Red-50",
+};
+
+export const CLASS_TO_CATEGORY: Record<string, IncomeCategory> = {
+    [WorkIncome.name]: 'Work',
+    [SocialSecurityIncome.name]: 'SocialSecurity',
+    [CurrentSocialSecurityIncome.name]: 'SocialSecurity',
+    [FutureSocialSecurityIncome.name]: 'SocialSecurity',
+    [FERSPensionIncome.name]: 'Pension',
+    [CSRSPensionIncome.name]: 'Pension',
+    [PassiveIncome.name]: 'Passive',
+    [WindfallIncome.name]: 'Windfall'
+};
+
+// Map Categories to their color palettes (using Tailwind classes)
+// Uses 5-step gradients (1, 25, 50, 75, 100) defined in :root for SVG access
+const PALETTE_STEPS = [1, 25, 50, 75, 100];
+export const CATEGORY_PALETTES: Record<IncomeCategory, string[]> = {
+	Work: PALETTE_STEPS.map(i => `bg-chart-Fuchsia-${i}`),
+	SocialSecurity: PALETTE_STEPS.map(i => `bg-chart-Blue-${i}`),
+	Pension: PALETTE_STEPS.map(i => `bg-chart-Green-${i}`),
+	Passive: PALETTE_STEPS.map(i => `bg-chart-Yellow-${i}`),
+	Windfall: PALETTE_STEPS.map(i => `bg-chart-Red-${i}`),
+};
+
+export function reconstituteIncome(data: unknown): AnyIncome | null {
+    if (!hasClassName(data)) return null;
+
+    const startDate = parseDateRequired(data.startDate);
+    const endDate = parseDate(data.end_date);
+    const frequency = (data.frequency as IncomeFrequency) || 'Monthly';
+    const id = String(data.id ?? '');
+    const name = String(data.name ?? 'Unnamed Income');
+    const amount = Number(data.amount) || 0;
+    const earned_income = (data.earned_income as "Yes" | "No") || "No";
+    const startMilestoneId = data.startMilestoneId ? String(data.startMilestoneId) : undefined;
+    const endMilestoneId = data.endMilestoneId ? String(data.endMilestoneId) : undefined;
+
+    switch (data.className) {
+        case 'WorkIncome': {
+            // Map old 'none' value to 'custom' for backwards compatibility
+            const autoMax401k = data.autoMax401k === 'none' ? 'custom' : (data.autoMax401k || 'custom');
+            return new WorkIncome(
+                id, name, amount, frequency, earned_income,
+                Number(data.preTax401k) || 0, Number(data.insurance) || 0,
+                Number(data.roth401k) || 0, Number(data.employerMatch) || 0,
+                String(data.matchAccountId ?? ''), (data.taxType as TaxType) || null,
+                (data.contributionGrowthStrategy as ContributionGrowthStrategy) || 'FIXED',
+                startDate, endDate, Number(data.hsaContribution) || 0, autoMax401k as AutoMax401kOption,
+                (data.esppContributionType as ESPPContributionType) || 'NONE',
+                Number(data.esppContributionAmount) || 0,
+                Number(data.esppDiscountPercent ?? 15),
+                (data.esppHasLookback as boolean) ?? true,
+                Number(data.esppOfferingPeriodMonths ?? 6),
+                data.esppAccountId ? String(data.esppAccountId) : null,
+                Number(data.esppExpectedStockGrowth ?? 7),
+                (data.pensionSystem as PensionSystem) || 'NONE',
+                startMilestoneId, endMilestoneId,
+                (data.employerMatchType as EmployerMatchType) || 'fixed',
+                Number(data.employerMatchPercent) || 0,
+                Number(data.employerMatchMax) || 0,
+            );
+        }
+        case 'SocialSecurityIncome':
+            return new SocialSecurityIncome(
+                id, name, amount, frequency, Number(data.claimingAge) || 67,
+                Number(data.fullRetirementAgeBenefit) || 0, startDate, endDate,
+                startMilestoneId, endMilestoneId
+            );
+        case 'PassiveIncome':
+            return new PassiveIncome(
+                id, name, amount, frequency, earned_income,
+                (data.sourceType as PassiveIncome['sourceType']) || 'Other',
+                startDate, endDate, (data.isReinvested as boolean) ?? false,
+                startMilestoneId, endMilestoneId
+            );
+        case 'WindfallIncome':
+            return new WindfallIncome(id, name, amount, frequency, earned_income, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+        case 'CurrentSocialSecurityIncome':
+            return new CurrentSocialSecurityIncome(id, name, amount, frequency, startDate, endDate,
+                startMilestoneId, endMilestoneId);
+        case 'FutureSocialSecurityIncome':
+            return new FutureSocialSecurityIncome(
+                id, name, Number(data.claimingAge) || 67,
+                Number(data.calculatedPIA) || 0, Number(data.calculationYear) || 0,
+                startDate, endDate, startMilestoneId, endMilestoneId,
+                Number(data.projectedPIA) || 0  // Preserve projectedPIA across save/reload
+            );
+        case 'FERSPensionIncome':
+            return new FERSPensionIncome(
+                id, name, Number(data.yearsOfService) || 0, Number(data.high3Salary) || 0,
+                Number(data.retirementAge) || 62, Number(data.birthYear) || 1970,
+                Number(data.calculatedBenefit) || 0, Number(data.fersSupplement) || 0,
+                Number(data.estimatedSSAt62) || 0, startDate, endDate,
+                (data.autoCalculateHigh3 as boolean) || false,
+                data.linkedIncomeId ? String(data.linkedIncomeId) : null,
+                startMilestoneId, endMilestoneId
+            );
+        case 'CSRSPensionIncome':
+            return new CSRSPensionIncome(
+                id, name, Number(data.yearsOfService) || 0, Number(data.high3Salary) || 0,
+                Number(data.retirementAge) || 55, Number(data.calculatedBenefit) || 0,
+                startDate, endDate, (data.autoCalculateHigh3 as boolean) || false,
+                data.linkedIncomeId ? String(data.linkedIncomeId) : null,
+                startMilestoneId, endMilestoneId
+            );
+        default:
+            return null;
+    }
+}

--- a/src/components/Objects/modelUtils.ts
+++ b/src/components/Objects/modelUtils.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared utilities for domain model reconstitution and type handling.
+ *
+ * These utilities consolidate common patterns across Account, Income, and Expense models
+ * to reduce duplication and improve maintainability.
+ */
+
+/**
+ * Parses a date value from various input formats.
+ * Handles strings, Date objects, timestamps, null, and undefined.
+ *
+ * @param value - The value to parse (string, Date, number, null, or undefined)
+ * @param fallback - Optional fallback value if input is null/undefined
+ * @returns A Date object, or undefined if no valid date could be created
+ */
+export function parseDate(value: unknown, fallback?: Date): Date | undefined {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    // Parse YYYY-MM-DD strings as local time to avoid UTC timezone shift
+    const dateOnly = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (dateOnly) {
+      return new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]));
+    }
+    // For full ISO strings (e.g. from JSON serialization), extract the date portion as local time
+    const isoDate = value.match(/^(\d{4})-(\d{2})-(\d{2})T/);
+    if (isoDate) {
+      return new Date(Number(isoDate[1]), Number(isoDate[2]) - 1, Number(isoDate[3]));
+    }
+    return new Date(value);
+  }
+
+  if (typeof value === 'number') {
+    return new Date(value);
+  }
+
+  return fallback;
+}
+
+/**
+ * Parses a required date value, using Date.now() as default if not provided.
+ *
+ * @param value - The value to parse
+ * @returns A Date object (never undefined)
+ */
+export function parseDateRequired(value: unknown): Date {
+  return parseDate(value, new Date()) as Date;
+}
+
+/**
+ * Common base fields shared across all domain models.
+ * Used to extract and normalize data during reconstitution.
+ */
+export interface BaseModelFields {
+  id: string;
+  name: string;
+  amount: number;
+}
+
+/**
+ * Extracts common base fields from raw JSON data.
+ * Provides sensible defaults for missing or invalid values.
+ *
+ * @param data - Raw JSON data from localStorage or import
+ * @param defaultName - Default name if not provided
+ * @returns Normalized base fields
+ */
+export function extractBaseFields(data: Record<string, unknown>, defaultName: string = "Unnamed"): BaseModelFields {
+  return {
+    id: String(data.id ?? ''),
+    name: String(data.name ?? defaultName),
+    amount: Number(data.amount) || 0,
+  };
+}
+
+/**
+ * Type guard to check if a value is a non-null object with a className property.
+ * Used to validate data before reconstitution.
+ */
+export function hasClassName(data: unknown): data is { className: string } & Record<string, unknown> {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'className' in data &&
+    typeof (data as Record<string, unknown>).className === 'string'
+  );
+}


### PR DESCRIPTION
Scoped review of the domain model classes (Accounts/Expense/Income), the
simulation engine orchestration (SimulationEngine + useSimulation), and the
assumptions/simulation contexts. ONLY the source files added in the diff are
under review. The test files in this branch are a behavioral reference ONLY
(not in the diff) and may be wrong or timezone-dependent: if source and a test
disagree, flag it as a question, do not assume the test.

ADJUDICATIONS: code-review-pr-50.md … code-review-pr-53.md (in this tree, base
commit) record findings already fixed or ruled by-design — do not resurface
wont-fixes.

ARCHITECTURE NOTES (recent, intentional — flag violations, not the design):
  - Goal funding is COMMITTED and DERIVED (2026-06): `endDate` IS a
    targetDate goal's target (no separate goalTargetDate field — reconstitute
    migrates legacy data); the set-aside is derived live
    (getGoalMonthlySetAside / getGoalFundAnnualSetAside, months-prorated) and
    counted with living expenses while the engine credits the fund directly.
    There is NO goal priority bucket and NO stored set-aside. Anything
    reintroducing stored copies, or reading a stored capValue for a goal
    fund, is a bug.
  - Goal `amount` is the TOTAL cost with frequency 'Monthly';
    getAnnualAmount/getMonthlyAmount return 0 for goals by design. Display
    sites must use the set-aside helpers.

Recurring problem areas that have actually bitten us here — extra scrutiny:

  1. Date-only / timezone handling (UNRESOLVED convention — the single
     highest-yield area). Creation is split between local midnight
     (parseDate/modelUtils, `new Date(y, m-1, d)`) and UTC midnight
     (Date.UTC in form defaults and model methods); readers split between
     getUTC* and local accessors. The unit suite runs in UTC and structurally
     cannot catch mismatches. Map creation sites to reader sites and flag
     every mismatched pair; if you can, propose the single convention.
  2. Reconstitution / persistence. `reconstitute*()` must round-trip every
     field the classes carry — a field added to a class but not to its
     reconstitute (or copyMetaTo/clone) silently vanishes on reload or on
     year-increment. Diff the class fields against both paths field by field.
  3. increment()/clone drift. Year-over-year increment methods rebuild
     objects through constructors; constructor-parameter drift (added params,
     reordered args) corrupts cloned state quietly.
  4. Engine totals. totalLivingExpenses composition (amortized mortgage/loan
     payments + getAnnualAmount + committed goal set-asides) flows into the
     solver, GK trims, and the Sankey — the per-category cashflowDetail must
     sum to the same number or the Sankey is unbalanced (bit us twice).
  5. Milestone resolution. Deleted-milestone fallbacks, END_OF_PLAN
     defaulting, and age-vs-date milestone math at year boundaries.
  6. Falsy-zero in model getters and context merge defaults (`||` vs `??`).

Output: ranked findings, each with a concrete failure scenario
(inputs/state -> wrong output). Findings that can't name a trigger should say
so explicitly.