### PR TITLE
Scope: persistence, contexts, import/export, QR + cloud backup (source)

### DIFF
--- a/src/components/Objects/Accounts/AccountContext.tsx
+++ b/src/components/Objects/Accounts/AccountContext.tsx
@@ -1,0 +1,224 @@
+import { createContext, ReactNode, Dispatch, useCallback, useRef } from 'react';
+import { AnyAccount, reconstituteAccount } from './models';
+import { usePersistedReducer } from '../../../hooks/usePersistedReducer';
+import { formatDateForInput } from '../../../utils/formatters';
+
+type AllKeys<T> = T extends unknown ? keyof T : never;
+export type AllAccountKeys = AllKeys<AnyAccount>;
+
+const CURRENT_SCHEMA_VERSION = 1;
+const STORAGE_KEY = 'user_accounts_data';
+
+export interface AmountHistoryEntry {
+  date: string;
+  num: number;
+}
+
+interface AccountState {
+  accounts: AnyAccount[];
+  amountHistory: Record<string, AmountHistoryEntry[]>;
+}
+
+type Action =
+  | { type: 'ADD_ACCOUNT'; payload: AnyAccount }
+  | { type: 'DELETE_ACCOUNT'; payload: { id: string } }
+  | { type: 'UPDATE_ACCOUNT_FIELD'; payload: { id: string; field: AllAccountKeys; value: unknown } }
+  | { type: 'ADD_AMOUNT_SNAPSHOT'; payload: { id: string; amount: number } }
+  | { type: 'REORDER_ACCOUNTS'; payload: { startIndex: number; endIndex: number } }
+  | { type: 'UPDATE_HISTORY_ENTRY'; payload: { id: string; index: number; date: string; num: number } }
+  | { type: 'DELETE_HISTORY_ENTRY'; payload: { id: string; index: number } }
+  | { type: 'ADD_HISTORY_ENTRY'; payload: { id: string; date: string; num: number } }
+  | { type: 'SET_BULK_DATA'; payload: { accounts: AnyAccount[]; amountHistory: Record<string, AmountHistoryEntry[]> } };
+
+const initialState: AccountState = {
+  accounts: [],
+  amountHistory: {},
+};
+
+function getTodayString(): string {
+  // Local date (not toISOString, which is UTC): otherwise a balance recorded in
+  // the evening of a negative-offset timezone gets stamped with tomorrow's date
+  // and lands in the wrong month for the budget's historicBalance lookups.
+  return formatDateForInput(new Date());
+}
+
+function accountReducer(state: AccountState, action: Action): AccountState {
+  switch (action.type) {
+    case 'SET_BULK_DATA':
+      return {
+        ...state,
+        accounts: action.payload.accounts,
+        amountHistory: action.payload.amountHistory,
+      };
+
+    case 'ADD_ACCOUNT': {
+      const today = getTodayString();
+      return {
+        ...state,
+        accounts: [...state.accounts, action.payload],
+        amountHistory: {
+          ...state.amountHistory,
+          [action.payload.id]: [{ date: today, num: action.payload.amount }],
+        },
+      };
+    }
+
+    case 'DELETE_ACCOUNT': {
+      const { [action.payload.id]: _, ...remainingHistory } = state.amountHistory;
+      return {
+        ...state,
+        accounts: state.accounts.filter((acc) => acc.id !== action.payload.id),
+        amountHistory: remainingHistory,
+      };
+    }
+
+    case 'UPDATE_ACCOUNT_FIELD':
+      return {
+        ...state,
+        accounts: state.accounts.map((acc) => {
+          if (acc.id !== action.payload.id) return acc;
+          const updated = Object.assign(Object.create(Object.getPrototypeOf(acc)), acc);
+          updated.className = acc.constructor.name;
+          updated[action.payload.field] = action.payload.value;
+          return updated;
+        }),
+      };
+
+    case 'ADD_AMOUNT_SNAPSHOT': {
+      const { id, amount } = action.payload;
+      const today = getTodayString();
+      const currentHistory = state.amountHistory[id] || [];
+      const lastEntry = currentHistory[currentHistory.length - 1];
+      const newEntry: AmountHistoryEntry = { date: today, num: amount };
+
+      // Replace today's entry if it exists, otherwise append
+      const newHistory = lastEntry?.date === today
+        ? [...currentHistory.slice(0, -1), newEntry]
+        : [...currentHistory, newEntry];
+
+      return { ...state, amountHistory: { ...state.amountHistory, [id]: newHistory } };
+    }
+
+    case 'REORDER_ACCOUNTS': {
+      const result = Array.from(state.accounts);
+      const [removed] = result.splice(action.payload.startIndex, 1);
+      result.splice(action.payload.endIndex, 0, removed);
+      return { ...state, accounts: result };
+    }
+
+    case 'UPDATE_HISTORY_ENTRY': {
+      const { id, index, date, num } = action.payload;
+      const history = [...(state.amountHistory[id] || [])];
+      if (!history[index]) return state;
+      history[index] = { ...history[index], date, num };
+      return { ...state, amountHistory: { ...state.amountHistory, [id]: history } };
+    }
+
+    case 'DELETE_HISTORY_ENTRY': {
+      const { id, index } = action.payload;
+      const history = [...(state.amountHistory[id] || [])];
+      history.splice(index, 1);
+      return { ...state, amountHistory: { ...state.amountHistory, [id]: history } };
+    }
+
+    case 'ADD_HISTORY_ENTRY': {
+      const { id, date, num } = action.payload;
+      const history = [...(state.amountHistory[id] || []), { date, num }];
+      history.sort((a, b) => a.date.localeCompare(b.date));
+      return { ...state, amountHistory: { ...state.amountHistory, [id]: history } };
+    }
+
+    default:
+      return state;
+  }
+}
+
+function hydrateAccountState(parsed: unknown, initial: AccountState): AccountState {
+  const data = parsed as { accounts?: unknown[]; amountHistory?: Record<string, AmountHistoryEntry[]> };
+  const accounts = (data.accounts || [])
+    .map(reconstituteAccount)
+    .filter((acc): acc is AnyAccount => acc !== null);
+  return {
+    ...initial,
+    accounts,
+    amountHistory: data.amountHistory || {},
+  };
+}
+
+function serializeAccountState(state: AccountState): string {
+  return JSON.stringify({
+    ...state,
+    accounts: state.accounts.map(acc => ({ ...acc, className: acc.constructor.name })),
+    version: CURRENT_SCHEMA_VERSION,
+  });
+}
+
+interface AccountDispatch {
+  dispatch: Dispatch<Action>;
+  exportData: () => void;
+  importData: (jsonData: string) => void;
+}
+
+export const AccountContext = createContext<AccountState>({
+  accounts: [],
+  amountHistory: {},
+});
+
+export const AccountDispatchContext = createContext<AccountDispatch>({
+  dispatch: () => null,
+  exportData: () => {},
+  importData: () => {},
+});
+
+export function AccountProvider({ children }: { children: ReactNode }): React.ReactElement {
+  const [state, dispatch] = usePersistedReducer(accountReducer, initialState, {
+    storageKey: STORAGE_KEY,
+    hydrate: hydrateAccountState,
+    serialize: serializeAccountState,
+  });
+
+  // Keep latest state in a ref so exportData can read it without re-creating.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  const exportData = useCallback(() => {
+    const data = {
+      version: CURRENT_SCHEMA_VERSION,
+      accounts: stateRef.current.accounts.map(acc => ({ ...acc, className: acc.constructor.name })),
+      amountHistory: stateRef.current.amountHistory,
+    };
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `stag_backup_${new Date().toISOString().split('T')[0]}.json`;
+    a.click();
+  }, []);
+
+  const importData = useCallback((json: string) => {
+    try {
+      const parsed = JSON.parse(json);
+      const accounts = (parsed.accounts || [])
+        .map(reconstituteAccount)
+        .filter((acc: AnyAccount | null): acc is AnyAccount => acc !== null);
+
+      dispatch({
+        type: 'SET_BULK_DATA',
+        payload: { accounts, amountHistory: parsed.amountHistory || {} },
+      });
+      alert('Import successful!');
+    } catch {
+      alert('Failed to import data. Check file format.');
+    }
+  }, []);
+
+  const dispatchValue = useRef<AccountDispatch>({ dispatch, exportData, importData });
+
+  return (
+    <AccountDispatchContext.Provider value={dispatchValue.current}>
+      <AccountContext.Provider value={state}>
+        {children}
+      </AccountContext.Provider>
+    </AccountDispatchContext.Provider>
+  );
+}

--- a/src/components/Objects/Accounts/ImportKeyContext.tsx
+++ b/src/components/Objects/Accounts/ImportKeyContext.tsx
@@ -1,0 +1,30 @@
+import { createContext, useState, useCallback, useMemo, ReactNode } from 'react';
+
+interface ImportKeyContextProps {
+    importKey: number;
+    incrementImportKey: () => void;
+}
+
+export const ImportKeyContext = createContext<ImportKeyContextProps>({
+    importKey: 0,
+    incrementImportKey: () => {},
+});
+
+export const ImportKeyProvider = ({ children }: { children: ReactNode }) => {
+    const [importKey, setImportKey] = useState(0);
+
+    const incrementImportKey = useCallback(() => {
+        setImportKey(prev => prev + 1);
+    }, []);
+
+    const contextValue = useMemo(() => ({
+        importKey,
+        incrementImportKey,
+    }), [importKey, incrementImportKey]);
+
+    return (
+        <ImportKeyContext.Provider value={contextValue}>
+            {children}
+        </ImportKeyContext.Provider>
+    );
+};

--- a/src/components/Objects/Accounts/QRTransfer/qrUtils.ts
+++ b/src/components/Objects/Accounts/QRTransfer/qrUtils.ts
@@ -1,0 +1,557 @@
+import pako from 'pako';
+
+// Epoch for date conversion: 2020-01-01
+const EPOCH = new Date('2020-01-01').getTime();
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Key mapping for compact format
+const KEY_MAP: Record<string, string> = {
+    // Common
+    id: 'd', name: 'n', amount: 'a', className: 'c',
+    // Accounts
+    apr: 'r', taxType: 'x', employerBalance: 'b', expenseRatio: 'p',
+    tenureYears: 'y', vestedPerYear: 'v', costBasis: 'o', conversionHistory: 'ch',
+    isContributionEligible: 'g', linkedAccountId: 'L', nonVestedAmount: 'V',
+    // ESPP Account
+    lots: 'lt', linkedIncomeId: 'li', customROR: 'cr',
+    stockTicker: 'st', currentSharePrice: 'cp', withdrawalPreference: 'wp', minimumHoldingDays: 'mh',
+    // ESPP Lot fields
+    grantDate: 'gd', purchaseDate: 'pd', fmvAtGrant: 'fg', fmvAtPurchase: 'fp',
+    purchasePrice: 'pp', shares: 'sh', totalCost: 'tc', discountAmount: 'da',
+    // Income/Expense
+    frequency: 'f', startDate: 's', endDate: 'E', annualGrowthRate: 'w',
+    earned_income: 'I', isDiscretionary: 'D', dueMonth: 'dm', annualMode: 'am',
+    goalType: 'gy', intervalYears: 'iy', goalTargetDate: 'gv', goalAccountId: 'gI',
+    // Work income
+    preTax401k: 'k', roth401k: 'K', insurance: 'u', employerMatch: 'M',
+    matchAccountId: 'A', contributionGrowthStrategy: 'G', hsaContribution: 'H', autoMax401k: 'X',
+    // Work income ESPP
+    esppContributionType: 'et', esppContributionAmount: 'ea', esppDiscountPercent: 'ed',
+    esppHasLookback: 'el', esppOfferingPeriodMonths: 'eo', esppAccountId: 'ei', esppExpectedStockGrowth: 'eg',
+    // Work income pension eligibility
+    pensionSystem: 'ps',
+    // Passive income
+    sourceType: 'O', isReinvested: 'R', end_date: 'Z',
+    // Social security
+    claimingAge: 'C', calculatedPIA: 'P', calculationYear: 'W', projectedPIA: 'pp',
+    // Expenses
+    payment: 'J', utilities: 'U', interest_type: 'T', is_tax_deductible: 'B', tax_deductible: 'Q',
+    // Tax
+    filingStatus: 'F', stateResidency: 'S', deductionMethod: 'N', year: 'Y',
+    fedOverride: 'O1', ficaOverride: 'O2', stateOverride: 'O3',
+    // Assumptions
+    inflationRate: 'ir', healthcareInflation: 'hi', inflationAdjusted: 'ia',
+    salaryGrowth: 'sg', qualifiesForSocialSecurity: 'ss', socialSecurityFundingPercent: 'sp',
+    lifestyleCreep: 'lc', housingAppreciation: 'ha', rentInflation: 'ri',
+    ror: 'rr', withdrawalStrategy: 'ws', withdrawalRate: 'wr',
+    gkUpperGuardrail: 'gu', gkLowerGuardrail: 'gl', gkAdjustmentPercent: 'ga', autoRothConversions: 'ar',
+    retirementAge: 'ra', lifeExpectancy: 'le', birthYear: 'by', priorYearMode: 'pm',
+    useCompactCurrency: 'cc', showExperimentalFeatures: 'ef', hsaEligible: 'he',
+    // Priorities/Withdrawal
+    type: 't', accountId: 'ai', capType: 'ct', capValue: 'cv',
+};
+
+// Create reverse mapping
+const REVERSE_KEY_MAP: Record<string, string> = Object.entries(KEY_MAP).reduce(
+    (acc, [full, short]) => ({ ...acc, [short]: full }),
+    {} as Record<string, string>
+);
+
+// Default values to strip (type -> field -> default)
+const DEFAULTS: Record<string, Record<string, unknown>> = {
+    account: {
+        employerBalance: 0,
+        tenureYears: 0,
+        vestedPerYear: 0,
+        costBasis: 0,
+        conversionHistory: [],
+        nonVestedAmount: 0,
+        expenseRatio: 0,
+        // ESPP Account defaults
+        lots: [],
+        linkedIncomeId: null,
+        withdrawalPreference: 'fifo',
+        minimumHoldingDays: 0,
+    },
+    income: {
+        annualGrowthRate: 0.03,
+        matchAccountId: null,
+        hsaContribution: 0,
+        autoMax401k: false,
+        // ESPP Work Income defaults
+        esppContributionType: 'NONE',
+        esppContributionAmount: 0,
+        esppDiscountPercent: 15,
+        esppHasLookback: true,
+        esppOfferingPeriodMonths: 6,
+        esppAccountId: null,
+        esppExpectedStockGrowth: 7,
+        // Pension eligibility defaults
+        pensionSystem: 'NONE',
+    },
+    expense: {
+        annualGrowthRate: 0.03,
+        is_tax_deductible: false,
+        tax_deductible: false,
+        annualMode: 'lump',
+    },
+};
+
+// Defaults for assumptions - values that can be stripped during compression
+const ASSUMPTIONS_DEFAULTS: Record<string, unknown> = {
+    // Macro
+    inflationRate: 2.6,
+    healthcareInflation: 3.9,
+    inflationAdjusted: true,
+    // Income
+    salaryGrowth: 1.0,
+    qualifiesForSocialSecurity: true,
+    socialSecurityFundingPercent: 100,
+    // Expenses
+    lifestyleCreep: 75.0,
+    housingAppreciation: 1.4,
+    rentInflation: 1.2,
+    // Investments
+    ror: 5.9,
+    withdrawalStrategy: 'Fixed Real',
+    withdrawalRate: 4.0,
+    gkUpperGuardrail: 1.2,
+    gkLowerGuardrail: 0.8,
+    gkAdjustmentPercent: 10,
+    autoRothConversions: false,
+    // Demographics
+    retirementAge: 65,
+    lifeExpectancy: 90,
+    priorYearMode: false,
+    // Display
+    useCompactCurrency: true,
+    showExperimentalFeatures: false,
+    hsaEligible: true,
+};
+
+// Defaults for tax settings
+const TAX_DEFAULTS: Record<string, unknown> = {
+    filingStatus: 'Single',
+    stateResidency: 'DC',
+    deductionMethod: 'Auto',
+    fedOverride: null,
+    ficaOverride: null,
+    stateOverride: null,
+};
+
+/**
+ * Converts an ISO date string to days since epoch.
+ */
+export function dateToDays(dateStr: string): number {
+    const date = new Date(dateStr);
+    return Math.floor((date.getTime() - EPOCH) / MS_PER_DAY);
+}
+
+/**
+ * Converts days since epoch back to ISO date string.
+ */
+export function daysToDate(days: number): string {
+    const date = new Date(EPOCH + days * MS_PER_DAY);
+    return date.toISOString().split('T')[0];
+}
+
+/**
+ * Recursively shorten all keys in an object.
+ * Handles Date objects by converting to ISO strings.
+ */
+export function shortenKeys(obj: unknown): unknown {
+    if (Array.isArray(obj)) {
+        return obj.map(shortenKeys);
+    }
+    // Convert Date objects to ISO strings before they get corrupted
+    if (obj instanceof Date) {
+        return obj.toISOString();
+    }
+    if (obj !== null && typeof obj === 'object') {
+        const result: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(obj)) {
+            const shortKey = KEY_MAP[key] || key;
+            result[shortKey] = shortenKeys(value);
+        }
+        return result;
+    }
+    return obj;
+}
+
+/**
+ * Recursively expand all keys in an object.
+ */
+export function expandKeys(obj: unknown): unknown {
+    if (Array.isArray(obj)) {
+        return obj.map(expandKeys);
+    }
+    if (obj !== null && typeof obj === 'object') {
+        const result: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(obj)) {
+            const fullKey = REVERSE_KEY_MAP[key] || key;
+            result[fullKey] = expandKeys(value);
+        }
+        return result;
+    }
+    return obj;
+}
+
+/**
+ * Strips default values and null from an object.
+ */
+export function stripDefaults(obj: Record<string, unknown>, type: string): Record<string, unknown> {
+    const typeDefaults = DEFAULTS[type] || {};
+    return Object.fromEntries(
+        Object.entries(obj).filter(([key, value]) =>
+            value !== null && !(key in typeDefaults && typeDefaults[key] === value)
+        )
+    );
+}
+
+/**
+ * Restores default values to an object.
+ */
+export function restoreDefaults(obj: Record<string, unknown>, type: string): Record<string, unknown> {
+    const typeDefaults = DEFAULTS[type] || {};
+    return { ...typeDefaults, ...obj };
+}
+
+/**
+ * Flattens the nested assumptions structure into a single-level object.
+ */
+export function flattenAssumptions(assumptions: Record<string, unknown>): Record<string, unknown> {
+    const flat: Record<string, unknown> = {};
+
+    for (const [category, values] of Object.entries(assumptions)) {
+        if (category === 'priorities' || category === 'withdrawalOrder') {
+            // Keep arrays as-is
+            if (Array.isArray(values) && values.length > 0) {
+                flat[category] = values;
+            }
+        } else if (typeof values === 'object' && values !== null) {
+            // Flatten nested object (macro, income, etc.)
+            for (const [key, value] of Object.entries(values as Record<string, unknown>)) {
+                // Handle nested returnRates.ror
+                if (key === 'returnRates' && typeof value === 'object' && value !== null) {
+                    flat['ror'] = (value as Record<string, unknown>).ror;
+                } else {
+                    flat[key] = value;
+                }
+            }
+        }
+    }
+
+    return flat;
+}
+
+/**
+ * Expands a flattened assumptions object back to nested structure.
+ */
+export function expandAssumptions(flat: Record<string, unknown>): Record<string, unknown> {
+    return {
+        macro: {
+            inflationRate: flat.inflationRate ?? ASSUMPTIONS_DEFAULTS.inflationRate,
+            healthcareInflation: flat.healthcareInflation ?? ASSUMPTIONS_DEFAULTS.healthcareInflation,
+            inflationAdjusted: flat.inflationAdjusted ?? ASSUMPTIONS_DEFAULTS.inflationAdjusted,
+        },
+        income: {
+            salaryGrowth: flat.salaryGrowth ?? ASSUMPTIONS_DEFAULTS.salaryGrowth,
+            qualifiesForSocialSecurity: flat.qualifiesForSocialSecurity ?? ASSUMPTIONS_DEFAULTS.qualifiesForSocialSecurity,
+            socialSecurityFundingPercent: flat.socialSecurityFundingPercent ?? ASSUMPTIONS_DEFAULTS.socialSecurityFundingPercent,
+        },
+        expenses: {
+            lifestyleCreep: flat.lifestyleCreep ?? ASSUMPTIONS_DEFAULTS.lifestyleCreep,
+            housingAppreciation: flat.housingAppreciation ?? ASSUMPTIONS_DEFAULTS.housingAppreciation,
+            rentInflation: flat.rentInflation ?? ASSUMPTIONS_DEFAULTS.rentInflation,
+        },
+        investments: {
+            returnRates: { ror: flat.ror ?? ASSUMPTIONS_DEFAULTS.ror },
+            withdrawalStrategy: flat.withdrawalStrategy ?? ASSUMPTIONS_DEFAULTS.withdrawalStrategy,
+            withdrawalRate: flat.withdrawalRate ?? ASSUMPTIONS_DEFAULTS.withdrawalRate,
+            gkUpperGuardrail: flat.gkUpperGuardrail ?? ASSUMPTIONS_DEFAULTS.gkUpperGuardrail,
+            gkLowerGuardrail: flat.gkLowerGuardrail ?? ASSUMPTIONS_DEFAULTS.gkLowerGuardrail,
+            gkAdjustmentPercent: flat.gkAdjustmentPercent ?? ASSUMPTIONS_DEFAULTS.gkAdjustmentPercent,
+            autoRothConversions: flat.autoRothConversions ?? ASSUMPTIONS_DEFAULTS.autoRothConversions,
+        },
+        demographics: {
+            birthYear: flat.birthYear, // No default - must be provided
+            retirementAge: flat.retirementAge ?? ASSUMPTIONS_DEFAULTS.retirementAge,
+            lifeExpectancy: flat.lifeExpectancy ?? ASSUMPTIONS_DEFAULTS.lifeExpectancy,
+            priorYearMode: flat.priorYearMode ?? ASSUMPTIONS_DEFAULTS.priorYearMode,
+        },
+        display: {
+            useCompactCurrency: flat.useCompactCurrency ?? ASSUMPTIONS_DEFAULTS.useCompactCurrency,
+            showExperimentalFeatures: flat.showExperimentalFeatures ?? ASSUMPTIONS_DEFAULTS.showExperimentalFeatures,
+            hsaEligible: flat.hsaEligible ?? ASSUMPTIONS_DEFAULTS.hsaEligible,
+        },
+        priorities: flat.priorities ?? [],
+        withdrawalOrder: flat.withdrawalOrder ?? [],
+    };
+}
+
+/**
+ * Compresses assumptions by flattening, stripping defaults, and shortening keys.
+ */
+export function compactAssumptions(assumptions: Record<string, unknown>): Record<string, unknown> {
+    const flat = flattenAssumptions(assumptions);
+    const result: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(flat)) {
+        // Skip default values
+        if (key in ASSUMPTIONS_DEFAULTS && ASSUMPTIONS_DEFAULTS[key] === value) continue;
+        // Skip empty arrays
+        if (Array.isArray(value) && value.length === 0) continue;
+
+        // Shorten key and add
+        const shortKey = KEY_MAP[key] || key;
+        // For arrays like priorities/withdrawalOrder, also shorten nested keys
+        if (Array.isArray(value)) {
+            result[shortKey] = value.map(item =>
+                typeof item === 'object' && item !== null ? shortenKeys(item) : item
+            );
+        } else {
+            result[shortKey] = value;
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Expands compact assumptions back to full nested structure.
+ */
+export function expandCompactAssumptions(compact: Record<string, unknown>): Record<string, unknown> {
+    // First expand short keys to full keys
+    const expanded = expandKeys(compact) as Record<string, unknown>;
+    // Then rebuild nested structure with defaults
+    return expandAssumptions(expanded);
+}
+
+/**
+ * Compresses tax settings by stripping defaults and shortening keys.
+ */
+function compactTax(tax: Record<string, unknown>): Record<string, unknown> {
+    return Object.fromEntries(
+        Object.entries(tax)
+            .filter(([key, value]) =>
+                value !== null && !(key in TAX_DEFAULTS && TAX_DEFAULTS[key] === value)
+            )
+            .map(([key, value]) => [KEY_MAP[key] || key, value])
+    );
+}
+
+/**
+ * Expands compact tax settings back to full format with defaults.
+ */
+function expandCompactTax(compact: Record<string, unknown>): Record<string, unknown> {
+    const expanded = expandKeys(compact) as Record<string, unknown>;
+    return { ...TAX_DEFAULTS, ...expanded };
+}
+
+/**
+ * Compacts amountHistory to use indexes and day arrays.
+ */
+export function compactHistory(
+    history: Record<string, Array<{ date: string; num: number }>>,
+    accounts: Array<{ id: string }>
+): Record<string, Array<[number, number]>> {
+    const idToIndex = new Map(accounts.map((acc, idx) => [acc.id, idx]));
+    const result: Record<string, Array<[number, number]>> = {};
+
+    for (const [accountId, entries] of Object.entries(history)) {
+        const index = idToIndex.get(accountId);
+        if (index === undefined) continue;
+
+        result[String(index)] = entries.map(entry => [
+            dateToDays(entry.date),
+            Math.round(entry.num)
+        ]);
+    }
+
+    return result;
+}
+
+/**
+ * Expands compacted amountHistory back to full format.
+ */
+export function expandHistory(
+    compact: Record<string, Array<[number, number]>>,
+    accounts: Array<{ id: string }>
+): Record<string, Array<{ date: string; num: number }>> {
+    const result: Record<string, Array<{ date: string; num: number }>> = {};
+
+    for (const [indexStr, entries] of Object.entries(compact)) {
+        const index = parseInt(indexStr, 10);
+        if (index >= accounts.length) continue;
+
+        const accountId = accounts[index].id;
+        result[accountId] = entries.map(([days, num]) => ({
+            date: daysToDate(days),
+            num
+        }));
+    }
+
+    return result;
+}
+
+interface FullBackup {
+    version: number;
+    accounts: Array<{ id: string } & Record<string, unknown>>;
+    amountHistory: Record<string, Array<{ date: string; num: number }>>;
+    incomes: Array<Record<string, unknown>>;
+    expenses: Array<Record<string, unknown>>;
+    taxSettings: Record<string, unknown>;
+    assumptions: Record<string, unknown>;
+}
+
+interface CompactBackup {
+    v: number;
+    a: Array<Record<string, unknown>>;
+    h: Record<string, Array<[number, number]>>;
+    i: Array<Record<string, unknown>>;
+    e: Array<Record<string, unknown>>;
+    t: Record<string, unknown>;
+    m: Record<string, unknown>;
+}
+
+/**
+ * Creates a compact backup from a full backup.
+ */
+export function createCompactBackup(full: FullBackup): CompactBackup {
+    // Process accounts - strip defaults and shorten keys
+    const compactAccounts = full.accounts.map(acc =>
+        shortenKeys(stripDefaults(acc, 'account'))
+    ) as Array<Record<string, unknown>>;
+
+    // Compact history using account indexes
+    const compactHistoryData = compactHistory(full.amountHistory, full.accounts);
+
+    // Process incomes
+    const compactIncomes = full.incomes.map(inc =>
+        shortenKeys(stripDefaults(inc, 'income'))
+    ) as Array<Record<string, unknown>>;
+
+    // Process expenses
+    const compactExpenses = full.expenses.map(exp =>
+        shortenKeys(stripDefaults(exp, 'expense'))
+    ) as Array<Record<string, unknown>>;
+
+    return {
+        v: full.version,
+        a: compactAccounts,
+        h: compactHistoryData,
+        i: compactIncomes,
+        e: compactExpenses,
+        t: compactTax(full.taxSettings),
+        m: compactAssumptions(full.assumptions),
+    };
+}
+
+/**
+ * Expands a compact backup to full format.
+ */
+export function expandCompactBackup(compact: CompactBackup): FullBackup {
+    // First expand accounts to get IDs for history mapping
+    const expandedAccounts = compact.a.map(acc =>
+        restoreDefaults(expandKeys(acc) as Record<string, unknown>, 'account')
+    ) as Array<{ id: string } & Record<string, unknown>>;
+
+    // Expand history using account IDs
+    const expandedHistory = expandHistory(compact.h, expandedAccounts);
+
+    // Expand incomes
+    const expandedIncomes = compact.i.map(inc =>
+        restoreDefaults(expandKeys(inc) as Record<string, unknown>, 'income')
+    );
+
+    // Expand expenses
+    const expandedExpenses = compact.e.map(exp =>
+        restoreDefaults(expandKeys(exp) as Record<string, unknown>, 'expense')
+    );
+
+    return {
+        version: compact.v,
+        accounts: expandedAccounts,
+        amountHistory: expandedHistory,
+        incomes: expandedIncomes,
+        expenses: expandedExpenses,
+        taxSettings: expandCompactTax(compact.t),
+        assumptions: expandCompactAssumptions(compact.m),
+    };
+}
+
+/**
+ * Checks if data is in compact format.
+ */
+export function isCompactFormat(data: unknown): data is CompactBackup {
+    if (typeof data !== 'object' || data === null) return false;
+    const obj = data as Record<string, unknown>;
+    return 'v' in obj && 'a' in obj && 'h' in obj;
+}
+
+/**
+ * Compresses a JavaScript object to a base64-encoded string using pako (zlib).
+ */
+export function compressData(data: object): string {
+    const jsonString = JSON.stringify(data);
+    const compressed = pako.deflate(jsonString);
+    return btoa(String.fromCharCode(...compressed));
+}
+
+/**
+ * Decompresses a base64-encoded string back to a JavaScript object.
+ */
+export function decompressData(compressed: string): object {
+    // Convert base64 to Uint8Array
+    const binaryString = atob(compressed);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+    }
+    const decompressed = pako.inflate(bytes, { to: 'string' });
+    return JSON.parse(decompressed);
+}
+
+/**
+ * Validates that the payload has the expected structure for a full backup.
+ */
+export function validatePayload(data: unknown): data is {
+    version: number;
+    accounts: unknown[];
+    amountHistory: Record<string, unknown>;
+    incomes: unknown[];
+    expenses: unknown[];
+    taxSettings: unknown;
+    assumptions: unknown;
+} {
+    if (typeof data !== 'object' || data === null) {
+        return false;
+    }
+
+    const backup = data as Record<string, unknown>;
+
+    // Check required fields exist
+    if (typeof backup.version !== 'number') return false;
+    if (!Array.isArray(backup.accounts)) return false;
+    if (typeof backup.amountHistory !== 'object' || backup.amountHistory === null) return false;
+    if (!Array.isArray(backup.incomes)) return false;
+    if (!Array.isArray(backup.expenses)) return false;
+    if (typeof backup.taxSettings !== 'object' || backup.taxSettings === null) return false;
+    if (typeof backup.assumptions !== 'object' || backup.assumptions === null) return false;
+
+    return true;
+}
+
+/**
+ * Maximum safe size for QR code data (in bytes).
+ * With error correction level "M", max capacity is ~2331 bytes.
+ * Using 2200 for safety margin.
+ */
+const MAX_QR_DATA_SIZE = 2200;
+
+/**
+ * Checks if the compressed data exceeds the safe QR code size limit.
+ */
+export function exceedsQRLimit(compressedData: string): boolean {
+    return compressedData.length > MAX_QR_DATA_SIZE;
+}

--- a/src/components/Objects/Accounts/useFileManager.ts
+++ b/src/components/Objects/Accounts/useFileManager.ts
@@ -1,0 +1,150 @@
+import { useContext } from 'react';
+import { AccountContext, AccountDispatchContext } from './AccountContext';
+import { IncomeContext, IncomeDispatchContext } from '../Income/IncomeContext';
+import { ExpenseContext, ExpenseDispatchContext } from '../Expense/ExpenseContext';
+import { TaxContext } from '../../Objects/Taxes/TaxContext';
+import { AssumptionsContext, AssumptionsState, defaultAssumptions } from '../Assumptions/AssumptionsContext';
+import { AnyAccount, reconstituteAccount } from './models';
+import { AmountHistoryEntry } from './AccountContext';
+import { AnyIncome, reconstituteIncome } from '../Income/models';
+import { AnyExpense, reconstituteExpense } from '../Expense/models';
+import { TaxState, defaultTaxState } from '../../Objects/Taxes/TaxContext';
+import { ImportKeyContext } from './ImportKeyContext';
+import { BudgetContext, BudgetState } from '../Budget/BudgetContext';
+import { loadAccountMap, saveAccountMap } from '../../../services/simplefinBalances';
+
+export interface FullBackup {
+    version: number;
+    accounts: any[];
+    amountHistory: Record<string, AmountHistoryEntry[]>;
+    incomes: any[];
+    expenses: any[];
+    taxSettings: TaxState;
+    assumptions: AssumptionsState;
+    // View state (selectedMonth/selectedYear) is intentionally excluded — it's UI
+    // state, not data, so it must not be backed up or count toward dirty-detection.
+    budget?: Omit<BudgetState, 'selectedMonth' | 'selectedYear'>; // Optional for backwards compatibility
+    // SimpleFIN -> Stag account mapping (csvAccount -> appAccountId[]). Lives in
+    // localStorage during normal use; carried in the blob so headless stag-feed
+    // can read it. Optional for backwards compatibility with v1 backups.
+    balanceAccountMap?: Record<string, string[]>;
+}
+
+export const useFileManager = () => {
+    const { accounts, amountHistory } = useContext(AccountContext);
+    const { dispatch: accountDispatch } = useContext(AccountDispatchContext);
+    const { incomes } = useContext(IncomeContext);
+    const incomeDispatch = useContext(IncomeDispatchContext);
+    const { expenses } = useContext(ExpenseContext);
+    const expenseDispatch = useContext(ExpenseDispatchContext);
+    const { state, dispatch: taxesDispatch } = useContext(TaxContext);
+    const { state: assumptions, dispatch: assumptionsDispatch } = useContext(AssumptionsContext);
+    const { importKey, incrementImportKey } = useContext(ImportKeyContext);
+    const budgetContext = useContext(BudgetContext);
+    const { dispatch: budgetDispatch } = budgetContext;
+
+    const handleGlobalExport = () => {
+        // Extract budget data (excluding dispatch/helpers). selectedMonth/selectedYear
+        // are UI view state, not data — omit them so switching months doesn't dirty the backup.
+        const { months, importSettings } = budgetContext;
+        const budgetState = { months, importSettings };
+
+        const fullBackup: FullBackup = {
+            version: 2,
+            accounts: accounts.map(a => ({ ...a, className: a.constructor.name })),
+            amountHistory,
+            incomes: incomes.map(i => ({ ...i, className: i.constructor.name })),
+            expenses: expenses.map(e => ({ ...e, className: e.constructor.name })),
+            taxSettings: state as TaxState,
+            assumptions: assumptions as AssumptionsState,
+            budget: budgetState,
+            balanceAccountMap: loadAccountMap(),
+        };
+
+        const blob = new Blob([JSON.stringify(fullBackup, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `stag_full_backup_${new Date().toISOString().split('T')[0]}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
+    const handleGlobalImport = (json: string) => {
+        try {
+            const data = JSON.parse(json);
+
+            const newAccounts = data.accounts.map(reconstituteAccount).filter(Boolean as any as (value: AnyAccount | null) => value is AnyAccount);
+            const newIncomes = data.incomes.map(reconstituteIncome).filter(Boolean as any as (value: AnyIncome | null) => value is AnyIncome);
+            const newExpenses = data.expenses.map(reconstituteExpense).filter(Boolean as any as (value: AnyExpense | null) => value is AnyExpense);
+
+            accountDispatch({ type: 'SET_BULK_DATA', payload: { accounts: newAccounts, amountHistory: data.amountHistory || {} } });
+            incomeDispatch({ type: 'SET_BULK_DATA', payload: { incomes: newIncomes } });
+            expenseDispatch({ type: 'SET_BULK_DATA', payload: { expenses: newExpenses } });
+            // Merge taxSettings with defaults to ensure all fields are present
+            const mergedTaxSettings = {
+                ...defaultTaxState,
+                ...data.taxSettings,
+            };
+            taxesDispatch({ type: 'SET_BULK_DATA', payload: mergedTaxSettings });
+            if (data.assumptions) { // Check if assumptions exist in the backup data
+                const mergedAssumptions = {
+                    ...defaultAssumptions,
+                    ...data.assumptions,
+                    macro: { ...defaultAssumptions.macro, ...(data.assumptions.macro || {}) },
+                    income: { ...defaultAssumptions.income, ...(data.assumptions.income || {}) },
+                    expenses: { ...defaultAssumptions.expenses, ...(data.assumptions.expenses || {}) },
+                    investments: {
+                        ...defaultAssumptions.investments,
+                        ...(data.assumptions.investments || {}),
+                        returnRates: {
+                            ...defaultAssumptions.investments.returnRates,
+                            ...((data.assumptions.investments && data.assumptions.investments.returnRates) || {}),
+                        },
+                    },
+                    demographics: { ...defaultAssumptions.demographics, ...(data.assumptions.demographics || {}) },
+                    priorities: data.assumptions.priorities || defaultAssumptions.priorities
+                };
+                assumptionsDispatch({ type: 'SET_BULK_DATA', payload: mergedAssumptions });
+            }
+            else {
+                assumptionsDispatch({ type: 'RESET_DEFAULTS'});
+            }
+            // Import budget data if present
+            if (data.budget) {
+                budgetDispatch({ type: 'SET_BULK_DATA', payload: data.budget });
+            }
+            // Restore the SimpleFIN account mapping if present (v2+ backups)
+            if (data.balanceAccountMap) {
+                saveAccountMap(data.balanceAccountMap);
+            }
+            // Increment shared importKey to force chart remounts after import
+            incrementImportKey();
+            // Force page reload to ensure all components update
+            //window.location.reload();
+        } catch (e) {
+            console.error(e);
+            alert("Error importing backup. Please check file format.");
+        }
+    };
+
+    const getBackupData = (): FullBackup => {
+        // selectedMonth/selectedYear are UI view state — omit so month switches don't dirty the backup.
+        const { months, importSettings } = budgetContext;
+        const budgetState = { months, importSettings };
+
+        return {
+            version: 2,
+            accounts: accounts.map(a => ({ ...a, className: a.constructor.name })),
+            amountHistory,
+            incomes: incomes.map(i => ({ ...i, className: i.constructor.name })),
+            expenses: expenses.map(e => ({ ...e, className: e.constructor.name })),
+            taxSettings: state as TaxState,
+            assumptions: assumptions as AssumptionsState,
+            budget: budgetState,
+            balanceAccountMap: loadAccountMap(),
+        };
+    };
+
+    return { handleGlobalExport, handleGlobalImport, getBackupData, importKey };
+};

--- a/src/components/Objects/Budget/BudgetContext.tsx
+++ b/src/components/Objects/Budget/BudgetContext.tsx
@@ -1,0 +1,525 @@
+import { createContext, ReactNode, Dispatch, useMemo, useCallback } from 'react';
+import { usePersistedReducer } from '../../../hooks/usePersistedReducer';
+
+// Re-export types and constants for backward compatibility
+export {
+    INCOME_CATEGORIES,
+    TRANSFER_CATEGORY_ID,
+    getFrequencyDivisor,
+} from './BudgetTypes';
+
+export type {
+    IncomeCategory,
+    TransactionFrequency,
+    Transaction,
+    CategoryMapping,
+    SavedCSVMapping,
+    MonthlySnapshot,
+    BudgetState,
+} from './BudgetTypes';
+
+import type {
+    Transaction,
+    CategoryMapping,
+    SavedCSVMapping,
+    MonthlySnapshot,
+    BudgetState,
+} from './BudgetTypes';
+
+function generateId(prefix: string): string {
+    return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+}
+
+const now = new Date();
+
+const initialState: BudgetState = {
+    months: [],
+    importSettings: {
+        dateColumn: 'Date',
+        amountColumn: 'Amount',
+        descriptionColumn: 'Description',
+        categoryMappings: [],
+        savedCSVFormats: [],
+        autoCreateRules: false,
+    },
+    selectedMonth: now.getMonth() + 1,
+    selectedYear: now.getFullYear(),
+};
+
+export type BudgetAction =
+    | { type: 'SET_SELECTED_MONTH'; payload: { month: number; year: number } }
+    | { type: 'ADD_MONTH'; payload: MonthlySnapshot }
+    | { type: 'UPDATE_MONTH'; payload: { id: string; updates: Partial<MonthlySnapshot> } }
+    | { type: 'DELETE_MONTH'; payload: { id: string } }
+    | { type: 'UPDATE_SPENDING'; payload: { monthId: string; expenseId: string; amount: number | null } }
+    | { type: 'UPDATE_ACCOUNT_BALANCE'; payload: { monthId: string; accountId: string; balance: number } }
+    | { type: 'UPDATE_CONTRIBUTION'; payload: { monthId: string; accountId: string; amount: number } }
+    | { type: 'ADD_TRANSACTION'; payload: { monthId: string; transaction: Transaction } }
+    | { type: 'UPDATE_TRANSACTION'; payload: { monthId: string; transactionId: string; updates: Partial<Transaction> } }
+    | { type: 'MOVE_TRANSACTION'; payload: { fromMonthId: string; transactionId: string; toMonth: number; toYear: number; updates?: Partial<Transaction> } }
+    | { type: 'DELETE_TRANSACTION'; payload: { monthId: string; transactionId: string } }
+    | { type: 'CLEAR_ALL_TRANSACTIONS'; payload: { monthId: string } }
+    | { type: 'BULK_ADD_TRANSACTIONS'; payload: { monthId: string; transactions: Transaction[] } }
+    | { type: 'ADD_CATEGORY_MAPPING'; payload: CategoryMapping }
+    | { type: 'UPDATE_CATEGORY_MAPPING'; payload: { id: string; updates: Partial<CategoryMapping> } }
+    | { type: 'DELETE_CATEGORY_MAPPING'; payload: { id: string } }
+    | { type: 'APPLY_CATEGORY_RULE'; payload: CategoryMapping & { expenseStart?: Date | string | null; expenseEnd?: Date | string | null } }
+    | { type: 'ADD_CSV_FORMAT'; payload: SavedCSVMapping }
+    | { type: 'UPDATE_CSV_FORMAT'; payload: { id: string; updates: Partial<SavedCSVMapping> } }
+    | { type: 'DELETE_CSV_FORMAT'; payload: { id: string } }
+    | { type: 'SET_AUTO_CREATE_RULES'; payload: boolean }
+    | { type: 'SET_PROJECT_FUTURE'; payload: boolean }
+    | { type: 'SET_BULK_DATA'; payload: Partial<BudgetState> };
+
+function budgetReducer(state: BudgetState, action: BudgetAction): BudgetState {
+    switch (action.type) {
+        case 'SET_SELECTED_MONTH':
+            return {
+                ...state,
+                selectedMonth: action.payload.month,
+                selectedYear: action.payload.year,
+            };
+
+        case 'ADD_MONTH':
+            return {
+                ...state,
+                months: [...state.months, action.payload],
+            };
+
+        case 'UPDATE_MONTH':
+            return {
+                ...state,
+                months: state.months.map(m =>
+                    m.id === action.payload.id
+                        ? { ...m, ...action.payload.updates, updatedAt: new Date() }
+                        : m
+                ),
+            };
+
+        case 'DELETE_MONTH':
+            return {
+                ...state,
+                months: state.months.filter(m => m.id !== action.payload.id),
+            };
+
+        case 'UPDATE_SPENDING': {
+            const { monthId, expenseId, amount } = action.payload;
+            return {
+                ...state,
+                months: state.months.map(m => {
+                    if (m.id !== monthId) return m;
+                    const newSpending = { ...m.spending };
+                    if (amount === null || amount === undefined) {
+                        delete newSpending[expenseId];
+                    } else {
+                        newSpending[expenseId] = amount;
+                    }
+                    return { ...m, spending: newSpending, updatedAt: new Date() };
+                }),
+            };
+        }
+
+        case 'UPDATE_ACCOUNT_BALANCE':
+            return {
+                ...state,
+                months: state.months.map(m =>
+                    m.id === action.payload.monthId
+                        ? {
+                            ...m,
+                            accountBalances: { ...m.accountBalances, [action.payload.accountId]: action.payload.balance },
+                            updatedAt: new Date(),
+                        }
+                        : m
+                ),
+            };
+
+        case 'UPDATE_CONTRIBUTION':
+            return {
+                ...state,
+                months: state.months.map(m =>
+                    m.id === action.payload.monthId
+                        ? {
+                            ...m,
+                            contributions: { ...m.contributions, [action.payload.accountId]: action.payload.amount },
+                            updatedAt: new Date(),
+                        }
+                        : m
+                ),
+            };
+
+        case 'ADD_TRANSACTION':
+            return {
+                ...state,
+                months: state.months.map(m =>
+                    m.id === action.payload.monthId
+                        ? {
+                            ...m,
+                            transactions: [...m.transactions, action.payload.transaction],
+                            updatedAt: new Date(),
+                        }
+                        : m
+                ),
+            };
+
+        case 'UPDATE_TRANSACTION':
+            return {
+                ...state,
+                months: state.months.map(m =>
+                    m.id === action.payload.monthId
+                        ? {
+                            ...m,
+                            transactions: m.transactions.map(t =>
+                                t.id === action.payload.transactionId
+                                    ? { ...t, ...action.payload.updates }
+                                    : t
+                            ),
+                            updatedAt: new Date(),
+                        }
+                        : m
+                ),
+            };
+
+        case 'MOVE_TRANSACTION': {
+            const { fromMonthId, transactionId, toMonth, toYear, updates } = action.payload;
+
+            // Find the transaction to move
+            const sourceMonth = state.months.find(m => m.id === fromMonthId);
+            const transaction = sourceMonth?.transactions.find(t => t.id === transactionId);
+            if (!transaction) return state;
+
+            // Apply any updates to the transaction
+            const updatedTransaction = { ...transaction, ...updates };
+
+            // Find or prepare the target month
+            let targetMonth = state.months.find(m => m.month === toMonth && m.year === toYear);
+            const targetMonthId = targetMonth?.id;
+
+            // If target month doesn't exist, we need to create it
+            if (!targetMonth) {
+                const newMonthId = `MONTH-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+                targetMonth = {
+                    id: newMonthId,
+                    month: toMonth,
+                    year: toYear,
+                    spending: {},
+                    accountBalances: {},
+                    contributions: {},
+                    transactions: [updatedTransaction],
+                    reconciled: false,
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                };
+
+                // Remove from source, add new target month
+                return {
+                    ...state,
+                    months: [
+                        ...state.months.map(m =>
+                            m.id === fromMonthId
+                                ? {
+                                    ...m,
+                                    transactions: m.transactions.filter(t => t.id !== transactionId),
+                                    updatedAt: new Date(),
+                                }
+                                : m
+                        ),
+                        targetMonth,
+                    ],
+                };
+            }
+
+            // Both months exist - remove from source and add to target
+            return {
+                ...state,
+                months: state.months.map(m => {
+                    if (m.id === fromMonthId) {
+                        return {
+                            ...m,
+                            transactions: m.transactions.filter(t => t.id !== transactionId),
+                            updatedAt: new Date(),
+                        };
+                    }
+                    if (m.id === targetMonthId) {
+                        return {
+                            ...m,
+                            transactions: [...m.transactions, updatedTransaction],
+                            updatedAt: new Date(),
+                        };
+                    }
+                    return m;
+                }),
+            };
+        }
+
+        case 'DELETE_TRANSACTION':
+            return {
+                ...state,
+                months: state.months.map(m =>
+                    m.id === action.payload.monthId
+                        ? {
+                            ...m,
+                            transactions: m.transactions.filter(t => t.id !== action.payload.transactionId),
+                            updatedAt: new Date(),
+                        }
+                        : m
+                ),
+            };
+
+        case 'CLEAR_ALL_TRANSACTIONS':
+            return {
+                ...state,
+                months: state.months.map(m =>
+                    m.id === action.payload.monthId
+                        ? {
+                            ...m,
+                            transactions: [],
+                            updatedAt: new Date(),
+                        }
+                        : m
+                ),
+            };
+
+        case 'BULK_ADD_TRANSACTIONS':
+            return {
+                ...state,
+                months: state.months.map(m =>
+                    m.id === action.payload.monthId
+                        ? {
+                            ...m,
+                            transactions: [...m.transactions, ...action.payload.transactions],
+                            updatedAt: new Date(),
+                        }
+                        : m
+                ),
+            };
+
+        case 'ADD_CATEGORY_MAPPING':
+            return {
+                ...state,
+                importSettings: {
+                    ...state.importSettings,
+                    categoryMappings: [...state.importSettings.categoryMappings, action.payload],
+                },
+            };
+
+        case 'UPDATE_CATEGORY_MAPPING':
+            return {
+                ...state,
+                importSettings: {
+                    ...state.importSettings,
+                    categoryMappings: state.importSettings.categoryMappings.map(m =>
+                        m.id === action.payload.id ? { ...m, ...action.payload.updates } : m
+                    ),
+                },
+            };
+
+        case 'DELETE_CATEGORY_MAPPING':
+            return {
+                ...state,
+                importSettings: {
+                    ...state.importSettings,
+                    categoryMappings: state.importSettings.categoryMappings.filter(m => m.id !== action.payload.id),
+                },
+            };
+
+        case 'APPLY_CATEGORY_RULE': {
+            // Apply a category rule to all matching uncategorized transactions
+            const { expenseStart, expenseEnd, ...rule } = action.payload;
+            const matchesRule = (description: string): boolean => {
+                if (rule.isRegex) {
+                    try {
+                        return new RegExp(rule.pattern, 'i').test(description);
+                    } catch {
+                        return false;
+                    }
+                }
+                return description.toLowerCase().includes(rule.pattern.toLowerCase());
+            };
+
+            // Check if the target expense is active for a given month
+            const isActiveForMonth = (month: number, year: number): boolean => {
+                const targetDate = new Date(year, month - 1, 15);
+                if (expenseStart && new Date(expenseStart) > targetDate) return false;
+                if (expenseEnd && new Date(expenseEnd) < targetDate) return false;
+                return true;
+            };
+
+            // Don't categorize transactions that already belong elsewhere: transfers,
+            // contributions, and true income. Tagging income with an expenseId creates a
+            // contradictory state that the reconcile reads as a (negative) reimbursement.
+            const isCategorizable = (t: Transaction): boolean =>
+                !t.expenseId
+                && !t.isTransfer
+                && !t.targetAccountId
+                && !(t.amount > 0 && !t.isReimbursement && t.incomeCategory);
+
+            return {
+                ...state,
+                months: state.months.map(month => ({
+                    ...month,
+                    transactions: month.transactions.map(t =>
+                        isCategorizable(t) && matchesRule(t.description) && isActiveForMonth(month.month, month.year)
+                            ? { ...t, expenseId: rule.expenseId }
+                            : t
+                    ),
+                })),
+            };
+        }
+
+        case 'ADD_CSV_FORMAT':
+            return {
+                ...state,
+                importSettings: {
+                    ...state.importSettings,
+                    savedCSVFormats: [...state.importSettings.savedCSVFormats, action.payload],
+                },
+            };
+
+        case 'UPDATE_CSV_FORMAT':
+            return {
+                ...state,
+                importSettings: {
+                    ...state.importSettings,
+                    savedCSVFormats: state.importSettings.savedCSVFormats.map(f =>
+                        f.id === action.payload.id ? { ...f, ...action.payload.updates } : f
+                    ),
+                },
+            };
+
+        case 'DELETE_CSV_FORMAT':
+            return {
+                ...state,
+                importSettings: {
+                    ...state.importSettings,
+                    savedCSVFormats: state.importSettings.savedCSVFormats.filter(f => f.id !== action.payload.id),
+                },
+            };
+
+        case 'SET_AUTO_CREATE_RULES':
+            return {
+                ...state,
+                importSettings: {
+                    ...state.importSettings,
+                    autoCreateRules: action.payload,
+                },
+            };
+
+        case 'SET_PROJECT_FUTURE':
+            return { ...state, projectFuture: action.payload };
+
+        case 'SET_BULK_DATA':
+            return { ...state, ...action.payload };
+
+        default:
+            return state;
+    }
+}
+
+const STORAGE_KEY = 'user_budget_data';
+
+interface BudgetContextProps extends BudgetState {
+    dispatch: Dispatch<BudgetAction>;
+    getOrCreateMonth: (month: number, year: number) => MonthlySnapshot;
+    getCurrentMonth: () => MonthlySnapshot | undefined;
+}
+
+export const BudgetContext = createContext<BudgetContextProps>({
+    ...initialState,
+    dispatch: () => null,
+    getOrCreateMonth: () => ({} as MonthlySnapshot),
+    getCurrentMonth: () => undefined,
+});
+
+function hydrateBudgetState(parsed: unknown, initial: BudgetState): BudgetState {
+    const data = parsed as Record<string, unknown>;
+    if (!data) return initial;
+
+    const months = ((data.months as unknown[]) || []).map((m: unknown) => {
+        const month = m as Record<string, unknown>;
+        const transactions = ((month.transactions as unknown[]) || []).map((t: unknown) => {
+            const trans = t as Record<string, unknown>;
+            return {
+                ...trans,
+                date: trans.date ? new Date(trans.date as string) : new Date(),
+                statementDate: trans.statementDate ? new Date(trans.statementDate as string) : undefined,
+            } as Transaction;
+        });
+        return {
+            ...month,
+            createdAt: month.createdAt ? new Date(month.createdAt as string) : new Date(),
+            updatedAt: month.updatedAt ? new Date(month.updatedAt as string) : new Date(),
+            transactions,
+        } as MonthlySnapshot;
+    });
+
+    const importSettingsData = (data.importSettings as Record<string, unknown>) || {};
+    const savedCSVFormats = ((importSettingsData.savedCSVFormats as unknown[]) || []).map((f: unknown) => {
+        const format = f as Record<string, unknown>;
+        return {
+            ...format,
+            lastUsed: format.lastUsed ? new Date(format.lastUsed as string) : new Date(),
+            createdAt: format.createdAt ? new Date(format.createdAt as string) : new Date(),
+        } as SavedCSVMapping;
+    });
+
+    return {
+        ...initial,
+        ...data,
+        months,
+        importSettings: {
+            ...initial.importSettings,
+            ...importSettingsData,
+            categoryMappings: (importSettingsData.categoryMappings as CategoryMapping[]) || [],
+            savedCSVFormats,
+        },
+        selectedMonth: (data.selectedMonth as number) || initial.selectedMonth,
+        selectedYear: (data.selectedYear as number) || initial.selectedYear,
+    };
+}
+
+export function BudgetProvider({ children }: { children: ReactNode }): React.ReactElement {
+    const [state, dispatch] = usePersistedReducer(budgetReducer, initialState, {
+        storageKey: STORAGE_KEY,
+        hydrate: hydrateBudgetState,
+    });
+
+    const getOrCreateMonth = useCallback((month: number, year: number): MonthlySnapshot => {
+        const existing = state.months.find(m => m.month === month && m.year === year);
+        if (existing) return existing;
+
+        const newMonth: MonthlySnapshot = {
+            id: generateId('MONTH'),
+            month,
+            year,
+            spending: {},
+            accountBalances: {},
+            contributions: {},
+            transactions: [],
+            reconciled: false,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        };
+
+        dispatch({ type: 'ADD_MONTH', payload: newMonth });
+        return newMonth;
+    }, [state.months]);
+
+    const getCurrentMonth = useCallback((): MonthlySnapshot | undefined => {
+        return state.months.find(
+            m => m.month === state.selectedMonth && m.year === state.selectedYear
+        );
+    }, [state.months, state.selectedMonth, state.selectedYear]);
+
+    const contextValue = useMemo(() => ({
+        ...state,
+        dispatch,
+        getOrCreateMonth,
+        getCurrentMonth,
+    }), [state, dispatch, getOrCreateMonth, getCurrentMonth]);
+
+    return (
+        <BudgetContext.Provider value={contextValue}>
+            {children}
+        </BudgetContext.Provider>
+    );
+}

--- a/src/components/Objects/Expense/ExpenseContext.tsx
+++ b/src/components/Objects/Expense/ExpenseContext.tsx
@@ -1,0 +1,107 @@
+import { createContext, ReactNode, Dispatch } from 'react';
+import {
+    AnyExpense,
+    RentExpense,
+    MortgageExpense,
+    LoanExpense,
+    DependentExpense,
+    TransportExpense,
+    reconstituteExpense
+} from './models';
+import { usePersistedReducer } from '../../../hooks/usePersistedReducer';
+
+export type AllExpenseKeys = keyof RentExpense | keyof MortgageExpense | keyof LoanExpense | keyof DependentExpense | keyof TransportExpense | 'startDate' | 'endDate';
+
+interface ExpenseState {
+  expenses: AnyExpense[];
+}
+
+type Action =
+  | { type: 'ADD_EXPENSE'; payload: AnyExpense }
+  | { type: 'DELETE_EXPENSE'; payload: { id: string } }
+  | { type: 'UPDATE_EXPENSE_FIELD'; payload: { id: string; field: AllExpenseKeys; value: unknown } }
+  | { type: 'REORDER_EXPENSES'; payload: { startIndex: number; endIndex: number } }
+  | { type: 'SET_BULK_DATA'; payload: { expenses: AnyExpense[] } };
+
+const STORAGE_KEY = 'user_expenses_data';
+
+const initialState: ExpenseState = {
+  expenses: [],
+};
+
+function expenseReducer(state: ExpenseState, action: Action): ExpenseState {
+  switch (action.type) {
+    case 'ADD_EXPENSE':
+      return { ...state, expenses: [...state.expenses, action.payload] };
+
+    case 'DELETE_EXPENSE':
+      return { ...state, expenses: state.expenses.filter((exp) => exp.id !== action.payload.id) };
+
+    case 'UPDATE_EXPENSE_FIELD':
+      return {
+        ...state,
+        expenses: state.expenses.map((exp) => {
+          if (exp.id !== action.payload.id) return exp;
+
+          const updated = Object.assign(Object.create(Object.getPrototypeOf(exp)), exp);
+          updated[action.payload.field] = action.payload.value;
+
+          // Recalculate derived amount for housing expenses
+          if (updated instanceof RentExpense) {
+            updated.amount = (updated.payment || 0) + (updated.utilities || 0);
+          } else if (updated instanceof MortgageExpense) {
+            updated.amount = updated.payment || 0;
+          }
+
+          return updated;
+        }),
+      };
+
+    case 'REORDER_EXPENSES': {
+      const result = Array.from(state.expenses);
+      const [removed] = result.splice(action.payload.startIndex, 1);
+      result.splice(action.payload.endIndex, 0, removed);
+      return { ...state, expenses: result };
+    }
+
+    case 'SET_BULK_DATA':
+      return { ...state, expenses: action.payload.expenses };
+
+    default:
+      return state;
+  }
+}
+
+function hydrateExpenseState(parsed: unknown, initial: ExpenseState): ExpenseState {
+  const data = parsed as { expenses?: unknown[] };
+  const expenses = (data.expenses || [])
+    .map(reconstituteExpense)
+    .filter((exp): exp is AnyExpense => exp !== null);
+  return { ...initial, expenses };
+}
+
+function serializeExpenseState(state: ExpenseState): string {
+  return JSON.stringify({
+    ...state,
+    expenses: state.expenses.map(exp => ({ ...exp, className: exp.constructor.name })),
+  });
+}
+
+export const ExpenseContext = createContext<ExpenseState>({ expenses: [] });
+export const ExpenseDispatchContext = createContext<Dispatch<Action>>(() => null);
+
+export function ExpenseProvider({ children }: { children: ReactNode }): React.ReactElement {
+  const [state, dispatch] = usePersistedReducer(expenseReducer, initialState, {
+    storageKey: STORAGE_KEY,
+    hydrate: hydrateExpenseState,
+    serialize: serializeExpenseState,
+  });
+
+  return (
+    <ExpenseDispatchContext.Provider value={dispatch}>
+      <ExpenseContext.Provider value={state}>
+        {children}
+      </ExpenseContext.Provider>
+    </ExpenseDispatchContext.Provider>
+  );
+}

--- a/src/components/Objects/Income/IncomeContext.tsx
+++ b/src/components/Objects/Income/IncomeContext.tsx
@@ -1,0 +1,92 @@
+import { createContext, ReactNode, Dispatch } from 'react';
+import { AnyIncome, reconstituteIncome } from './models';
+import { usePersistedReducer } from '../../../hooks/usePersistedReducer';
+
+type AllKeys<T> = T extends any ? keyof T : never;
+export type AllIncomeKeys = AllKeys<AnyIncome>;
+
+interface IncomeState {
+  incomes: AnyIncome[];
+}
+
+type Action =
+  | { type: 'ADD_INCOME'; payload: AnyIncome }
+  | { type: 'DELETE_INCOME'; payload: { id: string } }
+  | { type: 'UPDATE_INCOME_FIELD'; payload: { id: string; field: AllIncomeKeys; value: unknown } }
+  | { type: 'REORDER_INCOMES'; payload: { startIndex: number; endIndex: number } }
+  | { type: 'SET_BULK_DATA'; payload: { incomes: AnyIncome[] } };
+
+const STORAGE_KEY = 'user_incomes_data';
+
+const initialState: IncomeState = {
+  incomes: [],
+};
+
+function incomeReducer(state: IncomeState, action: Action): IncomeState {
+  switch (action.type) {
+    case 'ADD_INCOME':
+      return { ...state, incomes: [...state.incomes, action.payload] };
+
+    case 'DELETE_INCOME':
+      return { ...state, incomes: state.incomes.filter((inc) => inc.id !== action.payload.id) };
+
+    case 'UPDATE_INCOME_FIELD':
+      return {
+        ...state,
+        incomes: state.incomes.map((inc) => {
+          if (inc.id !== action.payload.id) return inc;
+          const updated = Object.assign(Object.create(Object.getPrototypeOf(inc)), inc);
+          updated.className = inc.className || inc.constructor.name;
+          updated[action.payload.field] = action.payload.value;
+          return updated;
+        }),
+      };
+
+    case 'REORDER_INCOMES': {
+      const result = Array.from(state.incomes);
+      const [removed] = result.splice(action.payload.startIndex, 1);
+      result.splice(action.payload.endIndex, 0, removed);
+      return { ...state, incomes: result };
+    }
+
+    case 'SET_BULK_DATA':
+      return { ...state, incomes: action.payload.incomes };
+
+    default:
+      return state;
+  }
+}
+
+function hydrateIncomeState(parsed: unknown, initial: IncomeState): IncomeState {
+  const data = parsed as { incomes?: unknown[] };
+  const incomes = (data.incomes || [])
+    .map(reconstituteIncome)
+    .filter((inc): inc is AnyIncome => inc !== null);
+  return { ...initial, incomes };
+}
+
+function serializeIncomeState(state: IncomeState): string {
+  return JSON.stringify({
+    ...state,
+    incomes: state.incomes.map(inc => ({ ...inc, className: inc.className || inc.constructor.name })),
+  });
+}
+
+export const IncomeContext = createContext<IncomeState>({ incomes: [] });
+export const IncomeDispatchContext = createContext<Dispatch<Action>>(() => null);
+
+export function IncomeProvider({ children }: { children: ReactNode }): React.ReactElement {
+  const [state, dispatch] = usePersistedReducer(incomeReducer, initialState, {
+    storageKey: STORAGE_KEY,
+    hydrate: hydrateIncomeState,
+    serialize: serializeIncomeState,
+  });
+
+  return (
+    <IncomeDispatchContext.Provider value={dispatch}>
+      <IncomeContext.Provider value={state}>
+        {children}
+      </IncomeContext.Provider>
+    </IncomeDispatchContext.Provider>
+  );
+}

--- a/src/hooks/useDebouncedLocalStorage.ts
+++ b/src/hooks/useDebouncedLocalStorage.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Custom hook that debounces localStorage writes to prevent blocking the main thread.
+ *
+ * Instead of writing to localStorage on every state change, this hook batches writes
+ * with a configurable delay (default 500ms). This prevents long tasks warnings caused
+ * by synchronous JSON.stringify and localStorage.setItem operations.
+ *
+ * @param key - The localStorage key to write to
+ * @param value - The value to serialize and store
+ * @param serializer - Function to serialize the value (default: JSON.stringify)
+ * @param delay - Debounce delay in milliseconds (default: 500)
+ */
+export function useDebouncedLocalStorage<T>(
+    key: string,
+    value: T,
+    serializer: (val: T) => string = JSON.stringify,
+    delay: number = 500
+): void {
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const valueRef = useRef<T>(value);
+    const serializerRef = useRef(serializer);
+    const keyRef = useRef(key);
+
+    // Update refs on every render so cleanup always has latest values
+    valueRef.current = value;
+    serializerRef.current = serializer;
+    keyRef.current = key;
+
+    useEffect(() => {
+        if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+        }
+
+        timeoutRef.current = setTimeout(() => {
+            try {
+                localStorage.setItem(key, serializer(valueRef.current));
+            } catch (e) {
+                console.error(`Failed to write to localStorage key "${key}":`, e);
+            }
+        }, delay);
+
+        return () => {
+            if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+            }
+        };
+    }, [key, value, serializer, delay]);
+
+    // Write immediately on unmount to ensure data is not lost
+    useEffect(() => {
+        return () => {
+            if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+            }
+            try {
+                localStorage.setItem(keyRef.current, serializerRef.current(valueRef.current));
+            } catch (e) {
+                console.error('Failed to write to localStorage on unmount:', e);
+            }
+        };
+    }, []);
+}

--- a/src/hooks/usePersistedReducer.ts
+++ b/src/hooks/usePersistedReducer.ts
@@ -1,0 +1,96 @@
+import { useReducer, useCallback, Reducer, Dispatch } from 'react';
+import { useDebouncedLocalStorage } from './useDebouncedLocalStorage';
+
+/**
+ * Configuration for persisted reducer
+ */
+export interface PersistedReducerConfig<S> {
+    /** localStorage key for persistence */
+    storageKey: string;
+    /** Function to transform raw JSON into proper state (e.g., reconstitute classes) */
+    hydrate?: (parsed: unknown, initialState: S) => S;
+    /** Function to transform state into serializable format */
+    serialize?: (state: S) => string;
+}
+
+/**
+ * Loads state from localStorage with error handling
+ */
+function loadFromStorage<S>(
+    storageKey: string,
+    initialState: S,
+    hydrate?: (parsed: unknown, initialState: S) => S
+): S {
+    try {
+        const saved = localStorage.getItem(storageKey);
+        if (saved) {
+            const parsed = JSON.parse(saved);
+            if (hydrate) {
+                return hydrate(parsed, initialState);
+            }
+            // Default: merge parsed with initial to handle new fields
+            return { ...initialState, ...parsed };
+        }
+    } catch (e) {
+        // Silently fall back to initial state on parse errors
+    }
+    return initialState;
+}
+
+/**
+ * A hook that combines useReducer with localStorage persistence.
+ *
+ * Features:
+ * - Automatic loading from localStorage on initialization
+ * - Debounced saving to localStorage on state changes
+ * - Support for custom hydration (e.g., reconstituting class instances)
+ * - Support for custom serialization (e.g., adding className fields)
+ *
+ * @example
+ * const [state, dispatch] = usePersistedReducer(
+ *     myReducer,
+ *     initialState,
+ *     {
+ *         storageKey: 'my_data',
+ *         hydrate: (parsed, initial) => ({
+ *             ...initial,
+ *             items: parsed.items.map(reconstituteItem).filter(Boolean)
+ *         }),
+ *         serialize: (state) => JSON.stringify({
+ *             ...state,
+ *             items: state.items.map(item => ({ ...item, className: item.constructor.name }))
+ *         })
+ *     }
+ * );
+ */
+export function usePersistedReducer<S, A>(
+    reducer: Reducer<S, A>,
+    initialState: S,
+    config: PersistedReducerConfig<S>
+): [S, Dispatch<A>] {
+    const { storageKey, hydrate, serialize } = config;
+
+    // Initialize state from localStorage
+    const [state, dispatch] = useReducer(
+        reducer,
+        initialState,
+        (initial) => loadFromStorage(storageKey, initial, hydrate)
+    );
+
+    // Create serializer callback (memoized)
+    const serializer = useCallback(
+        (s: S) => {
+            if (serialize) {
+                return serialize(s);
+            }
+            return JSON.stringify(s);
+        },
+        [serialize]
+    );
+
+    // Persist to localStorage with debouncing
+    useDebouncedLocalStorage(storageKey, state, serializer);
+
+    return [state, dispatch];
+}
+

--- a/src/services/CSVImportService.ts
+++ b/src/services/CSVImportService.ts
@@ -1,0 +1,904 @@
+/**
+ * CSVImportService - Handles CSV parsing, column detection, and format matching
+ */
+
+import type {
+    Transaction,
+    CategoryMapping,
+    IncomeCategory,
+    FormatFingerprint,
+    CSVMapping,
+    CSVImportOptions,
+    SavedCSVMapping,
+} from '../components/Objects/Budget/BudgetTypes';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+// Persistence-bound types live in BudgetTypes.ts (they're stored in
+// BudgetState.importSettings.savedCSVFormats). Re-export them here so existing
+// `from '.../CSVImportService'` consumers don't have to switch paths.
+export type {
+    FormatFingerprint,
+    CSVMapping,
+    CSVImportOptions,
+    SavedCSVMapping,
+} from '../components/Objects/Budget/BudgetTypes';
+
+export interface ParsedCSV {
+    headers: string[];
+    rows: string[][];
+    hasHeaders: boolean;
+}
+
+export interface ColumnDetection {
+    columnIndex: number;
+    type: 'date' | 'description' | 'amount' | 'debit' | 'credit' | 'balance' | 'transaction_type' | 'unknown';
+    confidence: number; // 0-1
+    detectedFormat?: string; // For dates: "M/D/YYYY", etc.
+}
+
+export interface FormatMatch {
+    mapping: SavedCSVMapping;
+    confidence: number; // 1.0 = exact match, 0.7-0.99 = fuzzy match
+}
+
+export interface ImportResult {
+    transactions: Transaction[];
+    autoCategorized: number;
+    duplicates: Transaction[];
+    errors: string[];
+}
+
+// ============================================================================
+// Date Pattern Detection
+// ============================================================================
+
+const DATE_PATTERNS: { regex: RegExp; format: string }[] = [
+    { regex: /^\d{1,2}\/\d{1,2}\/\d{4}$/, format: 'M/D/YYYY' },
+    { regex: /^\d{4}-\d{2}-\d{2}$/, format: 'YYYY-MM-DD' },
+    { regex: /^\d{1,2}\/\d{1,2}\/\d{2}$/, format: 'M/D/YY' },
+    { regex: /^\d{1,2}-\d{1,2}-\d{4}$/, format: 'M-D-YYYY' },
+    { regex: /^\d{1,2}-\d{1,2}-\d{2}$/, format: 'M-D-YY' },
+    { regex: /^\d{4}\/\d{2}\/\d{2}$/, format: 'YYYY/MM/DD' },
+    { regex: /^[A-Za-z]{3}\s+\d{1,2},?\s+\d{4}$/, format: 'MMM D, YYYY' }, // "Jan 15, 2025"
+];
+
+const AMOUNT_PATTERN = /^[$\-()\d,.]+$/;
+
+// ============================================================================
+// Income Detection Patterns
+// ============================================================================
+
+/**
+ * Patterns for detecting likely income transactions during import.
+ * Each pattern maps to an income category suggestion.
+ */
+const INCOME_PATTERNS: { patterns: RegExp[]; category: IncomeCategory }[] = [
+    {
+        patterns: [
+            /payroll/i,
+            /direct\s*dep(osit)?/i,
+            /salary/i,
+            /wages/i,
+            /pay\s*check/i,
+            /employer/i,
+            /\bpay\b.*\bdep\b/i,
+        ],
+        category: 'Salary',
+    },
+    {
+        patterns: [
+            /interest\s*(payment|paid|earned)?/i,
+            /\bint\s*pmt\b/i,
+            /\bapy\b/i,
+            /savings\s*interest/i,
+        ],
+        category: 'Interest',
+    },
+    {
+        patterns: [
+            /dividend/i,
+            /\bdiv\s*(pmt|payment)?\b/i,
+            /qualified\s*div/i,
+            /stock\s*div/i,
+        ],
+        category: 'Dividends',
+    },
+    {
+        patterns: [
+            /refund/i,
+            /rebate/i,
+            /credit\s*adj/i,
+            /return\s*(credit)?/i,
+            /price\s*adj/i,
+        ],
+        category: 'Refund',
+    },
+    {
+        patterns: [
+            /venmo/i,
+            /cash\s*app/i,
+            /\bzelle\b/i,
+            /paypal/i,
+            /\bp2p\b/i,
+        ],
+        category: 'Venmo/CashApp',
+    },
+    {
+        patterns: [
+            /freelance/i,
+            /consulting/i,
+            /contractor/i,
+            /side\s*(hustle|gig|job)/i,
+            /\b1099\b/i,
+        ],
+        category: 'Side Income',
+    },
+    {
+        patterns: [
+            /gift/i,
+            /birthday/i,
+            /holiday\s*(gift)?/i,
+        ],
+        category: 'Gift',
+    },
+];
+
+/**
+ * Detect if a transaction description matches income patterns
+ * Returns the suggested income category or null if no match
+ */
+export function detectIncomeCategory(description: string): IncomeCategory | null {
+    for (const { patterns, category } of INCOME_PATTERNS) {
+        for (const pattern of patterns) {
+            if (pattern.test(description)) {
+                return category;
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * Check if a description looks like income based on patterns
+ */
+export function isLikelyIncome(description: string): boolean {
+    return detectIncomeCategory(description) !== null;
+}
+
+// ============================================================================
+// Core Functions
+// ============================================================================
+
+/**
+ * Parse a CSV string into headers and rows
+ */
+export function parseCSV(content: string): ParsedCSV {
+    // Strip UTF-8 BOM if present (common in bank CSV downloads)
+    const cleaned = content.replace(/^\uFEFF/, '');
+    const lines = cleaned.split(/\r?\n/).filter(line => line.trim());
+
+    if (lines.length === 0) {
+        return { headers: [], rows: [], hasHeaders: true };
+    }
+
+    // Parse each line, handling quoted fields
+    const parsedRows = lines.map(line => parseCSVLine(line));
+
+    // Detect if first row is headers (contains mostly text, not numbers)
+    const hasHeaders = detectHeaders(parsedRows[0] || []);
+
+    if (hasHeaders && parsedRows.length > 0) {
+        return {
+            headers: parsedRows[0],
+            rows: parsedRows.slice(1),
+            hasHeaders: true,
+        };
+    }
+
+    // Auto-generate column headers
+    const colCount = parsedRows[0]?.length || 0;
+    const headers = Array.from({ length: colCount }, (_, i) => `Column ${i + 1}`);
+
+    return {
+        headers,
+        rows: parsedRows,
+        hasHeaders: false,
+    };
+}
+
+/**
+ * Parse a single CSV line, respecting quoted fields
+ */
+function parseCSVLine(line: string): string[] {
+    const fields: string[] = [];
+    let field = '';
+    let inQuotes = false;
+
+    for (let i = 0; i < line.length; i++) {
+        const char = line[i];
+        const nextChar = line[i + 1];
+
+        if (char === '"') {
+            if (inQuotes && nextChar === '"') {
+                // Escaped quote
+                field += '"';
+                i++;
+            } else {
+                // Toggle quote state
+                inQuotes = !inQuotes;
+            }
+        } else if (char === ',' && !inQuotes) {
+            fields.push(field.trim());
+            field = '';
+        } else {
+            field += char;
+        }
+    }
+
+    // Add last field
+    fields.push(field.trim());
+
+    return fields;
+}
+
+/**
+ * Detect if a row is likely a header row
+ */
+function detectHeaders(row: string[]): boolean {
+    if (!row || row.length === 0) return false;
+
+    let textLikeCount = 0;
+    let numberLikeCount = 0;
+
+    for (const cell of row) {
+        const trimmed = cell.trim();
+        if (!trimmed) continue;
+
+        // If it looks like a pure number or currency, it's probably data
+        if (AMOUNT_PATTERN.test(trimmed) && !isNaN(parseAmount(trimmed))) {
+            numberLikeCount++;
+        } else if (/[a-zA-Z]/.test(trimmed)) {
+            textLikeCount++;
+        }
+    }
+
+    // Headers should be mostly text
+    return textLikeCount > numberLikeCount;
+}
+
+/**
+ * Detect column types from sample data
+ */
+export function detectColumnTypes(csv: ParsedCSV): ColumnDetection[] {
+    const { headers, rows } = csv;
+    const detections: ColumnDetection[] = [];
+
+    for (let colIndex = 0; colIndex < headers.length; colIndex++) {
+        const columnValues = rows.map(row => row[colIndex] || '');
+        const detection = detectSingleColumnType(colIndex, headers[colIndex], columnValues);
+        detections.push(detection);
+    }
+
+    // Post-process to distinguish debit/credit columns
+    distinguishDebitCredit(detections, rows);
+
+    return detections;
+}
+
+/**
+ * Detect the type of a single column
+ */
+function detectSingleColumnType(
+    columnIndex: number,
+    header: string,
+    values: string[]
+): ColumnDetection {
+    const nonEmpty = values.filter(v => v.trim());
+
+    if (nonEmpty.length === 0) {
+        return { columnIndex, type: 'unknown', confidence: 0 };
+    }
+
+    // Check header hints
+    const headerLower = header.toLowerCase();
+
+    // Date column hints
+    if (/date|trans|posted|time/i.test(headerLower)) {
+        const dateFormat = detectDateFormat(nonEmpty);
+        if (dateFormat) {
+            return { columnIndex, type: 'date', confidence: 0.95, detectedFormat: dateFormat };
+        }
+    }
+
+    // Description hints
+    if (/desc|description|memo|merchant|payee|details|narrative/i.test(headerLower)) {
+        return { columnIndex, type: 'description', confidence: 0.95 };
+    }
+
+    // Amount hints
+    if (/amount|total|sum|value|price/i.test(headerLower)) {
+        const amountConf = checkAmountColumn(nonEmpty);
+        if (amountConf > 0.5) {
+            return { columnIndex, type: 'amount', confidence: amountConf };
+        }
+    }
+
+    // Transaction type column (e.g., "Credit" or "Debit" values)
+    if (/transaction\s*type|trans\s*type|type/i.test(headerLower)) {
+        const isTransactionType = checkTransactionTypeColumn(nonEmpty);
+        if (isTransactionType) {
+            return { columnIndex, type: 'transaction_type', confidence: 0.95 };
+        }
+    }
+
+    // Debit/credit hints
+    if (/debit|withdrawal|payment|charge|expense/i.test(headerLower)) {
+        return { columnIndex, type: 'debit', confidence: 0.9 };
+    }
+    if (/credit|deposit|income/i.test(headerLower)) {
+        return { columnIndex, type: 'credit', confidence: 0.9 };
+    }
+
+    // Balance hint
+    if (/balance|running|total\s*balance/i.test(headerLower)) {
+        return { columnIndex, type: 'balance', confidence: 0.9 };
+    }
+
+    // Auto-detect based on content
+    const dateFormat = detectDateFormat(nonEmpty);
+    if (dateFormat) {
+        return { columnIndex, type: 'date', confidence: 0.8, detectedFormat: dateFormat };
+    }
+
+    const amountConf = checkAmountColumn(nonEmpty);
+    if (amountConf > 0.7) {
+        return { columnIndex, type: 'amount', confidence: amountConf };
+    }
+
+    // Check for description (long text, variety of content)
+    const avgLength = nonEmpty.reduce((s, v) => s + v.length, 0) / nonEmpty.length;
+    const hasVariety = new Set(nonEmpty).size > nonEmpty.length * 0.5;
+    if (avgLength > 15 && hasVariety && nonEmpty.every(v => !/^\d+$/.test(v))) {
+        return { columnIndex, type: 'description', confidence: Math.min(avgLength / 30, 0.9) };
+    }
+
+    return { columnIndex, type: 'unknown', confidence: 0 };
+}
+
+/**
+ * Detect date format from sample values
+ */
+function detectDateFormat(values: string[]): string | null {
+    for (const { regex, format } of DATE_PATTERNS) {
+        const matches = values.filter(v => regex.test(v.trim()));
+        if (matches.length >= values.length * 0.8) {
+            return format;
+        }
+    }
+    return null;
+}
+
+/**
+ * Check if column looks like amounts
+ */
+function checkAmountColumn(values: string[]): number {
+    const nonEmpty = values.filter(v => v.trim());
+    const amountMatches = nonEmpty.filter(v => {
+        const trimmed = v.trim();
+        if (!AMOUNT_PATTERN.test(trimmed)) return false;
+        const parsed = parseAmount(trimmed);
+        return !isNaN(parsed);
+    });
+
+    return amountMatches.length / nonEmpty.length;
+}
+
+/**
+ * Check if column contains transaction type values (Credit/Debit)
+ */
+function checkTransactionTypeColumn(values: string[]): boolean {
+    const nonEmpty = values.filter(v => v.trim());
+    if (nonEmpty.length === 0) return false;
+
+    const validTypes = nonEmpty.filter(v => {
+        const lower = v.trim().toLowerCase();
+        return lower === 'credit' || lower === 'debit' ||
+               lower === 'cr' || lower === 'dr' ||
+               lower === 'c' || lower === 'd';
+    });
+
+    return validTypes.length >= nonEmpty.length * 0.8;
+}
+
+/**
+ * Distinguish between debit/credit split columns
+ */
+function distinguishDebitCredit(detections: ColumnDetection[], rows: string[][]): void {
+    // Find amount columns that might be split debit/credit
+    const amountCols = detections.filter(d => d.type === 'amount');
+
+    if (amountCols.length >= 2) {
+        // Check if columns are mutually exclusive (one has value when other is empty)
+        for (let i = 0; i < amountCols.length - 1; i++) {
+            for (let j = i + 1; j < amountCols.length; j++) {
+                const col1 = amountCols[i].columnIndex;
+                const col2 = amountCols[j].columnIndex;
+
+                let mutuallyExclusive = 0;
+                let total = 0;
+
+                for (const row of rows) {
+                    const val1 = row[col1]?.trim();
+                    const val2 = row[col2]?.trim();
+                    const has1 = val1 && parseAmount(val1) !== 0;
+                    const has2 = val2 && parseAmount(val2) !== 0;
+
+                    if ((has1 && !has2) || (!has1 && has2)) {
+                        mutuallyExclusive++;
+                    }
+                    total++;
+                }
+
+                if (mutuallyExclusive / total > 0.7) {
+                    // Mark as debit/credit pair
+                    detections[col1].type = 'debit';
+                    detections[col1].confidence = 0.85;
+                    detections[col2].type = 'credit';
+                    detections[col2].confidence = 0.85;
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Format Fingerprinting & Matching
+// ============================================================================
+
+/**
+ * Generate a fingerprint for a CSV format
+ */
+export function generateFingerprint(headers: string[]): FormatFingerprint {
+    const normalized = headers
+        .map(h => h.toLowerCase().trim().replace(/[^a-z0-9]/g, ''))
+        .sort()
+        .join('|');
+
+    return {
+        headerHash: simpleHash(normalized),
+        columnCount: headers.length,
+        headers: headers,
+    };
+}
+
+/**
+ * Simple string hash function
+ */
+function simpleHash(str: string): string {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+        const char = str.charCodeAt(i);
+        hash = ((hash << 5) - hash) + char;
+        hash = hash & hash; // Convert to 32-bit integer
+    }
+    return Math.abs(hash).toString(36);
+}
+
+/**
+ * Find a matching saved format for the given CSV
+ */
+export function findMatchingFormat(
+    csv: ParsedCSV,
+    savedFormats: SavedCSVMapping[]
+): FormatMatch | null {
+    const fingerprint = generateFingerprint(csv.headers);
+
+    // 1. Exact header hash match
+    const exactMatch = savedFormats.find(f =>
+        f.fingerprint.headerHash === fingerprint.headerHash
+    );
+    if (exactMatch) {
+        return { mapping: exactMatch, confidence: 1.0 };
+    }
+
+    // 2. Fuzzy match: same column count + similar headers
+    const fuzzyMatches = savedFormats
+        .filter(f => f.fingerprint.columnCount === fingerprint.columnCount)
+        .map(f => ({
+            mapping: f,
+            similarity: calculateHeaderSimilarity(f.fingerprint.headers, csv.headers)
+        }))
+        .filter(m => m.similarity > 0.7)
+        .sort((a, b) => b.similarity - a.similarity);
+
+    if (fuzzyMatches.length > 0) {
+        return {
+            mapping: fuzzyMatches[0].mapping,
+            confidence: fuzzyMatches[0].similarity
+        };
+    }
+
+    return null;
+}
+
+/**
+ * Calculate similarity between two sets of headers
+ */
+function calculateHeaderSimilarity(headers1: string[], headers2: string[]): number {
+    if (headers1.length !== headers2.length) return 0;
+
+    const normalize = (h: string) => h.toLowerCase().trim().replace(/[^a-z0-9]/g, '');
+    const set1 = new Set(headers1.map(normalize));
+    const set2 = new Set(headers2.map(normalize));
+
+    let matches = 0;
+    for (const h of set1) {
+        if (set2.has(h)) matches++;
+    }
+
+    return matches / Math.max(set1.size, set2.size);
+}
+
+// ============================================================================
+// Transaction Conversion
+// ============================================================================
+
+/**
+ * Check if a transaction type value indicates credit
+ */
+function isTransactionTypeCredit(value: string): boolean {
+    const lower = value.trim().toLowerCase();
+    return lower === 'credit' || lower === 'cr' || lower === 'c';
+}
+
+/**
+ * Apply mapping to convert CSV rows to transactions
+ */
+export function applyMapping(
+    csv: ParsedCSV,
+    mapping: CSVMapping,
+    options: CSVImportOptions
+): Transaction[] {
+    const transactions: Transaction[] = [];
+
+    for (const row of csv.rows) {
+        const dateStr = row[mapping.dateColumn];
+        const description = row[mapping.descriptionColumn] || '';
+
+        // Parse date
+        const date = parseDate(dateStr, options.dateFormat);
+        if (!date) continue;
+
+        // Parse amount
+        let amount: number;
+        let isPossibleCredit = false;
+
+        // Check if we have a transaction type column
+        const hasTransactionType = mapping.transactionTypeColumn !== undefined;
+        const transactionTypeValue = hasTransactionType
+            ? row[mapping.transactionTypeColumn!] || ''
+            : '';
+        const isCredit = hasTransactionType && isTransactionTypeCredit(transactionTypeValue);
+
+        if (mapping.amountColumn !== undefined) {
+            amount = parseAmount(row[mapping.amountColumn] || '0');
+            // Make amount positive first, then apply sign based on type
+            amount = Math.abs(amount);
+
+            if (hasTransactionType) {
+                // Use transaction type column to determine sign
+                if (isCredit) {
+                    // Credit = positive (income/refund)
+                    isPossibleCredit = true;
+                } else {
+                    // Debit = negative (expense)
+                    amount = -amount;
+                }
+            } else if (options.negativeIsExpense) {
+                // Original logic: Negative amounts are expenses (standard bank format)
+                const originalAmount = parseAmount(row[mapping.amountColumn] || '0');
+                if (originalAmount > 0) {
+                    isPossibleCredit = true;
+                    amount = originalAmount;
+                } else {
+                    amount = originalAmount;
+                }
+            } else {
+                // Positive amounts are expenses - convert to negative
+                // Negative amounts are credits/income - flag them for review
+                const originalAmount = parseAmount(row[mapping.amountColumn] || '0');
+                if (originalAmount > 0) {
+                    amount = -originalAmount;
+                } else if (originalAmount < 0) {
+                    isPossibleCredit = true;
+                    amount = -originalAmount; // Make positive since it's income
+                }
+            }
+        } else if (mapping.debitColumn !== undefined && mapping.creditColumn !== undefined) {
+            const debit = parseAmount(row[mapping.debitColumn] || '0');
+            const credit = parseAmount(row[mapping.creditColumn] || '0');
+            // Debits are expenses (negative), credits are income (positive)
+            if (debit > 0) {
+                amount = -debit;
+            } else if (credit > 0) {
+                amount = credit;
+                isPossibleCredit = true;
+            } else {
+                continue;
+            }
+        } else {
+            continue;
+        }
+
+        if (isNaN(amount) || amount === 0) continue;
+
+        // For credit transactions, try to detect income category
+        let detectedIncomeCategory: IncomeCategory | undefined;
+        if (isPossibleCredit || amount > 0) {
+            const detected = detectIncomeCategory(description);
+            if (detected) {
+                detectedIncomeCategory = detected;
+            }
+        }
+
+        transactions.push({
+            id: `TXN-${Date.now()}-${Math.floor(Math.random() * 10000)}`,
+            date,
+            description: description.trim(),
+            amount,
+            isPossibleCredit,
+            incomeCategory: detectedIncomeCategory,
+        });
+    }
+
+    return transactions;
+}
+
+/**
+ * Parse a date string using the detected format
+ */
+function parseDate(dateStr: string, format: string): Date | null {
+    if (!dateStr) return null;
+
+    const trimmed = dateStr.trim();
+
+    try {
+        switch (format) {
+            case 'YYYY-MM-DD':
+                return new Date(trimmed + 'T00:00:00');
+            case 'M/D/YYYY':
+            case 'M-D-YYYY': {
+                const sep = format.includes('/') ? '/' : '-';
+                const parts = trimmed.split(sep);
+                if (parts.length === 3) {
+                    const [month, day, year] = parts.map(p => parseInt(p, 10));
+                    return new Date(year, month - 1, day);
+                }
+                break;
+            }
+            case 'M/D/YY':
+            case 'M-D-YY': {
+                const sep = format.includes('/') ? '/' : '-';
+                const parts = trimmed.split(sep);
+                if (parts.length === 3) {
+                    const [month, day, year] = parts.map(p => parseInt(p, 10));
+                    const fullYear = year < 50 ? 2000 + year : 1900 + year;
+                    return new Date(fullYear, month - 1, day);
+                }
+                break;
+            }
+            case 'YYYY/MM/DD': {
+                const parts = trimmed.split('/');
+                if (parts.length === 3) {
+                    const [year, month, day] = parts.map(p => parseInt(p, 10));
+                    return new Date(year, month - 1, day);
+                }
+                break;
+            }
+            case 'MMM D, YYYY': {
+                return new Date(trimmed);
+            }
+            default:
+                return new Date(trimmed);
+        }
+    } catch {
+        return null;
+    }
+
+    return null;
+}
+
+/**
+ * Parse an amount string, handling various formats
+ */
+export function parseAmount(amountStr: string): number {
+    if (!amountStr) return 0;
+
+    let cleaned = amountStr.trim();
+
+    // Check for parentheses (negative)
+    const isParenthesized = cleaned.startsWith('(') && cleaned.endsWith(')');
+    if (isParenthesized) {
+        cleaned = cleaned.slice(1, -1);
+    }
+
+    // Remove currency symbols and commas
+    cleaned = cleaned.replace(/[$€£¥,]/g, '');
+
+    // Handle negative sign
+    const isNegative = cleaned.startsWith('-') || isParenthesized;
+    cleaned = cleaned.replace(/^-/, '');
+
+    const value = parseFloat(cleaned);
+
+    return isNegative ? -value : value;
+}
+
+// ============================================================================
+// Duplicate Detection
+// ============================================================================
+
+/**
+ * Detect potential duplicate transactions
+ */
+export function detectDuplicates(
+    newTransactions: Transaction[],
+    existingTransactions: Transaction[]
+): Transaction[] {
+    const duplicates: Transaction[] = [];
+
+    for (const newTxn of newTransactions) {
+        const isDuplicate = existingTransactions.some(existing => {
+            // Same date
+            const sameDate = new Date(existing.date).toDateString() === new Date(newTxn.date).toDateString();
+            // Same amount
+            const sameAmount = Math.abs(existing.amount - newTxn.amount) < 0.01;
+            // Similar description (at least 80% match)
+            const descSimilarity = calculateStringSimilarity(
+                existing.description.toLowerCase(),
+                newTxn.description.toLowerCase()
+            );
+
+            return sameDate && sameAmount && descSimilarity > 0.8;
+        });
+
+        if (isDuplicate) {
+            duplicates.push(newTxn);
+        }
+    }
+
+    return duplicates;
+}
+
+/**
+ * Calculate string similarity (Levenshtein-based)
+ */
+function calculateStringSimilarity(s1: string, s2: string): number {
+    const longer = s1.length > s2.length ? s1 : s2;
+    const shorter = s1.length > s2.length ? s2 : s1;
+
+    if (longer.length === 0) return 1.0;
+
+    // Quick check: if shorter is contained in longer, high similarity
+    if (longer.includes(shorter)) {
+        return shorter.length / longer.length;
+    }
+
+    // Simple word-based overlap
+    const words1 = s1.split(/\s+/);
+    const words2 = s2.split(/\s+/);
+    const commonWords = words1.filter(w => words2.includes(w));
+
+    return commonWords.length / Math.max(words1.length, words2.length);
+}
+
+// ============================================================================
+// Auto-categorization
+// ============================================================================
+
+/**
+ * Apply category rules to transactions
+ */
+export function applyCategories(
+    transactions: Transaction[],
+    rules: CategoryMapping[]
+): { categorized: Transaction[]; autoCategorizedCount: number } {
+    let autoCategorizedCount = 0;
+
+    const categorized = transactions.map(txn => {
+        // Don't auto-categorize transactions that already belong elsewhere: transfers,
+        // contributions, and true income. Tagging income with an expenseId creates a
+        // contradictory state that the reconcile reads as a (negative) reimbursement.
+        const isCategorizable = !txn.isTransfer
+            && !txn.targetAccountId
+            && !(txn.amount > 0 && !txn.isReimbursement && txn.incomeCategory);
+        if (!isCategorizable) return txn;
+
+        for (const rule of rules) {
+            const matches = rule.isRegex
+                ? new RegExp(rule.pattern, 'i').test(txn.description)
+                : txn.description.toLowerCase().includes(rule.pattern.toLowerCase());
+
+            if (matches) {
+                autoCategorizedCount++;
+                return { ...txn, expenseId: rule.expenseId };
+            }
+        }
+        return txn;
+    });
+
+    return { categorized, autoCategorizedCount };
+}
+
+// ============================================================================
+// Helper to create suggested mapping from detections
+// ============================================================================
+
+/**
+ * Create a suggested mapping based on auto-detection
+ */
+export function createSuggestedMapping(detections: ColumnDetection[]): {
+    mapping: Partial<CSVMapping>;
+    options: Partial<CSVImportOptions>;
+    complete: boolean;
+} {
+    const mapping: Partial<CSVMapping> = {};
+    const options: Partial<CSVImportOptions> = {
+        hasHeaderRow: true,
+        skipRows: 0,
+        negativeIsExpense: true,
+    };
+
+    // Find date column
+    const dateCol = detections.find(d => d.type === 'date' && d.confidence > 0.5);
+    if (dateCol) {
+        mapping.dateColumn = dateCol.columnIndex;
+        options.dateFormat = dateCol.detectedFormat;
+    }
+
+    // Find description column
+    const descCol = detections.find(d => d.type === 'description' && d.confidence > 0.5);
+    if (descCol) {
+        mapping.descriptionColumn = descCol.columnIndex;
+    }
+
+    // Find transaction type column (e.g., Capital One "Transaction Type")
+    const transTypeCol = detections.find(d => d.type === 'transaction_type' && d.confidence > 0.5);
+    if (transTypeCol) {
+        mapping.transactionTypeColumn = transTypeCol.columnIndex;
+    }
+
+    // Find amount columns
+    const amountCol = detections.find(d => d.type === 'amount' && d.confidence > 0.5);
+    const debitCol = detections.find(d => d.type === 'debit' && d.confidence > 0.5);
+    const creditCol = detections.find(d => d.type === 'credit' && d.confidence > 0.5);
+
+    if (amountCol) {
+        mapping.amountColumn = amountCol.columnIndex;
+    } else if (debitCol && creditCol) {
+        mapping.debitColumn = debitCol.columnIndex;
+        mapping.creditColumn = creditCol.columnIndex;
+    }
+
+    // Check if mapping is complete
+    const hasDate = mapping.dateColumn !== undefined;
+    const hasDesc = mapping.descriptionColumn !== undefined;
+    const hasAmount = mapping.amountColumn !== undefined ||
+                      (mapping.debitColumn !== undefined && mapping.creditColumn !== undefined);
+
+    return {
+        mapping,
+        options,
+        complete: hasDate && hasDesc && hasAmount,
+    };
+}
+
+/**
+ * Generate unique ID for saved mapping
+ */
+export function generateMappingId(): string {
+    return `FMT-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+}

--- a/src/services/SSAImportService.ts
+++ b/src/services/SSAImportService.ts
@@ -1,0 +1,158 @@
+/**
+ * SSA XML Import Service
+ *
+ * Parses Social Security Administration XML export files to extract
+ * earnings history for use in benefit calculations.
+ *
+ * XML Format (from ssa.gov):
+ * <osss:EarningsRecord>
+ *   <osss:Earnings startYear="2020" endYear="2020">
+ *     <osss:FicaEarnings>50000</osss:FicaEarnings>
+ *     <osss:MedicareEarnings>50000</osss:MedicareEarnings>
+ *   </osss:Earnings>
+ * </osss:EarningsRecord>
+ */
+
+import { EarningsRecord } from './SocialSecurityCalculator';
+
+export interface SSAEarningsImport {
+  earnings: EarningsRecord[];
+  dateOfBirth?: string;
+  name?: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  warnings: string[];
+}
+
+/**
+ * Parse SSA XML export file and extract earnings history.
+ * Handles both full XML files and EarningsRecord snippets.
+ * Works with or without the osss: namespace prefix.
+ */
+export function parseSSAXml(xmlString: string): SSAEarningsImport {
+  // Wrap snippet in root element if needed (for pasted EarningsRecord sections)
+  let xmlToParse = xmlString.trim();
+  if (!xmlToParse.startsWith('<?xml') && !xmlToParse.includes('OnlineSocialSecurityStatementData')) {
+    xmlToParse = `<?xml version="1.0"?><root>${xmlToParse}</root>`;
+  }
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xmlToParse, 'text/xml');
+
+  // Check for parse errors
+  const parseError = doc.querySelector('parsererror');
+  if (parseError) {
+    throw new Error('Invalid XML format');
+  }
+
+  const earnings: EarningsRecord[] = [];
+
+  // Find all Earnings elements (handles both osss:Earnings and Earnings)
+  // querySelectorAll with local-name() doesn't work, so we try both patterns
+  let earningsElements: Element[] = Array.from(doc.querySelectorAll('Earnings'));
+
+  // If no elements found with simple selector, try getElementsByTagName which handles namespaces
+  if (earningsElements.length === 0) {
+    earningsElements = Array.from(doc.getElementsByTagName('osss:Earnings'));
+  }
+
+  earningsElements.forEach(el => {
+    const startYear = el.getAttribute('startYear');
+    const year = parseInt(startYear || '0', 10);
+
+    // Find FicaEarnings - try both with and without namespace
+    let ficaElement = el.querySelector('FicaEarnings');
+    if (!ficaElement) {
+      // Try with namespace
+      const ficaElements = el.getElementsByTagName('osss:FicaEarnings');
+      ficaElement = ficaElements[0] || null;
+    }
+
+    const ficaEarnings = parseInt(ficaElement?.textContent || '0', 10);
+
+    // Filter out invalid entries:
+    // - year must be valid
+    // - earnings must be positive (-1 means "not yet recorded")
+    if (year > 0 && ficaEarnings > 0) {
+      earnings.push({ year, amount: ficaEarnings });
+    }
+  });
+
+  // Sort by year ascending
+  earnings.sort((a, b) => a.year - b.year);
+
+  // Extract optional user info
+  let dateOfBirth: string | undefined;
+  let name: string | undefined;
+
+  const dobElement = doc.querySelector('DateOfBirth') ||
+                     doc.getElementsByTagName('osss:DateOfBirth')[0];
+  if (dobElement?.textContent) {
+    // Parse ISO date format: 2001-04-11T00:00:00 or just 2001-04-11
+    dateOfBirth = dobElement.textContent.split('T')[0];
+  }
+
+  const nameElement = doc.querySelector('Name') ||
+                      doc.getElementsByTagName('osss:Name')[0];
+  if (nameElement?.textContent) {
+    name = nameElement.textContent;
+  }
+
+  return { earnings, dateOfBirth, name };
+}
+
+/**
+ * Validate imported earnings against app's birth year.
+ * Returns warnings for suspicious data but doesn't block import.
+ */
+export function validateEarningsImport(
+  earnings: EarningsRecord[],
+  appBirthYear: number
+): ValidationResult {
+  const warnings: string[] = [];
+
+  if (earnings.length === 0) {
+    warnings.push('No valid earnings records found');
+    return { valid: false, warnings };
+  }
+
+  // Check if any earnings are before a reasonable working age (14)
+  const earliestYear = Math.min(...earnings.map(e => e.year));
+  const ageAtFirstEarnings = earliestYear - appBirthYear;
+  if (ageAtFirstEarnings < 14) {
+    warnings.push(
+      `Earliest earnings (${earliestYear}) would be at age ${ageAtFirstEarnings}. ` +
+      `This may indicate a birth year mismatch.`
+    );
+  }
+
+  // Check for suspiciously old earnings (before 1951 - SS started tracking)
+  if (earliestYear < 1951) {
+    warnings.push(`Earnings found before 1951 (${earliestYear}), which is before SS records began`);
+  }
+
+  // Check for future years that slipped through
+  const currentYear = new Date().getFullYear();
+  const futureEarnings = earnings.filter(e => e.year > currentYear);
+  if (futureEarnings.length > 0) {
+    warnings.push(`Found ${futureEarnings.length} future year(s) which will be ignored`);
+  }
+
+  return { valid: warnings.length === 0, warnings };
+}
+
+/**
+ * Format earnings summary for display
+ */
+export function formatEarningsSummary(earnings: EarningsRecord[]): string {
+  if (earnings.length === 0) return 'No earnings';
+
+  const years = earnings.map(e => e.year).sort((a, b) => a - b);
+  const firstYear = years[0];
+  const lastYear = years[years.length - 1];
+  const totalEarnings = earnings.reduce((sum, e) => sum + e.amount, 0);
+
+  return `${earnings.length} years (${firstYear}-${lastYear}), $${totalEarnings.toLocaleString()} total`;
+}

--- a/src/services/backupMerge.ts
+++ b/src/services/backupMerge.ts
@@ -1,0 +1,340 @@
+/**
+ * backupMerge - headless, React-free merge of new SimpleFIN data into a decrypted
+ * Stag backup blob. This is the single source of truth that the in-app import UI
+ * (reducers in BudgetContext / AccountContext) and the headless stag-feed importer
+ * must agree on, so neither hand-mirrors the other.
+ *
+ * It operates on a *plain decrypted FullBackup object* (post-JSON.parse, no class
+ * reconstitution) and mutates it in place, returning a report. Fold repeatedly
+ * against the same working blob; don't recreate it between calls.
+ *
+ * Mirrors three pieces of in-app behavior exactly:
+ *   - BudgetContext `getOrCreateMonth` + `BULK_ADD_TRANSACTIONS` (append txns,
+ *     creating the month snapshot if missing).
+ *   - AccountContext `ADD_AMOUNT_SNAPSHOT` (append {date,num} to amountHistory[id],
+ *     replacing the last entry when it shares the same date => idempotent per day).
+ *   - ImportBalancesModal `handleApply` (BOTH the account.amount write AND the
+ *     history snapshot — the simulation reads account.amount, not the history tail).
+ *
+ * If you change those reducers, change this file (and backupMerge.test.ts) to match.
+ *
+ * Tolerates both v1 (no budget / no balanceAccountMap) and v2 blobs.
+ */
+
+import { applyCategories, detectDuplicates, detectIncomeCategory } from './CSVImportService';
+import { autoMatchAccount } from './simplefinBalances';
+import type { Transaction, CategoryMapping, MonthlySnapshot, BudgetState } from '../components/Objects/Budget/BudgetTypes';
+
+// --- The structural subset of a decrypted FullBackup these helpers read/mutate ---
+
+export interface AmountPoint {
+    date: string; // YYYY-MM-DD
+    num: number;
+}
+
+export interface MergeableAccount {
+    id: string;
+    name: string;
+    amount?: number;
+    [k: string]: unknown;
+}
+
+export interface MergeBlob {
+    version?: number;
+    accounts: MergeableAccount[];
+    amountHistory: Record<string, AmountPoint[]>;
+    budget?: BudgetState;
+    /** csvAccount -> appAccountId[] (present in v2 blobs). */
+    balanceAccountMap?: Record<string, string[]>;
+    [k: string]: unknown;
+}
+
+// --- Reports ---
+
+export interface TransactionMergeReport {
+    added: number;
+    duplicatesSkipped: number;
+    autoCategorized: number;
+    /** "YYYY-M" -> count appended */
+    byMonth: Record<string, number>;
+}
+
+export interface BalanceUpdate {
+    id: string;
+    name: string;
+    amount: number;
+}
+
+export interface BalanceFlag {
+    /** SimpleFIN account key from the input row. */
+    account: string;
+    reason:
+        | 'unmapped'             // no mapping and no confident auto-match
+        | 'auto-matched'         // not in the map, but matched a single account by name
+        | 'multi-target-split'   // one balance split across several accounts by weight
+        | 'missing-account';     // mapped id no longer exists in the blob
+}
+
+export interface BalanceMergeReport {
+    updated: BalanceUpdate[];
+    flagged: BalanceFlag[];
+}
+
+export interface BalanceRowInput {
+    /** SimpleFIN account key — matches the keys in balanceAccountMap. */
+    account: string;
+    /** Current balance (may be negative for debts/credit cards). */
+    balance: number;
+}
+
+export interface NewTransactionInput {
+    /** Stable unique id. For a stable source (SimpleFIN), use its txn id so
+     *  exact id-dedup works across overlapping re-fetches. */
+    id: string;
+    /** Posted date as 'YYYY-MM-DD'. */
+    date: string;
+    description: string;
+    /** Signed amount in Stag's convention: money out = negative. */
+    amount: number;
+}
+
+export interface ApplyTransactionsOptions {
+    /**
+     * 'fuzzy' (default): date + amount ±$0.01 + ~80% description similarity —
+     *   mirrors the in-app manual-CSV importer, for sources without stable ids.
+     * 'id': exact match on Transaction.id against existing txns — correct for a
+     *   stable-id source (keeps two genuinely-distinct same-day/same-amount
+     *   charges; suppresses only true re-fetches of the same id).
+     */
+    dedup?: 'fuzzy' | 'id';
+}
+
+/**
+ * Build a Transaction from a stable source, mirroring CSVImportService.applyMapping's
+ * flagging so the headless path and the in-app path agree:
+ *   - date -> a local-midnight Date (matches parseDate('YYYY-MM-DD'); avoids the
+ *     UTC-bucketing-into-the-prior-month boundary bug on negative-offset runners),
+ *   - isPossibleCredit = amount > 0,
+ *   - incomeCategory via detectIncomeCategory for credits.
+ * expenseId is left for applyCategories; isReimbursement/isTransfer/accountId/
+ * statementDate default off, exactly as applyMapping leaves them.
+ */
+export function makeTransaction(input: NewTransactionInput): Transaction {
+    const isPossibleCredit = input.amount > 0;
+    return {
+        id: input.id,
+        date: new Date(`${input.date}T00:00:00`),
+        description: input.description.trim(),
+        amount: input.amount,
+        isPossibleCredit,
+        incomeCategory: isPossibleCredit ? (detectIncomeCategory(input.description) ?? undefined) : undefined,
+    };
+}
+
+// --- Small helpers (mirror the app) ---
+
+function generateMonthId(): string {
+    // Mirrors BudgetContext.generateId('MONTH').
+    return `MONTH-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+}
+
+function localToday(): string {
+    // Mirrors AccountContext.getTodayString(): local run-day date (not UTC, which
+    // would stamp tomorrow's date in the evening of a negative-offset timezone).
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function round2(n: number): number {
+    return Math.round(n * 100) / 100;
+}
+
+/**
+ * Find or create the month snapshot in the blob (mutates blob.budget.months).
+ * Creates a default budget container if the blob has none (v1 backups).
+ */
+function getOrCreateMonth(blob: MergeBlob, month: number, year: number): MonthlySnapshot {
+    if (!blob.budget) {
+        blob.budget = {
+            months: [],
+            importSettings: {
+                dateColumn: '',
+                amountColumn: '',
+                descriptionColumn: '',
+                categoryMappings: [],
+                savedCSVFormats: [],
+                autoCreateRules: false,
+            },
+            selectedMonth: month,
+            selectedYear: year,
+        };
+    }
+    const existing = blob.budget.months.find(m => m.month === month && m.year === year);
+    if (existing) return existing;
+
+    const created: MonthlySnapshot = {
+        id: generateMonthId(),
+        month,
+        year,
+        spending: {},
+        accountBalances: {},
+        contributions: {},
+        transactions: [],
+        reconciled: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    };
+    blob.budget.months.push(created);
+    return created;
+}
+
+/** Mirror of AccountContext ADD_AMOUNT_SNAPSHOT, but date is caller-controlled. */
+function addAmountSnapshot(blob: MergeBlob, id: string, amount: number, date: string): void {
+    const history = blob.amountHistory[id] ?? [];
+    const last = history[history.length - 1];
+    const entry: AmountPoint = { date, num: amount };
+    blob.amountHistory[id] = last?.date === date
+        ? [...history.slice(0, -1), entry]
+        : [...history, entry];
+}
+
+// --- Public API ---
+
+/**
+ * Merge incoming transactions into the blob. Pipeline mirrors useCSVImportFlow:
+ * auto-categorize -> detect duplicates against ALL existing blob transactions ->
+ * drop duplicates -> bucket by month -> append (creating months as needed).
+ *
+ * `incoming` is already parsed into Transactions (build them directly, or via
+ * CSVImportService's parse functions). Each must carry a stable, unique `id`;
+ * dates should be ISO strings since the blob is JSON.
+ */
+export function applyTransactions(
+    blob: MergeBlob,
+    incoming: Transaction[],
+    opts: ApplyTransactionsOptions = {}
+): TransactionMergeReport {
+    const report: TransactionMergeReport = {
+        added: 0,
+        duplicatesSkipped: 0,
+        autoCategorized: 0,
+        byMonth: {},
+    };
+    if (incoming.length === 0) return report;
+
+    const rules: CategoryMapping[] = blob.budget?.importSettings?.categoryMappings ?? [];
+
+    // Existing transactions across every month — the dedup universe.
+    const existing: Transaction[] = (blob.budget?.months ?? []).flatMap(m => m.transactions ?? []);
+
+    const { categorized, autoCategorizedCount } = applyCategories(incoming, rules);
+
+    let toAdd: Transaction[];
+    if ((opts.dedup ?? 'fuzzy') === 'id') {
+        const existingIds = new Set(existing.map(e => e.id));
+        toAdd = categorized.filter(t => !existingIds.has(t.id));
+    } else {
+        const dupeIds = new Set(detectDuplicates(categorized, existing).map(d => d.id));
+        toAdd = categorized.filter(t => !dupeIds.has(t.id));
+    }
+
+    report.autoCategorized = autoCategorizedCount;
+    report.duplicatesSkipped = categorized.length - toAdd.length;
+
+    // Bucket by month/year exactly as the UI does.
+    const byMonth: Record<string, Transaction[]> = {};
+    for (const txn of toAdd) {
+        const d = new Date(txn.date);
+        const key = `${d.getFullYear()}-${d.getMonth() + 1}`;
+        (byMonth[key] ??= []).push(txn);
+    }
+
+    for (const [key, txns] of Object.entries(byMonth)) {
+        const [yearStr, monthStr] = key.split('-');
+        const snapshot = getOrCreateMonth(blob, parseInt(monthStr, 10), parseInt(yearStr, 10));
+        snapshot.transactions = [...snapshot.transactions, ...txns];
+        snapshot.updatedAt = new Date();
+        report.byMonth[key] = txns.length;
+        report.added += txns.length;
+    }
+
+    return report;
+}
+
+/**
+ * Apply SimpleFIN balances to the blob. For each row:
+ *   - 1 mapped account  -> apply the full balance.
+ *   - N mapped accounts -> split by current-balance weight (splitByWeight); even
+ *     split when all current balances are zero. Flagged 'multi-target-split'.
+ *   - no mapping        -> try a confident name auto-match (flagged 'auto-matched');
+ *                          otherwise flagged 'unmapped' and skipped.
+ * Each applied account gets BOTH writes: account.amount and a history snapshot.
+ *
+ * `date` defaults to the UTC run-date, matching the in-app reducer (idempotent
+ * per day). Pass an explicit date only if you intend to own same-date dedup.
+ */
+export function applyBalances(
+    blob: MergeBlob,
+    rows: BalanceRowInput[],
+    opts: { date?: string } = {}
+): BalanceMergeReport {
+    const date = opts.date ?? localToday();
+    const map = blob.balanceAccountMap ?? {};
+    const report: BalanceMergeReport = { updated: [], flagged: [] };
+
+    const accountById = new Map(blob.accounts.map(a => [a.id, a]));
+
+    const applyOne = (id: string, value: number) => {
+        const account = accountById.get(id);
+        if (!account) return false;
+        account.amount = value;
+        addAmountSnapshot(blob, id, value, date);
+        report.updated.push({ id, name: account.name, amount: value });
+        return true;
+    };
+
+    for (const row of rows) {
+        const targetIds = map[row.account];
+
+        // Fallback: no explicit mapping -> attempt a confident single auto-match.
+        if (!targetIds || targetIds.length === 0) {
+            const matched = autoMatchAccount(row.account, blob.accounts);
+            if (matched) {
+                applyOne(matched, round2(row.balance));
+                report.flagged.push({ account: row.account, reason: 'auto-matched' });
+            } else {
+                report.flagged.push({ account: row.account, reason: 'unmapped' });
+            }
+            continue;
+        }
+
+        if (targetIds.length === 1) {
+            const ok = applyOne(targetIds[0], round2(row.balance));
+            if (!ok) report.flagged.push({ account: row.account, reason: 'missing-account' });
+            continue;
+        }
+
+        // Multi-target: split by current-balance weight.
+        const present = targetIds.filter(id => accountById.has(id));
+        if (present.length === 0) {
+            report.flagged.push({ account: row.account, reason: 'missing-account' });
+            continue;
+        }
+        const weights = present.map(id => Math.abs(accountById.get(id)!.amount ?? 0));
+        const totalWeight = weights.reduce((s, w) => s + w, 0);
+
+        let allocated = 0;
+        present.forEach((id, i) => {
+            // Last account absorbs the rounding remainder so the split sums exactly.
+            const isLast = i === present.length - 1;
+            const share = isLast
+                ? round2(row.balance - allocated)
+                : round2(totalWeight > 0 ? row.balance * (weights[i] / totalWeight) : row.balance / present.length);
+            allocated = round2(allocated + share);
+            applyOne(id, share);
+        });
+        report.flagged.push({ account: row.account, reason: 'multi-target-split' });
+    }
+
+    return report;
+}

--- a/src/services/cloud/CloudBackupService.ts
+++ b/src/services/cloud/CloudBackupService.ts
@@ -1,0 +1,163 @@
+/**
+ * Cloud backup service. Encrypts client-side and stores the ciphertext blob
+ * directly via the backend's /backup endpoint (CouchDB-backed). The server only
+ * ever holds ciphertext it cannot read.
+ *
+ * Concurrency: the browser and the headless stag-feed process both write the
+ * same per-user document, so writes carry the last-seen `rev` (CouchDB `_rev`,
+ * opaque to us). The backend rejects a stale write with 409; callers must then
+ * re-download and retry rather than clobber.
+ */
+
+import { EncryptedBackup, encrypt, decrypt } from '../encryption/CryptoService';
+
+export interface BackupMetadata {
+    exists: boolean;
+    timestamp: string | null;
+    size: number | null;
+    rev: string | null;
+}
+
+export interface DownloadResult {
+    plaintext: string;
+    rev: string | null;
+}
+
+export class BackupConflictError extends Error {
+    constructor() {
+        super('Cloud copy changed since your last sync. Restore first, then back up.');
+        this.name = 'BackupConflictError';
+    }
+}
+
+const MAX_BACKUP_SIZE = 5 * 1024 * 1024; // 5 MB
+
+function authHeaders(idToken: string): Record<string, string> {
+    return { Authorization: `Bearer ${idToken}` };
+}
+
+/**
+ * Encrypt and upload the backup blob. Sends the last-seen `rev` for optimistic
+ * locking; throws BackupConflictError on a 409 (someone wrote since we read).
+ */
+export async function uploadBackup(
+    apiEndpoint: string,
+    idToken: string,
+    plaintext: string,
+    passphrase: string,
+    rev: string | null
+): Promise<{ timestamp: string; rev: string | null }> {
+    const envelope = await encrypt(plaintext, passphrase);
+    const blob = JSON.stringify(envelope);
+
+    const blobSize = new Blob([blob]).size;
+    if (blobSize > MAX_BACKUP_SIZE) {
+        const sizeMB = (blobSize / (1024 * 1024)).toFixed(2);
+        throw new Error(
+            `Backup size (${sizeMB} MB) exceeds the 5 MB limit. ` +
+            `Try removing unused accounts or historical data to reduce the size.`
+        );
+    }
+
+    const response = await fetch(`${apiEndpoint}/backup`, {
+        method: 'POST',
+        headers: {
+            ...authHeaders(idToken),
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ blob, rev }),
+    });
+
+    if (response.status === 409) {
+        throw new BackupConflictError();
+    }
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Upload failed: ${response.status} ${errorText}`);
+    }
+
+    const data = await response.json();
+    return { timestamp: data.timestamp ?? envelope.timestamp, rev: data.rev ?? null };
+}
+
+/**
+ * Download and decrypt the backup. Returns the plaintext and the blob's current
+ * `rev` so the caller can send it back on the next write.
+ */
+export async function downloadBackup(
+    apiEndpoint: string,
+    idToken: string,
+    passphrase: string
+): Promise<DownloadResult> {
+    const response = await fetch(`${apiEndpoint}/backup`, {
+        method: 'GET',
+        headers: authHeaders(idToken),
+    });
+
+    if (response.status === 404) {
+        throw new Error('No cloud backup found.');
+    }
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Download failed: ${response.status} ${errorText}`);
+    }
+
+    const data = await response.json();
+    if (!data?.blob) {
+        throw new Error('No cloud backup found.');
+    }
+
+    const envelope: EncryptedBackup = JSON.parse(data.blob);
+    const plaintext = await decrypt(envelope, passphrase);
+    return { plaintext, rev: data.rev ?? null };
+}
+
+/**
+ * Check whether a backup exists and read its metadata (including current rev).
+ */
+export async function getBackupMetadata(
+    apiEndpoint: string,
+    idToken: string
+): Promise<BackupMetadata> {
+    const response = await fetch(`${apiEndpoint}/backup`, {
+        method: 'GET',
+        headers: authHeaders(idToken),
+    });
+
+    if (response.status === 404) {
+        return { exists: false, timestamp: null, size: null, rev: null };
+    }
+    if (!response.ok) {
+        throw new Error(`Failed to check backup: ${response.status}`);
+    }
+
+    const data = await response.json();
+    if (!data?.blob) {
+        return { exists: false, timestamp: null, size: null, rev: data?.rev ?? null };
+    }
+
+    return {
+        exists: true,
+        timestamp: data.timestamp ?? null,
+        size: data.size ?? null,
+        rev: data.rev ?? null,
+    };
+}
+
+/**
+ * Delete the cloud backup.
+ */
+export async function deleteBackup(
+    apiEndpoint: string,
+    idToken: string
+): Promise<void> {
+    const response = await fetch(`${apiEndpoint}/backup`, {
+        method: 'DELETE',
+        headers: authHeaders(idToken),
+    });
+
+    if (!response.ok && response.status !== 404) {
+        const errorText = await response.text();
+        throw new Error(`Failed to delete backup: ${response.status} ${errorText}`);
+    }
+}


### PR DESCRIPTION
Scoped review of the persistence layer: localStorage hydration (contexts +
persisted-reducer hooks), backup merge, CSV/SSA import, QR transfer
compression, and cloud backup. Most of this has NOT been through a scoped
review before. ONLY the source files added in the diff are under review. The
test files in this branch are a behavioral reference ONLY (not in the diff)
and may be wrong or timezone-dependent: if source and a test disagree, flag it
as a question, do not assume the test.

ADJUDICATIONS: code-review-pr-50.md … code-review-pr-53.md (in this tree, base
commit) record findings already fixed or ruled by-design — do not resurface
wont-fixes.

Recurring problem areas that have actually bitten us here — extra scrutiny:

  1. Deep-merge dropping saved-only fields. A merge that iterates only the
     keys present in the DEFAULTS silently drops fields that exist only in
     the saved data (e.g. imported SSA earnings) on reload. Check every
     merge/hydration path: context reducers' load, backupMerge, cloud
     restore. This is PR #53-era problem area 5 and the single most likely
     real-data-loss class in the app.
  2. QR key-shortening round-trip. qrUtils' key map must round-trip every
     persisted field — a field added to a model but missing from the map (or
     mapped twice to the same short key) corrupts QR backups. Date objects
     need special handling in shortenKeys (known sharp edge). Legacy short
     keys (e.g. 'gv' for the removed goalTargetDate) must keep DECODING even
     though nothing writes them anymore.
  3. Reconstitution ordering + migration. Legacy-data migrations live in
     reconstitute* (e.g. goalTargetDate -> endDate, 2026-06); hydration paths
     that bypass reconstitute (direct JSON.parse) skip migrations. Find any.
  4. Date round-trips. toISOString()/new Date('YYYY-MM-DD') UTC-parse
     off-by-one for date-only values (repo-wide recurring bug; the CSV/SSA
     importers and AddESPPLotModal-style `new Date(dateString)` calls are the
     usual suspects). Storage should round-trip through formatDateForInput/
     parseDate.
  5. Write races. Debounced localStorage writes vs imports that dispatch many
     actions: an import immediately followed by a reload can persist a stale
     snapshot; ImportKeyContext remounts charts but does not flush writes.
  6. Balance-history integrity. CSV "Import balances" + amountHistory: 401k
     split handling, duplicate-date entries, and merge of history arrays in
     backupMerge (last-write vs union).
  7. Cloud backup (self-hosted CouchDB /backup). Merge semantics shared with
     local backupMerge — verify both call the SAME helper and neither has
     drifted; auth-failure paths must not wipe local state.

Output: ranked findings, each with a concrete failure scenario
(inputs/state -> wrong output). Findings that can't name a trigger should say
so explicitly.