### PR TITLE
Campaign 7 fact-check: verify the review fixes against their claims

### DIFF
--- a/code-review-pr54.md
+++ b/code-review-pr54.md
@@ -1,0 +1,20 @@
+# PR #54 review — outstanding tasks
+
+13 of the 15 review findings are fixed and committed to `main`
+(commits `55e4ab5`, `2aaa8bf`, `0f843fb`, `69fc644`, `c6ed1fa`). The two below
+were **not** shipped — each is a deliberate design/policy decision rather than a
+defect, so they need a product call before changing.
+
+---
+
+## #6 — State Social-Security treatment is hardcoded exempt in the solver/planner
+- **Where:** `src/services/simulation/YearSolver.ts` (authoritative state tax, ~1567/1601) and `src/services/simulation/WithdrawalPlanner.ts` (~824)
+- **What:** State tax is computed via the low-level bracket function with taxable SS manually stripped (`allOrdinaryIncome - currentSSTaxable`), hardcoding "SS exempt" for every state. This bypasses the data-driven `socialSecurityTreatment` flag that `stateTax.ts` and `RothConversionDP.ts` (which checks `=== 'taxable'`) honor.
+- **Status:** **Latent** — every state in `TaxData` is currently `socialSecurityTreatment: 'exempt'`, so the result is correct today. The inline SS-stripping looks like the same deliberate choice as #15.
+- **Decision needed:** If a `'taxable'` state is ever added (CO/CT/MN/etc. tax SS in reality), the solver/planner would silently undercharge state tax. Worth routing state tax through the SS-treatment-aware path **only if** taxable-SS states will be modeled. Otherwise leave as-is.
+
+## #15 — ACA FPL cliff is clamped flat for years beyond the published table
+- **Where:** `src/services/simulation/TaxOptimizedWithdrawal.ts` — `getAcaCliffThreshold`
+- **What:** `FPL_BASE` has explicit entries only through 2026; later years reuse the most recent known value instead of growing it with inflation.
+- **Status:** **Intentional design.** Implementing "grow the cliff ~3%/yr past the table" broke 3 existing tests under a describe block named *"Future Years (Uses Most Recent Known)"* — the flat-clamp is documented behavior. Reverted.
+- **Decision needed:** Policy call — clamp (conservative, current behavior) vs. project FPL forward by inflation (more realistic for long projections, but speculative). If you want it projected, the existing "Future Years" tests must be updated to expect the grown values.

--- a/code-review-pr55.md
+++ b/code-review-pr55.md
@@ -1,0 +1,162 @@
+# Code Review — PR #55 (`review/tax-7`)
+
+**Scope:** tax services + tax data tables (source) — 14 files, +2169 lines, purely additive.
+**Effort:** xhigh (9 finder angles — 5 correctness / 3 cleanup / 1 altitude — + verify + gap sweep).
+
+## Setup caveat
+Campaign-7 scoped-review PR: the reviewed source is identical to `main`, so findings were
+validated against the real tree. The federal math engine was traced against IRS worksheets
+(17+ cases — provisional income, taxable-SS, bracket walk, LTCG stacking, NIIT) with **no**
+correctness bug found. The cross-file tracer confirmed `tsc -b` exits 0 — no signature,
+return-shape, or import breaks at any call site. This is mature, already-reviewed code
+(it passed PR #54), so the surviving items are modeling inconsistencies and cleanup, not
+high-severity defects.
+
+---
+
+## Resolution (applied to `main`, full suite green: 121 files / 3383 tests, `tsc -b` clean)
+
+All 13 findings were fixed in parallel by five isolated worktree agents (one per file group),
+each writing a red→green or characterization test before its fix; the branches were cherry-picked
+onto `main` (commits `73248f5`, `6075a54`, `57f161e`, `96d8877`, `583409a`) and one reconciliation
+commit (`0aa7a6a`) resolved two cross-fix test interactions.
+
+| # | Finding | Disposition | Commit |
+|---|---------|-------------|--------|
+| 1 | Additional Medicare missing from combined marginal rate | **Fixed** — shared `getAdditionalMedicareThreshold` helper; `+0.009` above threshold | `6075a54` |
+| 2 | `seniorDeduction` not inflated in projection branch | **Fixed** — inflate `seniorDeduction` (+ unpopulated `ssExemptionThreshold`/`retirementIncomeExemption`) | `73248f5` |
+| 3 | 2024 Single brackets off-by-one (`+1` convention) | **Fixed** — corrected to breakpoint values; 5 existing boundary assertions updated | `583409a` |
+| 4 | No deflation below the data range | **Deferred — out of scope/risky** (forward-only projection); noted, not implemented | — |
+| 5 | NaN if partial `assumptions` lacks `inflationRate` | **Fixed** — `Number.isFinite` guard → treat as 0% | `73248f5` |
+| 6 | Nearest-year tie-break prefers older year | **Fixed** (`<`→`<=` in shared `findNearestYear`) — latent, not separately unit-tested | `73248f5` |
+| 7 | `calculateUnifiedStateTax` duplicates `calculateStateTax` | **Fixed** — shared `computeStateTaxFromGross`; base delegates with `additional=0` | `57f161e` |
+| 8 | State tax computed then discarded under `Standard` | **Fixed** — SALT/itemized block guarded by `deductionMethod !== 'Standard'` | `57f161e` |
+| 9 | Duplicated nearest-year reducer (+ memoization) | **Partially fixed** — reducer extracted; memoization left out (out of scope) | `73248f5` |
+| 10 | `getPre/PostTaxExemptions` duplication | **Fixed** — shared `resolveEffective401k(...,'preTax'|'roth')` | `96d8877` |
+| 11 | Redundant `if (totalSSBenefits > 0)` wrapper | **Fixed** — flattened into the shared state-tax helper | `57f161e` |
+| 12 | `\|\| 14600` falsy-zero fallback | **Fixed** (`?? 14600` / `?? 0`) — latent, not separately unit-tested | `6075a54` |
+| 13 | `(exp as any).tax_deductible \|\| 0` cast | **Fixed** — `hasTaxDeductible` type guard, no `as any`, `?? 0` | `96d8877` |
+
+**Net: 11 fixed, 1 partially fixed (#9 — reducer extracted, memoization deferred), 1 deferred (#4).**
+
+Each behavioral fix shipped with a red→green test; the refactors (#7/#8/#9/#10/#11/#13) shipped with
+characterization tests verified green against the original code first. Two cross-fix interactions were
+reconciled in `0aa7a6a`: the #1 surtax made a pre-existing "Medicare-only above wage base" test collide
+with the $200k threshold (income moved to $175k, preserving its intent), and the #3 bracket fix shifted
+three #8 characterization values by exactly $0.10 (the correct post-fix amounts).
+
+**Flagged for a future pass (not in this scope):** `calculateFederalTaxFromIncomes` with
+`deductionMethod: 'Auto'` returns its own internally-computed min, which does **not** equal
+`min(standalone Standard, standalone Itemized)` (e.g. 13427.08 vs 13356.44 for the same inputs). Pinned
+as a regression guard in `ReviewFixes_PR55_stateTax.test.ts`; worth confirming the divergence is intended.
+
+---
+
+## Findings
+
+### 1. [Confirmed · Med] `marginalRates.ts:110` — combined marginal rate omits 0.9% Additional Medicare
+`getCombinedMarginalRate` builds `ficaRate` as SS + Medicare (or Medicare-only above the wage
+base) but never adds the **0.9% Additional Medicare surtax** above the filing-status threshold —
+the opposite direction from `calculateFicaTax:32`, which *does* charge it. Single filer, earned
+income $260k, `includesFICA=true`: realized FICA includes 0.9% on the $60k over $200k, but the
+marginal rate returns `fica=0.0145`. `TaxOptimizationService.ts` (196/464/579/888) sizes
+conversions/withdrawals off this understated rate, so the optimizer's estimate disagrees with the
+tax it actually realizes above $200k/$250k/$125k. No test covers >$200k earned income with FICA,
+so the gap isn't locked in.
+
+### 2. [Confirmed · Med] `parameters.ts:116` — inflation branch leaves `seniorDeduction` un-inflated
+The `year > max_year` branch inflates `standardDeduction`, `brackets`, `socialSecurityWageBase`,
+and `capitalGainsBrackets`, but spreads `seniorDeduction` (and the other state-only thresholds)
+through from the base year via `...baseYearParams`, un-inflated. Virginia, MFJ, 65+, year 2050,
+`inflationAdjusted=true`: brackets and the $17,500 standard deduction scale ~1.85×, but
+`seniorDeduction` stays $12,000 (then doubled to $24k in `stateTax.ts`). Because the app projects
+**every** year past 2026 through this branch, a VA senior's age deduction erodes in real terms in
+every projected year, overstating VA tax.
+
+### 3. [Confirmed · Low] `TaxData.tsx:71` — 2024 Single brackets use the `+1` convention, inconsistent with the rest of the table
+Federal 2024 Single is `47151 / 100526 / 191951 / 243726` (IRS "+1" lower-bound convention), while
+the 2024 **MFS** row (`47150 / 100525 / 191950 / 243725`) and the 2025/2026 Single rows all use the
+breakpoint value. The 2024 Single row is the lone outlier. A 2024 Single filer with taxable income
+between 47150 and 47151 is taxed at 12% instead of 22% (each boundary $1 too high). ~$0.10 impact,
+but a confirmed internal inconsistency that also shifts any Roth-ceiling keyed to the 2024 22/24/32/35%
+bracket tops by a dollar.
+
+### 4. [Plausible · Low] `parameters.ts:90` — inflation only goes up, never down
+Inflation is applied only when `year > max_year`; there is no deflation for years below the data
+range. `year=2019, inflationAdjusted=true, MFJ` → `getClosestTaxYear` snaps to 2024 and returns the
+larger 2024 brackets/$29,200 std deduction verbatim. A historical/back-test scenario understates
+tax. Edge case (the app normally projects forward), but the inflate-up / never-deflate-down asymmetry
+is undocumented.
+
+### 5. [Plausible · Low] `parameters.ts:76` — NaN if a partial `assumptions` lacks `inflationRate`
+`inflation = assumptions.macro.inflationRate / 100` has no NaN guard, and the default-parameter
+override fires only when the **entire** `assumptions` arg is `undefined`. A partial/migrated object
+`{ macro: { inflationAdjusted: true } }` at year 2030 → `inflation=NaN` → `Math.pow(1+NaN,…)=NaN` →
+every threshold/deduction NaN → `calculateTax` returns NaN, silently poisoning SimulationYear totals
+with no thrown error.
+
+### 6. [Plausible · Low] `parameters.ts:144` — nearest-year tie-break prefers the older year
+The fallback reducer uses strict `<`, so an exactly-equidistant target keeps the first (older) year
+in `Object.keys` order. Latent: a state table with only 2024 and 2026 rows queried for 2025 returns
+the older 2024 brackets. No current state data has a missing middle year, so it doesn't trigger today,
+but it silently prefers stale data if such a gap is ever introduced.
+
+### 7. [Cleanup] `stateTax.ts:120` — `calculateUnifiedStateTax` duplicates `calculateStateTax` (~60 lines)
+Near line-for-line copy: identical SS-treatment switch, senior-deduction doubling, and
+Auto/Standard/Itemized selection; the only difference is `annualGross` including
+`additionalOrdinaryIncome`. Any fix to SS treatment, senior-deduction logic, or deduction selection
+must be made in both, and a one-sided edit silently diverges the withdrawal-inclusive path from the
+base path. Extract a shared `computeStateTax(adjustedGross, params, …)` helper (same pattern PR #54
+used for the conversion-tax helper).
+
+### 8. [Cleanup/Efficiency] `federalTax.ts:62` — state tax computed then discarded under `deductionMethod === 'Standard'`
+`stateTax` → `cappedStateTax` → `itemizedTotal` are computed unconditionally to build the SALT-capped
+itemized deduction, but on the `'Standard'` path `itemizedTotal` is never used. For a Standard-method
+user, every per-year federal calc runs a full state-tax pass (its own `getTaxParameters` + bracket
+walk) and throws it away. Guard the SALT/itemized block behind `deductionMethod !== 'Standard'`.
+
+### 9. [Cleanup/Efficiency] `parameters.ts:140` — duplicated nearest-year reducer + no memoization
+The `Object.keys(sourceData).map(Number).filter(!NaN).reduce(nearest)` search is duplicated (96-102
+and 140-146), and `getTaxParameters` is re-invoked per year by federal/state/fica/capitalGains with no
+caching — a single `calculateFederalTaxFromIncomes` triggers 2-3 passes for the same (year, status),
+each potentially the O(years) fallback scan. Extract the reducer and consider memoizing by
+(year, status, authority, state, inflation).
+
+### 10. [Cleanup] `incomeAggregation.ts:59` — `getPostTaxExemptions` / `getPreTaxExemptions` duplication
+Identical filter+reduce over `WorkIncome` with the same `useStoredValue`/`getEffective401k`
+resolution; only the field read differs. A change to how effective 401k is resolved (e.g. catch-up
+handling) must be edited in both. Extract `getEffective401kField(inc, year, age, useStoredValue,
+'preTax'|'roth')`.
+
+### 11. [Cleanup] `stateTax.ts:48` — redundant `if (totalSSBenefits > 0)` wrapper
+The `'income-based'` and `'exempt'` arms are byte-identical (`adjustedGross = annualGross −
+totalSSBenefits`), which equals `annualGross` when SS is 0 — only the `'taxable'` arm needs the guard.
+Flatten to `if (ssTreatment === 'taxable') { … } else { adjustedGross -= totalSSBenefits }`
+(subtracting 0 when no SS). Duplicated in both state functions.
+
+### 12. [Plausible · Low] `marginalRates.ts:96` — `|| 14600` falsy-zero fallback
+`fedParams?.standardDeduction || 14600` replaces a legitimately-zero standard deduction with the
+hardcoded $14,600. Currently safe (federal rows never carry 0) but fragile — use `?? 14600`.
+
+### 13. [Plausible · Low] `deductions.ts:15` — `(exp as any).tax_deductible || 0` casts away type-checking
+`tax_deductible` is not declared on every member of the `AnyExpense` union, so the compiler can't
+catch a member that passes the `is_tax_deductible` filter but lacks the field — it silently becomes
+`undefined || 0 = 0`, dropping the deduction. Narrow with a type guard instead of `as any`.
+
+---
+
+## Checked and deprioritized
+- **Math engine — verified correct:** provisional-income / taxable-SS / ordinary bracket walk (`>` is
+  right) / LTCG stacking with `unusedDeduction` offset / NIIT base (`min(NII, MAGI-excess)`) all match
+  IRS worksheets; pre-tax deductions are applied exactly once.
+- **Not a bug — tested as intended:** `marginalRates.ts:39` negative-income headroom returns the bracket
+  boundary (not `threshold − income`); `getMarginalTaxRate(-5000)` explicitly asserts `headroom=12400`.
+- **Not a bug — documented intentional:** `stateTax.ts:78` MFJ senior-deduction doubling assumes both
+  spouses meet the age threshold (stated in the comment); there is no second-spouse age to check.
+- **Refuted:** `bracketTax.ts:141` NIIT MAGI "double-counts deductions" — the only caller passes gross
+  `ordinaryIncome` (`nonSSGross + additionalOrdinaryIncome`), so `preTaxDeductions` is subtracted once.
+- **Data — spot-checked clean:** all `brackets`/`capitalGainsBrackets` strictly monotonic, rates ascend,
+  every array starts at threshold 0; 2024/2025/2026 ordinary brackets, std deductions, LTCG 0/15/20%
+  thresholds, SS wage bases (168600/176100/184500), and FICA 6.2%/1.45% match published figures; MFS
+  ≈ ½ MFJ. California's missing 2024 row is handled by the documented nearest-year fallback; Texas
+  omitting `socialSecurityTreatment` is correct (no income tax).

--- a/code-review-pr56.md
+++ b/code-review-pr56.md
@@ -1,0 +1,150 @@
+# Code Review — PR #56 (`review/retirement-7`)
+
+**Scope:** retirement-flow services + their data tables (source) — 11 files, +4135 lines, purely additive.
+Roth-conversion DP, RMD service, income projection (work/SS/pension/interest), income classification,
+account growth + contribution caps, milestone evaluation, cashflow-detail builder, and the
+RMD / Social-Security / federal-pension / contribution-limit data.
+**Effort:** xhigh (9 finder angles — 5 correctness / 3 cleanup / 1 altitude — + verify + gap sweep,
+3 parallel finder agents + a manual line-by-line pass).
+
+## Setup caveat
+Campaign-7 scoped-review PR (scope-3-retirement): the reviewed source is identical to `main`, so every
+finding was validated against the real tree (`SimulationEngine.tsx`, `YearSolver.ts`, the Income models,
+`TaxService`). Findings that depend on what a function actually receives were traced to the call site —
+the headline bug only exists because the stored `SimulationYear.incomes` (`returnedIncomes`) strips the
+RMD income that the DP's comment assumes is present.
+
+Confirmed clean (no defect): no taxable-SS double-count in conversion sizing (federal vs state SS each
+counted once), LTCG not double-counted, all three SS sibling classes
+(`SocialSecurityIncome`/`CurrentSocialSecurityIncome`/`FutureSocialSecurityIncome`) are enumerated in
+every in-scope `instanceof` list, `??` is used correctly throughout the DP/growth code (no falsy-zero),
+the interest `PassiveIncome` correctly uses `Date.UTC`, the RMD 25% excise flows into the year's taxes,
+the §415(c) match trim is authoritative downstream in `CashflowDetailBuilder`, and the RMD divisor table
+has a single source (`TaxOptimizationService` imports `getDistributionPeriod`, no drift).
+
+---
+
+## Resolution (applied to `main`; suites green: 50 files / 880 tests across the affected paths, `tsc -b` clean)
+
+Six findings fixed by four sequential agents working on `main`, each writing a red→green regression test
+that failed before its fix; one finding refuted on closer reading. Every behavioral fix shipped with a
+test and the `fix(review7):` commit prefix. No cross-fix test interactions (unlike PR #55) — the full
+simulation + integration + data suites pass clean against the stacked fixes.
+
+| # | Finding | Disposition | Commit |
+|---|---------|-------------|--------|
+| 1 | DP double-subtracts RMD from the ordinary-income base | **Fixed** — drop `- baselineRMDAmount` (gross already excludes RMD); stale comment corrected | `073c260` |
+| 2 | SS earnings-test reduction compounds year-over-year | **Fixed** — base the withholding on the preserved full `projectedPIA`, not the running reduced amount (FRA-restoration left as the pre-existing documented limitation) | `b2a4e86` |
+| 3 | Same-year ESPP purchase nets against a sale, dropping the sale | **Fixed** — drop the redundant positive `userInflows[esppId]` purchase writes (balance is set via `addLot`); `userInflows` now carries only the sale | `b6f8317` |
+| 4 | FERS MRA-to-62 supplement never auto-computed | **Fixed** — derive it via `calculateFERSSupplement` on auto-High-3 activation when retiring before 62 | `a9c7121` |
+| 5 | §415(c) employee-only excess across multiple incomes into one account | **Fixed** — after match-first trim, trim employee deferrals for any remaining excess | `882cb92` |
+| 6 | CSRS early-retirement log message shows uncapped reduction | **Fixed** — compute capped reduction once, use it in both `reductionPercent` and `message` | `3580718` |
+| 7 | `DeficitDebtAccount` branch in `growAccounts` map loop is "dead" | **Refuted / wont-fix** — `DeficitDebtAccount extends DebtAccount`, so the branch (line 240) short-circuits the subclass before the generic `DebtAccount` branch (line 245) which would apply APR to deficit debt; the post-loop block only repairs the *system* entry. Removing it would corrupt the map's intermediate. Defensive, not dead. | — |
+
+**Net: 6 fixed, 1 refuted.** Each fix verified red→green individually; the consolidated run
+(simulation services, integration stories, SimulationEngine, RMD/SS/Pension/contribution-limit data)
+is green and `tsc -b` exits 0.
+
+Notable fix details:
+- **#3:** investigation confirmed the positive ESPP purchase write to `userInflows` was consumed by
+  nothing (balance flows through `addLot`; cashflow tracks ESPP via the `WorkIncome` contribution), so
+  removing it is safe and leaves `userInflows[esppId]` carrying only the sale signal.
+- **#2:** `projectedPIA` is set equal to `calculatedPIA` at activation and COLA-grown in lockstep, so it
+  reliably holds the full benefit; the fix falls back to `amount/12` when `projectedPIA` is unset (one
+  existing test constructs the income without it), preserving the single-year reduction there.
+
+All review-fix regression tests live in `src/__tests__/services/simulation/ReviewFixes_PR56.test.ts`.
+
+---
+
+## Findings
+
+### 1. [Confirmed · High] `RothConversionDP.ts:445` — RMD double-subtracted from the DP's ordinary-income base
+`buildDPYearContexts` computes
+`nonSSOrdinaryIncomeExclRMD = max(0, grossIncome - ssBenefits - baselineRMDAmount)` where
+`grossIncome = getGrossIncome(simYear.incomes)`. The comment at line 435 asserts "getGrossIncome
+includes RMD," but the baseline `SimulationYear.incomes` is `returnedIncomes`, which
+`SimulationEngine.tsx:630-632,668` builds by filtering out every `PassiveIncome` with
+`sourceType === 'RMD'`. So gross income **already excludes** RMD, and subtracting `baselineRMDAmount`
+removes it a second time. Retiree age 76, $40k pension, $60k required RMD: `grossIncome - ss = $40k`,
+then `- $60k` → clamped to `$0`. `evaluateCell` then rebuilds ordinary income as `0 + rmd + conversion`,
+losing the $40k of pension/wage/passive ordinary income **every post-RMD year**, so the DP sees phantom
+bracket headroom and mis-prices/over-sizes conversions across the whole RMD horizon — the headline use
+case for this module. (Secondary: `baselineRMDAmount` uses `rmdDetails.totalRMD` (required) while a
+shortfall year's gross would reflect `totalWithdrawn` — moot once the erroneous subtraction is removed.)
+
+### 2. [Confirmed · Med] `IncomeProjection.ts:287-298` — SS earnings-test reduction compounds year-over-year and is never restored
+The earnings-test reduction is written back as the new `calculatedPIA` (line 291, `monthlyReduced`), so
+the reduced benefit is what carries forward. Next year, `shouldRecalculate` is false (past claiming age),
+`inc.increment()` COLA-grows the **already-reduced** PIA, and the earnings-test block reduces it **again**
+by roughly the same withholding. For a pre-FRA claimant who keeps working, the benefit ratchets down each
+year and, once work stops, stays permanently reduced instead of recovering toward the full PIA
+(`projectedPIA` is preserved but never used to restore — the code's own comment flags "recalculated at
+FRA (not yet implemented)"). Born 1965, claims at 62 (FRA 67), earns $80k: benefit shrinks every working
+year and never recovers. _(Fix targets the compounding; FRA-restoration remains the documented
+limitation.)_
+
+### 3. [Confirmed · Med] `AccountGrowth.ts:266` — a same-year ESPP purchase nets against a sale, dropping the sale
+`growAccounts` derives `grossWithdrawn = userIn < 0 ? -userIn : 0` from the **net** `userInflows[esppId]`.
+But ESPP sales write a negative there (`SimulationEngine.tsx:61-62`) while same-year ESPP purchases write
+a positive (`AccountGrowth.ts:152/170`), and for ESPP the purchase reaches the balance only via `addLot`
+(positive `userIn` is otherwise ignored). Still-employed user contributes +$8k to ESPP and the planner
+sells $5k for a one-off expense: net `userIn = +$3k` → `grossWithdrawn = 0` → `removeSoldShares` never
+runs, the $5k of shares stay on the books, and the ESPP balance is overstated by the unsold $5k even
+though the cash was spent. (Any year with both a buy and a sell mis-handles the balance — the buy masks
+part/all of the sell.)
+
+### 4. [Confirmed · Med] `IncomeProjection.ts:113-120` — FERS MRA-to-62 supplement is never auto-computed
+On auto-High-3 FERS activation the new `FERSPensionIncome` is built passing `inc.fersSupplement`
+verbatim (line 116). The model's `getSupplement()` / `calculateFERSSupplement` (models.tsx:657) that would
+derive it is **dead code — never called anywhere**. A FERS employee with `autoCalculateHigh3=true`
+retiring at 57 with 30 years of service and `estimatedSSAt62` set, but `fersSupplement` left at its
+default 0, gets `$0` bridge supplement from 57–62 instead of the expected `~(30/40)×SS@62` — understating
+spendable income for those years. (High-3 and base benefit *are* auto-derived; the supplement alone is
+not — the asymmetry the dead `getSupplement()` was meant to close. The default-config UI sets
+`fersSupplement=0, estimatedSSAt62=0`, confirming the supplement is intended to be auto-derived.)
+
+### 5. [Plausible · Low] `AccountGrowth.ts:66-72` — §415(c) cap trims only the employer match; employee-only excess slips through
+The §415(c) combined limit is enforced by trimming the employer match
+(`trimmedMatch = max(0, employerMatch - excess)`). When two incomes feed the **same** 401k account, their
+combined employee deferrals alone can exceed the limit with no match to trim: two `WorkIncome`s each under
+the §402(g) elective limit but summing to $75k of employee contributions vs a $70k §415(c) cap → the
+already-zero match is clamped to zero, nothing is removed, and `userInflows` lands $5k over the cap.
+Uncommon (two incomes → one account) but real.
+
+### 6. [Confirmed · Low/cosmetic] `PensionData.tsx:277-281` — CSRS early-retirement log message shows the uncapped reduction
+`checkCSRSEligibility` returns `reductionPercent: Math.min(reduction, 10)` (benefit correctly cut ≤10%)
+but interpolates the **uncapped** `reduction` into `message`. age 45 / 25 yrs → returns 10% but the
+message says "Early retirement with 20% reduction"; `IncomeProjection.ts:159` then logs the
+self-contradictory "reduced by 10% (Early retirement with 20% reduction)". Log-only, no math impact.
+
+### 7. [Cleanup → Refuted] `AccountGrowth.ts:240-243` — the `DeficitDebtAccount` branch in the `growAccounts` map loop is **not** dead
+Initially flagged as dead (the post-loop block at 301-318 re-derives and replaces the system entry), but
+`DeficitDebtAccount extends DebtAccount`, so the specific branch at line 240 must precede the generic
+`DebtAccount` branch at line 245 to short-circuit the subclass — otherwise a deficit-debt account would be
+treated as an APR-bearing `DebtAccount` in the map result. The post-loop block only repairs the *system*
+`system-deficit-debt` entry. The branch is defensive, not dead. **Wont-fix.**
+
+---
+
+## Checked and deprioritized
+- **No taxable-SS double-count in conversion sizing** — `computeYearTax` passes SS-excluding
+  `ordinaryIncome` to `calculateTotalFederalTax` (which derives taxable SS internally) and adds
+  `getTaxableSocialSecurityBenefits` to the state base only for SS-taxing states. Each counted once.
+- **All three SS sibling classes enumerated** — `IncomeClassifier` (55-57, 154-156),
+  `CashflowDetailBuilder` (121-125): no silent third-class drop in scope.
+- **`getFERSCOLA` diet-COLA boundaries** correct at the 2%/3% edges; **`getClaimingAdjustment`** matches
+  SSA (5/9%/mo then 5/12%/mo, 2/3%/mo delayed); RMD **25% excise** flows `RMDService` → `SimulationEngine`
+  → `YearSolver` `totalPenalties`.
+- **Refuted — earnings-test claiming-year proration:** `FutureSocialSecurityIncome` activates with a
+  Jan-1 `startDate`, so the claiming-year benefit is modeled full-year — no partial-year-benefit /
+  full-year-limit mismatch.
+- **Refuted — `SocialSecurityData.ts:471` year-of-FRA window / `calculateBenefitAdjustment` FRA=67:** the
+  integer-vs-fractional-FRA logic lives in `SocialSecurityCalculator` (out of scope); the in-scope
+  `getClaimingAdjustment`/`getFRA` are correct. `calculateBenefitAdjustment` is in `models.tsx`
+  (out of scope).
+- **`IncomeClassifier` RMD add/undo** (83-93) is self-consistent (subtracts the same `annualAmount` it
+  added); `classified.taxableTotal`'s naive "full SS taxable" sum is **not consumed** anywhere outside the
+  type, so it poisons nothing.
+- **`getDistributionPeriod` pre-72 fallback** returns the age-72 divisor for age < 72, but all callers
+  guard on `age >= rmdStartAge` / `age < 72` first — latent footgun, no live trigger.

--- a/code-review-pr57.md
+++ b/code-review-pr57.md
@@ -1,0 +1,139 @@
+# PR #57 Review — domain models + simulation orchestration
+
+Scope reviewed: `Accounts/models.tsx`, `Income/models.tsx`, `Expense/models.tsx`,
+`modelUtils.ts`, `Assumptions/{AssumptionsContext,MonteCarloContext,SimulationContext,SimulationEngine,useSimulation}.tsx`.
+Effort: xhigh (9 finder angles + verify + sweep). Reviewed source ≈ `main`
+(SimulationEngine already carried the PR #56 `ordinaryTax` fix).
+
+Status legend: ☐ open · ☑ fixed (test-backed) · ◇ cleanup (no failing test) · ⏸ deferred
+
+## Resolution (2026-06-11)
+
+Fixed test-first via 4 file-disjoint sub-agents + a reconciliation pass. Final
+state: **3425 tests pass under default, `Australia/Sydney` (+UTC), and
+`America/New_York` (−UTC)**; `tsc -b` clean; no new lint (only pre-existing
+`react-refresh/only-export-components`).
+
+- **#1 ☑** Date convention unified to LOCAL everywhere. Readers `getUTC*`→`getFullYear()/getMonth()` in `Expense/models`, `Income/models`, `SimulationEngine:548`, `MilestoneEvaluator:130-131`; `Date.UTC` date-only creation → `new Date(y,m-1,d)` in `Income/models:807`, `incomeFormTypes:59`, `IncomeProjection.ts`. ESPP lot dates (`AccountGrowth`) left as-is (consumed via `getTime()` diffs, TZ-agnostic). Proven by full-suite runs in both ± UTC zones.
+- **#2 ☑** `LoanExpense.getAnnualAmount(year)` now returns `calculateAnnualAmortization(year).totalPayment` (capped); `getMonthlyAmount` delegates to it.
+- **#3 ☑** FERS supplement no longer `*(1+cola)`. (Latent: `getFERSCOLA` returns 0 under 62, so it never actually grew — fix kept as a guard against future COLA changes.)
+- **#4 ☑ / #8 ☑** Goal funding + purchase loops iterate `milestoneFilteredExpenses`; funding assigns the per-account total ONCE per unique fund id (helper now sums all goals on the account) — fixes both the milestone bypass and the shared-account double-count. Engine test proves the double-count guard by temporary revert.
+- **#5 ☑** `MortgageExpense.calculatePayment()` PMI now LTV-gated like the constructor.
+- **#6 ◇ REFUTED** No off-by-one: `increment(year, currentAge)` zeroes the supplement in the SAME year `currentAge>=62`. Regression test kept.
+- **#7 ☑** `PropertyAccount` increment + reconstitute now pass `apr`.
+- **#9 ☑** `reconstituteAccount` uses `!= null` for `customROR` (Invested + ESPP).
+
+New tests: `Accounts/models-bugs-7-9.test.tsx`, `Expense/bugs.test.tsx`,
+`services/simulation/GoalFundingMilestone.test.ts`. Corrected pre-existing tests
+that encoded the false "UTC-midnight storage" premise (`modelUtils.test.ts`,
+`IncomeClassifierDateFilter.test.ts`, `GoalFundingGateUtcYear.test.tsx`,
+`Income/models.test.tsx`, `IncomeProjection.test.ts`, `Expense/models.test.tsx`)
+to construct LOCAL dates — same assertions, now TZ-robust.
+
+Cleanups #10–#15 NOT done (no failing test; out of scope for this pass).
+
+---
+
+## Correctness findings
+
+### 1. ☐ Date convention is inverted (systemic, latent for US users)
+`parseDate` (`modelUtils.ts:29`) builds **local-midnight** dates, but the window
+readers across the model files use `getUTCFullYear()/getUTCMonth()` — and the
+inline comments claim the opposite ("parseDate returns UTC dates"). Creation is
+itself split: `Date.UTC(...)` in `incomeFormTypes.ts:59`,
+`Income/models.tsx:807` (`calculateSocialSecurityStartDate`),
+`IncomeProjection.ts` (SS start/end), `AccountGrowth.ts:123-124` (ESPP lots);
+local `new Date(y,m-1,d)` in `parseDate` and the expense/TriggerSelector forms.
+
+- Correct for **negative-UTC** (Americas) — which is why it works for the current user.
+- Wrong for **positive-UTC** (Europe/Asia/Australia): a `YYYY-01-01` value rolls
+  back to the prior year/month, shifting every active-income/expense window, goal
+  due-year, and goal funding window.
+- The Vitest suite runs in UTC (local == UTC), so it structurally cannot catch this.
+
+Readers affected: `getExpenseActiveMultiplier:826`, `isExpenseActiveInCurrentMonth`,
+`isGoalDueInYear:932`, `getGoalFundMonthlyCap:965`, `goalMonthsActiveInYear:983`,
+`monthsBetween/getGoalMonthlySetAside`, `LoanExpense`/`MortgageExpense`
+amortization date reads; `getIncomeActiveMultiplier`, `isIncomeActiveInCurrentMonth`.
+
+**Convention to adopt (per repo memory):** local everywhere — readers use
+`getFullYear()/getMonth()`, all date-only creation uses `new Date(y,m-1,d)`. Must
+be made **consistent per file** (a half-conversion that leaves one side `Date.UTC`
+and the other local would regress negative-UTC / the current user). Prove with TZ
+overrides in BOTH `America/New_York` (no regression) and `Australia/Sydney` (fix).
+
+### 2. ☐ `LoanExpense.getAnnualAmount` is uncapped → Sankey imbalance in payoff year
+`Expense/models.tsx:683` returns `payment × activeMonths` with no payoff cap. The
+solver totals loans via `calculateAnnualAmortization().totalPayment` (capped,
+`SimulationEngine:287`), but `CashflowDetailBuilder.ts:173` uses `getAnnualAmount`
+for loans (only Mortgage is special-cased). In any loan's payoff year the Sankey
+Expenses node overstates vs the solver's living-expense total — the exact
+"category sum must equal living expenses" invariant the builder relies on.
+Fix: make `getAnnualAmount` (and `getMonthlyAmount`) derive from
+`calculateAnnualAmortization(year).totalPayment` so all consumers agree.
+
+### 3. ☐ FERS Annuity Supplement grows with COLA
+`Income/models.tsx:668`: `newSupplement = currentAge >= 62 ? 0 : this.fersSupplement * (1 + cola)`.
+The real FERS supplement receives **no** COLA. Compounding ~CPI overstates pre-62
+bridge income every year. Fix: drop the `* (1 + cola)` factor.
+
+### 4. ☐ Goal funding/purchase loops bypass the milestone filter
+`SimulationEngine.tsx:274` (funding) and `:544` (purchase) iterate the unfiltered
+`expenses`, while living expenses use `milestoneFilteredExpenses` (`:235`). A goal
+gated by a start/end milestone is therefore funded and purchased outside its
+milestone window, and its set-aside can diverge from the Sankey's filtered list.
+Fix: iterate the milestone-filtered set in both loops (and pass the filtered list
+to `getGoalFundAnnualSetAside`).
+
+### 5. ☐ `MortgageExpense.calculatePayment()` adds PMI unconditionally
+`Expense/models.tsx:441` computes `valuation*pmi/12` with no LTV gate, unlike the
+constructor (`:277`) and `increment` (`:322-329`) which drop PMI at ≤80% LTV. For
+a >20%-equity mortgage that carries a PMI rate, the recomputed payment (e.g. via
+`ExpenseCard.tsx:146` on edit) is inflated. Fix: gate PMI on `loan_balance/valuation > 0.8`.
+
+### 6. ☐ FERS supplement paid through the age-62 year (off-by-one)
+`increment` zeroes the supplement only for the year **after** `currentAge >= 62`,
+but `getTotalAnnualAmount` (`:698`) still pays the full (COLA-grown) supplement in
+the age-62 year. Result: ~one extra year of the bridge. Tie the cutoff to the same
+age basis so the supplement stops at 62.
+
+### 7. ☐ `PropertyAccount` drops `apr` on increment and reconstitute
+`Accounts/models.tsx:834` (`increment`) and `:992` (`reconstituteAccount`) rebuild
+the account with only 7 of 8 constructor args, omitting `apr` (defaults to 0). A
+user-set property APR silently reverts every sim year and on reload. (Currently
+`apr` isn't consumed by the engine, so observable impact is UI/future-use only —
+but it's a real constructor-arg drift.) Fix: pass `this.apr` / `Number(data.apr)`.
+
+### 8. ☐ `getGoalFundAnnualSetAside` double-counts when two goals share a fund account
+`Expense/models.tsx:1008` resolves the goal via `expenses.find()` by
+`goalAccountId`, returning the FIRST match. If two goals share one fund account the
+engine loop adds the first goal's set-aside twice and ignores the second. Fix: sum
+the set-asides of all goals targeting the account (or document one-goal-per-account
+as an invariant and enforce it).
+
+### 9. ☐ `reconstituteAccount` coerces `customROR: null` to a hard 0%
+`Accounts/models.tsx:963` (and ESPP `:984`): `data.customROR !== undefined ? Number(...) : undefined`
+turns a persisted/imported `null` into `Number(null)=0` — a 0% custom return
+instead of "use global ROR". Fix: use `!= null` (covers null and undefined).
+
+---
+
+## Cleanup findings (no failing test; lower priority)
+
+- **10. ◇** `reconstitute{Account,Income,Expense}` hand-roll id/name/amount instead of the existing `modelUtils.extractBaseFields()` (`Accounts:934`, `Income:913`, `Expense:1121`).
+- **11. ◇** The amortization formula + 0%-APR guard is copy-pasted 5× in `MortgageExpense` (`:270,:432,:472,:502`) instead of delegating to the private `calculatePrincipalAndInterest()` (`:353`).
+- **12. ◇** `getExpenseActiveMultiplier`/`isExpenseActiveInCurrentMonth` are line-for-line duplicates of the Income equivalents; extract one shared helper in `modelUtils`.
+- **13. ◇** `WorkIncome.increment` ESPP `'PERCENTAGE'` branch (`Income:232-234`) is a no-op (assigns the value it already holds).
+- **14. ◇** Per-year hot-path scans in `SimulationEngine` (`goalFundIds` rebuild `:349`, `accounts.find` per withdrawal, `getBirthYear` milestone scan) — hoist out of the year loop / use a `Map` (matters at N years × M Monte Carlo trials).
+- **15. ◇** `LoanExpense.getMonthlyAmount` (`:687`) recomputes `getProratedAnnual(this.payment)/12` instead of delegating to `getAnnualAmount(year)/12`.
+
+---
+
+## Refuted / by-design (checked, not bugs)
+
+- `CLASS_TO_CATEGORY[exp.constructor.name]` is safe — `vite.config.ts` sets `keepNames: true`.
+- InvestedAccount `lots` not restored on reconstitute is **by design** (sim-internal; ESPP lots ARE persisted).
+- `getTotalAnnualAmount` returning 0 when `base <= 0` is correct (pension inactive — don't pay the supplement before the annuity starts).
+- `age || this.retirementAge` falsy-zero (`Income:662`) is untriggerable — `age` is always threaded as a positive int via `IncomeProjection.ts:136`.
+- `mergeSection` typeof guard and `autoMax401k || 'custom'` only misfire on corrupt/undefined-default data — effectively by-design.
+</content>

--- a/code-review-pr58.md
+++ b/code-review-pr58.md
@@ -1,0 +1,211 @@
+# PR #58 Review — persistence, contexts, import/export, QR + cloud backup
+
+Scope reviewed: `hooks/{usePersistedReducer,useDebouncedLocalStorage}.ts`,
+`Accounts/{AccountContext,ImportKeyContext,useFileManager}.{ts,tsx}`,
+`Budget/BudgetContext.tsx`, `Income/IncomeContext.tsx`, `Expense/ExpenseContext.tsx`,
+`QRTransfer/qrUtils.ts`, `services/{CSVImportService,SSAImportService,backupMerge}.ts`,
+`services/cloud/CloudBackupService.ts`.
+Effort: xhigh (5+3+1 finder angles via sub-agents + verify + sweep). Reviewed
+source ≈ `main`.
+
+Status legend: ☐ open · ☑ fixed (test-backed) · ◇ cleanup (no failing test) · ⏸ deferred
+
+## Resolution (2026-06-11)
+
+Fixed test-first via 4 file-disjoint sub-agents + a reconciliation pass. Final
+state: **3443 tests pass** (127 files); `tsc -b` clean; no new lint (only
+pre-existing `react-refresh/only-export-components` + `no-explicit-any` in the
+context files). All 12 correctness findings **and** cleanups #13–#15 fixed.
+
+- **#1 ☑ / #4 ☑ / #6 ☑** `qrUtils` `flattenAssumptions`/`expandAssumptions`
+  rebuilt to round-trip the real `AssumptionsState`: top-level `milestones` and
+  the `withdrawalStrategy` **burn-order array** (flattened under a synthetic
+  `burnOrder` key, distinct from the `investments.withdrawalStrategy` string),
+  `demographics.priorEarnings`, and the 5 newer investments flags
+  (`taxOptimizationEnabled`, `acaAware`, `rothConversion{Strategy,MinRateGap,DPBackloadDelta}`).
+  Stopped emitting the phantom `withdrawalOrder`. New short keys added
+  collision-checked; the 5 flags added to `ASSUMPTIONS_DEFAULTS` so they strip/restore.
+- **#2 ☑** `projectedPIA` moved to a new unique short key `Pi`; `pp` now decodes
+  unambiguously to `purchasePrice`, so ESPP lot cost basis survives QR import.
+- **#3 ☑** `applyMapping` ids now `crypto.randomUUID()` (counter fallback) —
+  unique within an import. Test: 500-row CSV → all ids distinct.
+- **#5 ☑** `applyCategories` wraps `new RegExp` in try/catch (mirrors the
+  reducer's `APPLY_CATEGORY_RULE` guard); an invalid saved rule no longer aborts
+  the import.
+- **#7 ☑** `useDebouncedLocalStorage` registers `pagehide` + `visibilitychange→hidden`
+  listeners that flush the pending write synchronously; timer callback nulls the
+  ref so the flush only writes when genuinely pending.
+- **#8 ☑ / #12 ☑** `handleGlobalImport` now routes imported assumptions through
+  `migrateAssumptions` (exported) instead of the bespoke spread — deep-merges
+  every section incl. `display`. **Deeper bug found+fixed:** `migrateAssumptions`'
+  legacy `birthYear→milestone` synthesis was **dead code** (it seeded `milestones`
+  from `defaults.milestones`, so the `if (!existingIds.has(...))` guards never
+  fired); now seeds `[]` when saved data lacks milestones, so legacy
+  demographics actually populate Birth/Retire/End-of-Plan (fresh users still get
+  identical built-ins — 44 AssumptionsContext tests still green).
+- **#9 ☑** Budget date reconstitution extracted from `hydrateBudgetState` into
+  exported `reconstituteBudgetState`; `handleGlobalImport` now dispatches it so
+  imported transaction/month dates are real `Date`s (instant round-trip, no UTC
+  date-only parsing).
+- **#10 ☑** `BudgetContext.generateId` + inline `MOVE_TRANSACTION` minter +
+  `backupMerge.generateMonthId` use `crypto.randomUUID()` (monotonic-counter
+  fallback) — collision-free within a tick.
+- **#11 ☑** `validateEarningsImport` now returns `valid: earnings.length > 0`
+  (empty is the only hard block); benign warnings no longer flip `valid`. Two
+  pre-existing tests that encoded the buggy `valid:false` were corrected.
+
+New tests: `hooks/useDebouncedLocalStorage.test.tsx`,
+`Budget/budgetImport.test.ts`, plus `PR #58 regressions` blocks in
+`QRUtils.test.ts`, `CSVImportService.test.ts`, `SSAImportService.test.ts`,
+`backupMerge.test.ts`, `useFileManager.test.tsx`. Eight pre-existing QR tests
+that encoded the obsolete `withdrawalOrder` shape were corrected (marked
+`PR #58: corrected`); no coverage deleted.
+
+---
+
+## Correctness findings
+
+### 1. ☐ QR round-trip drops `milestones` → age timeline reset to defaults
+`qrUtils.ts` `flattenAssumptions:222` / `expandAssumptions:250` predate the
+milestone refactor. `milestones` (now the source of birthYear / retirementAge /
+lifeExpectancy) is not special-cased in `flattenAssumptions`, so it's spread as
+numeric-index keys (`flat['0']`, `flat['1']`, …); `expandAssumptions` never
+re-emits it. A QR export→scan (`getBackupData()` carries the full live
+assumptions → `createCompactBackup` → `compactAssumptions`) followed by
+`handleGlobalImport` leaves `milestones = createBuiltinMilestones()` (birth 1990,
+retire 65, life 90). **Every projected year is silently reset.** Fix: round-trip
+the real top-level `milestones` array.
+
+### 2. ☐ QR `pp` key collision corrupts ESPP lot `purchasePrice`
+`qrUtils.ts` KEY_MAP maps **both** `purchasePrice` (ESPP lot, `:20`) and
+`projectedPIA` (Social Security, `:36`) to short key `pp`. `REVERSE_KEY_MAP['pp']`
+resolves to the last writer, `projectedPIA`, so `expandKeys` renames every lot's
+`purchasePrice` → `projectedPIA` on import. `reconstituteAccount`
+(`models.tsx:977`, `purchasePrice: Number(lot.purchasePrice) || 0`) then sees no
+`purchasePrice` and sets it to **0**, destroying the lot's cost basis and all
+ESPP gain/tax math. Fix: give `projectedPIA` a unique short key; keep `pp`
+decoding to `purchasePrice` (legacy SS `projectedPIA` is recomputed, so losing
+its legacy decode is harmless).
+
+### 3. ☐ CSV import mints colliding transaction ids
+`CSVImportService.ts:648`: `TXN-${Date.now()}-${Math.floor(Math.random()*10000)}`
+runs inside a synchronous loop, so `Date.now()` is constant and only a 4-digit
+random varies — ~99% collision probability for a ~300-row CSV. `BudgetContext`
+`DELETE_TRANSACTION` (`filter(t => t.id !== id)`) and `UPDATE_TRANSACTION`
+(`t.id === id`) act on **every** colliding twin, and React list keys collide.
+Fix: per-import counter or `crypto.randomUUID()`.
+
+### 4. ☐ QR round-trip drops the burn order (top-level `withdrawalStrategy` array)
+`qrUtils.ts` `flattenAssumptions:226` special-cases a key named `withdrawalOrder`
+that **does not exist** in `AssumptionsState`; the real burn order is the
+top-level `withdrawalStrategy: WithdrawalBucket[]`, which falls into the object
+branch and is lost. `expandAssumptions:288` re-emits the phantom `withdrawalOrder`
+(nothing reads it). After import `withdrawalStrategy = []` (default), so
+`SimulationEngine.tsx:384` (`assumptions.withdrawalStrategy.map(...)`) runs on an
+empty array — the user's manual withdrawal order is silently reset. Fix:
+flatten/expand the top-level `withdrawalStrategy` array under a distinct key from
+the `investments.withdrawalStrategy` **string**.
+
+### 5. ☐ One invalid saved regex rule crashes the whole CSV import
+`CSVImportService.ts:822` (`applyCategories`) builds `new RegExp(rule.pattern, 'i')`
+with **no** try/catch, unlike the guarded `BudgetContext` `APPLY_CATEGORY_RULE`
+(`:329`). A saved category rule with an invalid pattern (`(`, `[a-`) throws
+`SyntaxError` inside `.map`, aborting the entire import pipeline
+(`useCSVImportFlow.ts:69,153`). Fix: wrap the regex build/test in try/catch
+returning `false` (mirror the reducer).
+
+### 6. ☐ QR round-trip drops `priorEarnings` and newer investments flags
+`qrUtils.ts` `expandAssumptions:250` hardcodes a stale subset, dropping
+`demographics.priorEarnings` (imported SSA earnings) and
+`investments.{taxOptimizationEnabled,acaAware,rothConversionStrategy,rothConversionMinRateGap,rothConversionDPBackloadDelta}`.
+These ride into the compact payload but are never restored, so import falls back
+to defaults: SS PIA projection loses earnings history; Tax-Optimization / ACA /
+Roth-strategy revert, silently changing the simulation. Fix: restore them in
+`expandAssumptions` (or replace the bespoke allow-list with a generic
+shorten/expand keyed off `defaultAssumptions`).
+
+### 7. ☐ Debounced write lost on hard reload / tab close within 500ms
+`useDebouncedLocalStorage.ts:36` schedules the write 500ms out; the unmount-flush
+effect (`:52`) does **not** run on a real browser navigation/unload, and there is
+no `beforeunload`/`pagehide` handler. Edit-then-reload (or close) inside the
+window loses the change — most acute right after `handleGlobalImport`, where
+users commonly reload to "make it take." Fix: flush synchronously on `pagehide`
+(and/or `visibilitychange → hidden`).
+
+### 8. ☐ Importing a legacy (pre-milestones) backup resets the age timeline
+`useFileManager.ts:90` `handleGlobalImport` merges assumptions inline but never
+runs the `birthYear/retirementAge/lifeExpectancy → milestone` migration that
+`migrateAssumptions` performs on the localStorage path. Importing an older JSON
+backup (demographics.birthYear, no `milestones`) takes `milestones` from
+`...defaultAssumptions` (built-ins, birth 1990) and ignores the legacy birth
+year. Fix: route imported assumptions through `migrateAssumptions` (single source
+of truth) instead of the bespoke spread.
+
+### 9. ☐ Budget import leaves transaction/month dates as strings
+`useFileManager.ts:115` dispatches `budget` SET_BULK_DATA with the raw
+`JSON.parse`'d payload, so `transactions[].date` / `createdAt` / `updatedAt` /
+`statementDate` stay **strings** (typed `Date`); it bypasses `hydrateBudgetState`
+(localStorage-only) and no reload follows (`window.location.reload` is commented
+out, `:124`). The live post-import session holds string dates where `Date` is
+expected — consumers that don't defensively wrap in `new Date(...)` mis-render
+until a hard reload. Fix: reconstitute budget dates in the import payload (reuse
+`hydrateBudgetState`'s date mapping).
+
+### 10. ☐ MONTH-id collision when several months are created in one tick
+`BudgetContext.tsx:29` `generateId('MONTH')` = `MONTH-${Date.now()}-${rand(1000)}`
+(and `backupMerge.ts:138` `generateMonthId`). A CSV import spanning multiple new
+months runs `getOrCreateMonth` several times in one synchronous tick; with
+~1/1000 per pair two distinct months get the same id, and every id-keyed action
+(UPDATE_MONTH, ADD/UPDATE/DELETE_TRANSACTION, UPDATE_SPENDING) then hits both.
+Fix: monotonic counter / `crypto.randomUUID()` in both id minters.
+
+### 11. ☐ `validateEarningsImport` blocks on benign warnings
+`SSAImportService.ts:143` returns `valid: warnings.length === 0`, so a benign
+"Found N future year(s) which will be ignored" warning (common — SSA exports list
+the current partial year) flips `valid` to false, contradicting the documented
+"doesn't block import" contract. Latent today (the caller checks `warnings.length`)
+but wrong-by-contract. Fix: base `valid` only on truly blocking conditions
+(e.g. `earnings.length === 0`).
+
+### 12. ☐ `handleGlobalImport` doesn't deep-merge `display` (and arrays) with defaults
+`useFileManager.ts:91`: macro/income/expenses/investments/demographics are
+deep-merged with `defaultAssumptions`, but `display` is replaced wholesale by
+`...data.assumptions`, so a backup predating a newer display field (e.g.
+`hsaEligible`) leaves it `undefined` instead of defaulted. Subsumed by the
+finding #8 fix (route through `migrateAssumptions`, which deep-merges every
+section). Listed separately for completeness.
+
+---
+
+## Cleanup / lower-priority
+
+- **13. ☑** `qrUtils.stripDefaults` now compares empty default **arrays**
+  structurally, so `conversionHistory: []` / `lots: []` strip (and re-add via
+  `restoreDefaults`) instead of bloating the payload. The intentional, tested
+  null-stripping is retained. Test corrected: empty default array now strips +
+  round-trips.
+- **14. ☑** `AccountContext.exportData` now calls `URL.revokeObjectURL(url)` after
+  `a.click()`, matching `useFileManager.handleGlobalExport`.
+- **15. ☑** `compressData` builds the binary string in 32 KB chunks before
+  `btoa`, avoiding the `String.fromCharCode(...bytes)` spread `RangeError` on
+  large payloads. Regression test: a 379 KB deflated payload (proven to throw on
+  the old spread) now compresses and round-trips.
+
+---
+
+## Refuted / by-design (checked, not bugs)
+
+- **No crash importing a backup missing `withdrawalStrategy`/`milestones`.**
+  `...defaultAssumptions` backfills both before `...data.assumptions` spreads, so
+  `SimulationEngine.tsx:384`'s `.map` and `getBirthYear().find` never see
+  undefined — the real failure is silent data **reset** (#1/#4/#8), not a crash.
+- **`applyBalances` multi-target split setting a zero-weight account to 0 is
+  by-design.** A 0-balance account inside a weighted split (e.g. a 401k pre-tax /
+  Roth / employer split) correctly receives its proportional share of 0; it is not
+  "wiping a standalone account" (a standalone account wouldn't be in the map).
+- **`detectDuplicates` date comparison is consistent in-app.** Hydrated and
+  freshly-parsed transaction dates are both local-instant `Date` objects that
+  round-trip through `toISOString`/`new Date`, so `toDateString()` agrees; no
+  UTC off-by-one on the in-app path.
+- **`useDebouncedLocalStorage` unmount flush ordering is correct** — effect-A
+  cleanup clears the timer, effect-B cleanup writes the latest value via refs.

--- a/pr57.md
+++ b/pr57.md
@@ -1,0 +1,139 @@
+# PR #57 Review — domain models + simulation orchestration
+
+Scope reviewed: `Accounts/models.tsx`, `Income/models.tsx`, `Expense/models.tsx`,
+`modelUtils.ts`, `Assumptions/{AssumptionsContext,MonteCarloContext,SimulationContext,SimulationEngine,useSimulation}.tsx`.
+Effort: xhigh (9 finder angles + verify + sweep). Reviewed source ≈ `main`
+(SimulationEngine already carried the PR #56 `ordinaryTax` fix).
+
+Status legend: ☐ open · ☑ fixed (test-backed) · ◇ cleanup (no failing test) · ⏸ deferred
+
+## Resolution (2026-06-11)
+
+Fixed test-first via 4 file-disjoint sub-agents + a reconciliation pass. Final
+state: **3425 tests pass under default, `Australia/Sydney` (+UTC), and
+`America/New_York` (−UTC)**; `tsc -b` clean; no new lint (only pre-existing
+`react-refresh/only-export-components`).
+
+- **#1 ☑** Date convention unified to LOCAL everywhere. Readers `getUTC*`→`getFullYear()/getMonth()` in `Expense/models`, `Income/models`, `SimulationEngine:548`, `MilestoneEvaluator:130-131`; `Date.UTC` date-only creation → `new Date(y,m-1,d)` in `Income/models:807`, `incomeFormTypes:59`, `IncomeProjection.ts`. ESPP lot dates (`AccountGrowth`) left as-is (consumed via `getTime()` diffs, TZ-agnostic). Proven by full-suite runs in both ± UTC zones.
+- **#2 ☑** `LoanExpense.getAnnualAmount(year)` now returns `calculateAnnualAmortization(year).totalPayment` (capped); `getMonthlyAmount` delegates to it.
+- **#3 ☑** FERS supplement no longer `*(1+cola)`. (Latent: `getFERSCOLA` returns 0 under 62, so it never actually grew — fix kept as a guard against future COLA changes.)
+- **#4 ☑ / #8 ☑** Goal funding + purchase loops iterate `milestoneFilteredExpenses`; funding assigns the per-account total ONCE per unique fund id (helper now sums all goals on the account) — fixes both the milestone bypass and the shared-account double-count. Engine test proves the double-count guard by temporary revert.
+- **#5 ☑** `MortgageExpense.calculatePayment()` PMI now LTV-gated like the constructor.
+- **#6 ◇ REFUTED** No off-by-one: `increment(year, currentAge)` zeroes the supplement in the SAME year `currentAge>=62`. Regression test kept.
+- **#7 ☑** `PropertyAccount` increment + reconstitute now pass `apr`.
+- **#9 ☑** `reconstituteAccount` uses `!= null` for `customROR` (Invested + ESPP).
+
+New tests: `Accounts/models-bugs-7-9.test.tsx`, `Expense/bugs.test.tsx`,
+`services/simulation/GoalFundingMilestone.test.ts`. Corrected pre-existing tests
+that encoded the false "UTC-midnight storage" premise (`modelUtils.test.ts`,
+`IncomeClassifierDateFilter.test.ts`, `GoalFundingGateUtcYear.test.tsx`,
+`Income/models.test.tsx`, `IncomeProjection.test.ts`, `Expense/models.test.tsx`)
+to construct LOCAL dates — same assertions, now TZ-robust.
+
+Cleanups #10–#15 NOT done (no failing test; out of scope for this pass).
+
+---
+
+## Correctness findings
+
+### 1. ☐ Date convention is inverted (systemic, latent for US users)
+`parseDate` (`modelUtils.ts:29`) builds **local-midnight** dates, but the window
+readers across the model files use `getUTCFullYear()/getUTCMonth()` — and the
+inline comments claim the opposite ("parseDate returns UTC dates"). Creation is
+itself split: `Date.UTC(...)` in `incomeFormTypes.ts:59`,
+`Income/models.tsx:807` (`calculateSocialSecurityStartDate`),
+`IncomeProjection.ts` (SS start/end), `AccountGrowth.ts:123-124` (ESPP lots);
+local `new Date(y,m-1,d)` in `parseDate` and the expense/TriggerSelector forms.
+
+- Correct for **negative-UTC** (Americas) — which is why it works for the current user.
+- Wrong for **positive-UTC** (Europe/Asia/Australia): a `YYYY-01-01` value rolls
+  back to the prior year/month, shifting every active-income/expense window, goal
+  due-year, and goal funding window.
+- The Vitest suite runs in UTC (local == UTC), so it structurally cannot catch this.
+
+Readers affected: `getExpenseActiveMultiplier:826`, `isExpenseActiveInCurrentMonth`,
+`isGoalDueInYear:932`, `getGoalFundMonthlyCap:965`, `goalMonthsActiveInYear:983`,
+`monthsBetween/getGoalMonthlySetAside`, `LoanExpense`/`MortgageExpense`
+amortization date reads; `getIncomeActiveMultiplier`, `isIncomeActiveInCurrentMonth`.
+
+**Convention to adopt (per repo memory):** local everywhere — readers use
+`getFullYear()/getMonth()`, all date-only creation uses `new Date(y,m-1,d)`. Must
+be made **consistent per file** (a half-conversion that leaves one side `Date.UTC`
+and the other local would regress negative-UTC / the current user). Prove with TZ
+overrides in BOTH `America/New_York` (no regression) and `Australia/Sydney` (fix).
+
+### 2. ☐ `LoanExpense.getAnnualAmount` is uncapped → Sankey imbalance in payoff year
+`Expense/models.tsx:683` returns `payment × activeMonths` with no payoff cap. The
+solver totals loans via `calculateAnnualAmortization().totalPayment` (capped,
+`SimulationEngine:287`), but `CashflowDetailBuilder.ts:173` uses `getAnnualAmount`
+for loans (only Mortgage is special-cased). In any loan's payoff year the Sankey
+Expenses node overstates vs the solver's living-expense total — the exact
+"category sum must equal living expenses" invariant the builder relies on.
+Fix: make `getAnnualAmount` (and `getMonthlyAmount`) derive from
+`calculateAnnualAmortization(year).totalPayment` so all consumers agree.
+
+### 3. ☐ FERS Annuity Supplement grows with COLA
+`Income/models.tsx:668`: `newSupplement = currentAge >= 62 ? 0 : this.fersSupplement * (1 + cola)`.
+The real FERS supplement receives **no** COLA. Compounding ~CPI overstates pre-62
+bridge income every year. Fix: drop the `* (1 + cola)` factor.
+
+### 4. ☐ Goal funding/purchase loops bypass the milestone filter
+`SimulationEngine.tsx:274` (funding) and `:544` (purchase) iterate the unfiltered
+`expenses`, while living expenses use `milestoneFilteredExpenses` (`:235`). A goal
+gated by a start/end milestone is therefore funded and purchased outside its
+milestone window, and its set-aside can diverge from the Sankey's filtered list.
+Fix: iterate the milestone-filtered set in both loops (and pass the filtered list
+to `getGoalFundAnnualSetAside`).
+
+### 5. ☐ `MortgageExpense.calculatePayment()` adds PMI unconditionally
+`Expense/models.tsx:441` computes `valuation*pmi/12` with no LTV gate, unlike the
+constructor (`:277`) and `increment` (`:322-329`) which drop PMI at ≤80% LTV. For
+a >20%-equity mortgage that carries a PMI rate, the recomputed payment (e.g. via
+`ExpenseCard.tsx:146` on edit) is inflated. Fix: gate PMI on `loan_balance/valuation > 0.8`.
+
+### 6. ☐ FERS supplement paid through the age-62 year (off-by-one)
+`increment` zeroes the supplement only for the year **after** `currentAge >= 62`,
+but `getTotalAnnualAmount` (`:698`) still pays the full (COLA-grown) supplement in
+the age-62 year. Result: ~one extra year of the bridge. Tie the cutoff to the same
+age basis so the supplement stops at 62.
+
+### 7. ☐ `PropertyAccount` drops `apr` on increment and reconstitute
+`Accounts/models.tsx:834` (`increment`) and `:992` (`reconstituteAccount`) rebuild
+the account with only 7 of 8 constructor args, omitting `apr` (defaults to 0). A
+user-set property APR silently reverts every sim year and on reload. (Currently
+`apr` isn't consumed by the engine, so observable impact is UI/future-use only —
+but it's a real constructor-arg drift.) Fix: pass `this.apr` / `Number(data.apr)`.
+
+### 8. ☐ `getGoalFundAnnualSetAside` double-counts when two goals share a fund account
+`Expense/models.tsx:1008` resolves the goal via `expenses.find()` by
+`goalAccountId`, returning the FIRST match. If two goals share one fund account the
+engine loop adds the first goal's set-aside twice and ignores the second. Fix: sum
+the set-asides of all goals targeting the account (or document one-goal-per-account
+as an invariant and enforce it).
+
+### 9. ☐ `reconstituteAccount` coerces `customROR: null` to a hard 0%
+`Accounts/models.tsx:963` (and ESPP `:984`): `data.customROR !== undefined ? Number(...) : undefined`
+turns a persisted/imported `null` into `Number(null)=0` — a 0% custom return
+instead of "use global ROR". Fix: use `!= null` (covers null and undefined).
+
+---
+
+## Cleanup findings (no failing test; lower priority)
+
+- **10. ◇** `reconstitute{Account,Income,Expense}` hand-roll id/name/amount instead of the existing `modelUtils.extractBaseFields()` (`Accounts:934`, `Income:913`, `Expense:1121`).
+- **11. ◇** The amortization formula + 0%-APR guard is copy-pasted 5× in `MortgageExpense` (`:270,:432,:472,:502`) instead of delegating to the private `calculatePrincipalAndInterest()` (`:353`).
+- **12. ◇** `getExpenseActiveMultiplier`/`isExpenseActiveInCurrentMonth` are line-for-line duplicates of the Income equivalents; extract one shared helper in `modelUtils`.
+- **13. ◇** `WorkIncome.increment` ESPP `'PERCENTAGE'` branch (`Income:232-234`) is a no-op (assigns the value it already holds).
+- **14. ◇** Per-year hot-path scans in `SimulationEngine` (`goalFundIds` rebuild `:349`, `accounts.find` per withdrawal, `getBirthYear` milestone scan) — hoist out of the year loop / use a `Map` (matters at N years × M Monte Carlo trials).
+- **15. ◇** `LoanExpense.getMonthlyAmount` (`:687`) recomputes `getProratedAnnual(this.payment)/12` instead of delegating to `getAnnualAmount(year)/12`.
+
+---
+
+## Refuted / by-design (checked, not bugs)
+
+- `CLASS_TO_CATEGORY[exp.constructor.name]` is safe — `vite.config.ts` sets `keepNames: true`.
+- InvestedAccount `lots` not restored on reconstitute is **by design** (sim-internal; ESPP lots ARE persisted).
+- `getTotalAnnualAmount` returning 0 when `base <= 0` is correct (pension inactive — don't pay the supplement before the annuity starts).
+- `age || this.retirementAge` falsy-zero (`Income:662`) is untriggerable — `age` is always threaded as a positive int via `IncomeProjection.ts:136`.
+- `mergeSection` typeof guard and `autoMax401k || 'custom'` only misfire on corrupt/undefined-default data — effectively by-design.
+</content>

--- a/pr58.md
+++ b/pr58.md
@@ -1,0 +1,211 @@
+# PR #58 Review — persistence, contexts, import/export, QR + cloud backup
+
+Scope reviewed: `hooks/{usePersistedReducer,useDebouncedLocalStorage}.ts`,
+`Accounts/{AccountContext,ImportKeyContext,useFileManager}.{ts,tsx}`,
+`Budget/BudgetContext.tsx`, `Income/IncomeContext.tsx`, `Expense/ExpenseContext.tsx`,
+`QRTransfer/qrUtils.ts`, `services/{CSVImportService,SSAImportService,backupMerge}.ts`,
+`services/cloud/CloudBackupService.ts`.
+Effort: xhigh (5+3+1 finder angles via sub-agents + verify + sweep). Reviewed
+source ≈ `main`.
+
+Status legend: ☐ open · ☑ fixed (test-backed) · ◇ cleanup (no failing test) · ⏸ deferred
+
+## Resolution (2026-06-11)
+
+Fixed test-first via 4 file-disjoint sub-agents + a reconciliation pass. Final
+state: **3443 tests pass** (127 files); `tsc -b` clean; no new lint (only
+pre-existing `react-refresh/only-export-components` + `no-explicit-any` in the
+context files). All 12 correctness findings **and** cleanups #13–#15 fixed.
+
+- **#1 ☑ / #4 ☑ / #6 ☑** `qrUtils` `flattenAssumptions`/`expandAssumptions`
+  rebuilt to round-trip the real `AssumptionsState`: top-level `milestones` and
+  the `withdrawalStrategy` **burn-order array** (flattened under a synthetic
+  `burnOrder` key, distinct from the `investments.withdrawalStrategy` string),
+  `demographics.priorEarnings`, and the 5 newer investments flags
+  (`taxOptimizationEnabled`, `acaAware`, `rothConversion{Strategy,MinRateGap,DPBackloadDelta}`).
+  Stopped emitting the phantom `withdrawalOrder`. New short keys added
+  collision-checked; the 5 flags added to `ASSUMPTIONS_DEFAULTS` so they strip/restore.
+- **#2 ☑** `projectedPIA` moved to a new unique short key `Pi`; `pp` now decodes
+  unambiguously to `purchasePrice`, so ESPP lot cost basis survives QR import.
+- **#3 ☑** `applyMapping` ids now `crypto.randomUUID()` (counter fallback) —
+  unique within an import. Test: 500-row CSV → all ids distinct.
+- **#5 ☑** `applyCategories` wraps `new RegExp` in try/catch (mirrors the
+  reducer's `APPLY_CATEGORY_RULE` guard); an invalid saved rule no longer aborts
+  the import.
+- **#7 ☑** `useDebouncedLocalStorage` registers `pagehide` + `visibilitychange→hidden`
+  listeners that flush the pending write synchronously; timer callback nulls the
+  ref so the flush only writes when genuinely pending.
+- **#8 ☑ / #12 ☑** `handleGlobalImport` now routes imported assumptions through
+  `migrateAssumptions` (exported) instead of the bespoke spread — deep-merges
+  every section incl. `display`. **Deeper bug found+fixed:** `migrateAssumptions`'
+  legacy `birthYear→milestone` synthesis was **dead code** (it seeded `milestones`
+  from `defaults.milestones`, so the `if (!existingIds.has(...))` guards never
+  fired); now seeds `[]` when saved data lacks milestones, so legacy
+  demographics actually populate Birth/Retire/End-of-Plan (fresh users still get
+  identical built-ins — 44 AssumptionsContext tests still green).
+- **#9 ☑** Budget date reconstitution extracted from `hydrateBudgetState` into
+  exported `reconstituteBudgetState`; `handleGlobalImport` now dispatches it so
+  imported transaction/month dates are real `Date`s (instant round-trip, no UTC
+  date-only parsing).
+- **#10 ☑** `BudgetContext.generateId` + inline `MOVE_TRANSACTION` minter +
+  `backupMerge.generateMonthId` use `crypto.randomUUID()` (monotonic-counter
+  fallback) — collision-free within a tick.
+- **#11 ☑** `validateEarningsImport` now returns `valid: earnings.length > 0`
+  (empty is the only hard block); benign warnings no longer flip `valid`. Two
+  pre-existing tests that encoded the buggy `valid:false` were corrected.
+
+New tests: `hooks/useDebouncedLocalStorage.test.tsx`,
+`Budget/budgetImport.test.ts`, plus `PR #58 regressions` blocks in
+`QRUtils.test.ts`, `CSVImportService.test.ts`, `SSAImportService.test.ts`,
+`backupMerge.test.ts`, `useFileManager.test.tsx`. Eight pre-existing QR tests
+that encoded the obsolete `withdrawalOrder` shape were corrected (marked
+`PR #58: corrected`); no coverage deleted.
+
+---
+
+## Correctness findings
+
+### 1. ☐ QR round-trip drops `milestones` → age timeline reset to defaults
+`qrUtils.ts` `flattenAssumptions:222` / `expandAssumptions:250` predate the
+milestone refactor. `milestones` (now the source of birthYear / retirementAge /
+lifeExpectancy) is not special-cased in `flattenAssumptions`, so it's spread as
+numeric-index keys (`flat['0']`, `flat['1']`, …); `expandAssumptions` never
+re-emits it. A QR export→scan (`getBackupData()` carries the full live
+assumptions → `createCompactBackup` → `compactAssumptions`) followed by
+`handleGlobalImport` leaves `milestones = createBuiltinMilestones()` (birth 1990,
+retire 65, life 90). **Every projected year is silently reset.** Fix: round-trip
+the real top-level `milestones` array.
+
+### 2. ☐ QR `pp` key collision corrupts ESPP lot `purchasePrice`
+`qrUtils.ts` KEY_MAP maps **both** `purchasePrice` (ESPP lot, `:20`) and
+`projectedPIA` (Social Security, `:36`) to short key `pp`. `REVERSE_KEY_MAP['pp']`
+resolves to the last writer, `projectedPIA`, so `expandKeys` renames every lot's
+`purchasePrice` → `projectedPIA` on import. `reconstituteAccount`
+(`models.tsx:977`, `purchasePrice: Number(lot.purchasePrice) || 0`) then sees no
+`purchasePrice` and sets it to **0**, destroying the lot's cost basis and all
+ESPP gain/tax math. Fix: give `projectedPIA` a unique short key; keep `pp`
+decoding to `purchasePrice` (legacy SS `projectedPIA` is recomputed, so losing
+its legacy decode is harmless).
+
+### 3. ☐ CSV import mints colliding transaction ids
+`CSVImportService.ts:648`: `TXN-${Date.now()}-${Math.floor(Math.random()*10000)}`
+runs inside a synchronous loop, so `Date.now()` is constant and only a 4-digit
+random varies — ~99% collision probability for a ~300-row CSV. `BudgetContext`
+`DELETE_TRANSACTION` (`filter(t => t.id !== id)`) and `UPDATE_TRANSACTION`
+(`t.id === id`) act on **every** colliding twin, and React list keys collide.
+Fix: per-import counter or `crypto.randomUUID()`.
+
+### 4. ☐ QR round-trip drops the burn order (top-level `withdrawalStrategy` array)
+`qrUtils.ts` `flattenAssumptions:226` special-cases a key named `withdrawalOrder`
+that **does not exist** in `AssumptionsState`; the real burn order is the
+top-level `withdrawalStrategy: WithdrawalBucket[]`, which falls into the object
+branch and is lost. `expandAssumptions:288` re-emits the phantom `withdrawalOrder`
+(nothing reads it). After import `withdrawalStrategy = []` (default), so
+`SimulationEngine.tsx:384` (`assumptions.withdrawalStrategy.map(...)`) runs on an
+empty array — the user's manual withdrawal order is silently reset. Fix:
+flatten/expand the top-level `withdrawalStrategy` array under a distinct key from
+the `investments.withdrawalStrategy` **string**.
+
+### 5. ☐ One invalid saved regex rule crashes the whole CSV import
+`CSVImportService.ts:822` (`applyCategories`) builds `new RegExp(rule.pattern, 'i')`
+with **no** try/catch, unlike the guarded `BudgetContext` `APPLY_CATEGORY_RULE`
+(`:329`). A saved category rule with an invalid pattern (`(`, `[a-`) throws
+`SyntaxError` inside `.map`, aborting the entire import pipeline
+(`useCSVImportFlow.ts:69,153`). Fix: wrap the regex build/test in try/catch
+returning `false` (mirror the reducer).
+
+### 6. ☐ QR round-trip drops `priorEarnings` and newer investments flags
+`qrUtils.ts` `expandAssumptions:250` hardcodes a stale subset, dropping
+`demographics.priorEarnings` (imported SSA earnings) and
+`investments.{taxOptimizationEnabled,acaAware,rothConversionStrategy,rothConversionMinRateGap,rothConversionDPBackloadDelta}`.
+These ride into the compact payload but are never restored, so import falls back
+to defaults: SS PIA projection loses earnings history; Tax-Optimization / ACA /
+Roth-strategy revert, silently changing the simulation. Fix: restore them in
+`expandAssumptions` (or replace the bespoke allow-list with a generic
+shorten/expand keyed off `defaultAssumptions`).
+
+### 7. ☐ Debounced write lost on hard reload / tab close within 500ms
+`useDebouncedLocalStorage.ts:36` schedules the write 500ms out; the unmount-flush
+effect (`:52`) does **not** run on a real browser navigation/unload, and there is
+no `beforeunload`/`pagehide` handler. Edit-then-reload (or close) inside the
+window loses the change — most acute right after `handleGlobalImport`, where
+users commonly reload to "make it take." Fix: flush synchronously on `pagehide`
+(and/or `visibilitychange → hidden`).
+
+### 8. ☐ Importing a legacy (pre-milestones) backup resets the age timeline
+`useFileManager.ts:90` `handleGlobalImport` merges assumptions inline but never
+runs the `birthYear/retirementAge/lifeExpectancy → milestone` migration that
+`migrateAssumptions` performs on the localStorage path. Importing an older JSON
+backup (demographics.birthYear, no `milestones`) takes `milestones` from
+`...defaultAssumptions` (built-ins, birth 1990) and ignores the legacy birth
+year. Fix: route imported assumptions through `migrateAssumptions` (single source
+of truth) instead of the bespoke spread.
+
+### 9. ☐ Budget import leaves transaction/month dates as strings
+`useFileManager.ts:115` dispatches `budget` SET_BULK_DATA with the raw
+`JSON.parse`'d payload, so `transactions[].date` / `createdAt` / `updatedAt` /
+`statementDate` stay **strings** (typed `Date`); it bypasses `hydrateBudgetState`
+(localStorage-only) and no reload follows (`window.location.reload` is commented
+out, `:124`). The live post-import session holds string dates where `Date` is
+expected — consumers that don't defensively wrap in `new Date(...)` mis-render
+until a hard reload. Fix: reconstitute budget dates in the import payload (reuse
+`hydrateBudgetState`'s date mapping).
+
+### 10. ☐ MONTH-id collision when several months are created in one tick
+`BudgetContext.tsx:29` `generateId('MONTH')` = `MONTH-${Date.now()}-${rand(1000)}`
+(and `backupMerge.ts:138` `generateMonthId`). A CSV import spanning multiple new
+months runs `getOrCreateMonth` several times in one synchronous tick; with
+~1/1000 per pair two distinct months get the same id, and every id-keyed action
+(UPDATE_MONTH, ADD/UPDATE/DELETE_TRANSACTION, UPDATE_SPENDING) then hits both.
+Fix: monotonic counter / `crypto.randomUUID()` in both id minters.
+
+### 11. ☐ `validateEarningsImport` blocks on benign warnings
+`SSAImportService.ts:143` returns `valid: warnings.length === 0`, so a benign
+"Found N future year(s) which will be ignored" warning (common — SSA exports list
+the current partial year) flips `valid` to false, contradicting the documented
+"doesn't block import" contract. Latent today (the caller checks `warnings.length`)
+but wrong-by-contract. Fix: base `valid` only on truly blocking conditions
+(e.g. `earnings.length === 0`).
+
+### 12. ☐ `handleGlobalImport` doesn't deep-merge `display` (and arrays) with defaults
+`useFileManager.ts:91`: macro/income/expenses/investments/demographics are
+deep-merged with `defaultAssumptions`, but `display` is replaced wholesale by
+`...data.assumptions`, so a backup predating a newer display field (e.g.
+`hsaEligible`) leaves it `undefined` instead of defaulted. Subsumed by the
+finding #8 fix (route through `migrateAssumptions`, which deep-merges every
+section). Listed separately for completeness.
+
+---
+
+## Cleanup / lower-priority
+
+- **13. ☑** `qrUtils.stripDefaults` now compares empty default **arrays**
+  structurally, so `conversionHistory: []` / `lots: []` strip (and re-add via
+  `restoreDefaults`) instead of bloating the payload. The intentional, tested
+  null-stripping is retained. Test corrected: empty default array now strips +
+  round-trips.
+- **14. ☑** `AccountContext.exportData` now calls `URL.revokeObjectURL(url)` after
+  `a.click()`, matching `useFileManager.handleGlobalExport`.
+- **15. ☑** `compressData` builds the binary string in 32 KB chunks before
+  `btoa`, avoiding the `String.fromCharCode(...bytes)` spread `RangeError` on
+  large payloads. Regression test: a 379 KB deflated payload (proven to throw on
+  the old spread) now compresses and round-trips.
+
+---
+
+## Refuted / by-design (checked, not bugs)
+
+- **No crash importing a backup missing `withdrawalStrategy`/`milestones`.**
+  `...defaultAssumptions` backfills both before `...data.assumptions` spreads, so
+  `SimulationEngine.tsx:384`'s `.map` and `getBirthYear().find` never see
+  undefined — the real failure is silent data **reset** (#1/#4/#8), not a crash.
+- **`applyBalances` multi-target split setting a zero-weight account to 0 is
+  by-design.** A 0-balance account inside a weighted split (e.g. a 401k pre-tax /
+  Roth / employer split) correctly receives its proportional share of 0; it is not
+  "wiping a standalone account" (a standalone account wouldn't be in the map).
+- **`detectDuplicates` date comparison is consistent in-app.** Hydrated and
+  freshly-parsed transaction dates are both local-instant `Date` objects that
+  round-trip through `toISOString`/`new Date`, so `toDateString()` agrees; no
+  UTC off-by-one on the in-app path.
+- **`useDebouncedLocalStorage` unmount flush ordering is correct** — effect-A
+  cleanup clears the timer, effect-B cleanup writes the latest value via refs.

--- a/src/__tests__/Components/Objects/Accounts/models-bugs-7-9.test.tsx
+++ b/src/__tests__/Components/Objects/Accounts/models-bugs-7-9.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Regression tests for confirmed bugs in Accounts/models.tsx
+ *
+ * Finding 7: PropertyAccount drops `apr` on increment AND reconstitute
+ * Finding 9: reconstituteAccount coerces customROR null → 0 instead of undefined
+ */
+import { describe, it, expect } from 'vitest';
+import {
+    PropertyAccount,
+    InvestedAccount,
+    ESPPAccount,
+    reconstituteAccount,
+} from '../../../../components/Objects/Accounts/models';
+import { defaultAssumptions } from '../../../../components/Objects/Assumptions/AssumptionsContext';
+
+// Minimal assumptions sufficient for PropertyAccount.increment
+const mockAssumptions = {
+    ...defaultAssumptions,
+    macro: {
+        ...defaultAssumptions.macro,
+        inflationRate: 3,
+        inflationAdjusted: false,
+    },
+    expenses: {
+        ...defaultAssumptions.expenses,
+        housingAppreciation: 5,
+    },
+};
+
+// ─── Finding 7 ────────────────────────────────────────────────────────────────
+
+describe('Finding 7 – PropertyAccount preserves apr', () => {
+    it('increment: apr is carried through to the returned instance', () => {
+        const acc = new PropertyAccount('p1', 'My Home', 500_000, 'Financed', 400_000, 400_000, 'm1', 5);
+
+        const next = acc.increment(mockAssumptions);
+
+        // BUG: before fix, next.apr would be 0 (default, because 8th arg was omitted)
+        expect(next.apr).toBe(5);
+    });
+
+    it('increment with override: apr is still preserved', () => {
+        const acc = new PropertyAccount('p1', 'My Home', 500_000, 'Financed', 400_000, 400_000, 'm1', 7.25);
+
+        const next = acc.increment(mockAssumptions, { newValue: 510_000, newLoanBalance: 395_000 });
+
+        expect(next.apr).toBe(7.25);
+    });
+
+    it('reconstitute: apr is restored from serialized data', () => {
+        const serialized = {
+            className: 'PropertyAccount',
+            id: 'p2',
+            name: 'Beach House',
+            amount: 800_000,
+            ownershipType: 'Financed',
+            loanAmount: 600_000,
+            startingLoanBalance: 620_000,
+            linkedAccountId: 'loan-99',
+            apr: 5,
+        };
+
+        const result = reconstituteAccount(serialized) as PropertyAccount;
+
+        // BUG: before fix, result.apr would be 0 because the 8th arg was missing
+        expect(result).not.toBeNull();
+        expect(result.apr).toBe(5);
+    });
+
+    it('reconstitute: fractional apr round-trips correctly', () => {
+        const serialized = {
+            className: 'PropertyAccount',
+            id: 'p3',
+            name: 'Rental',
+            amount: 300_000,
+            ownershipType: 'Financed',
+            loanAmount: 200_000,
+            startingLoanBalance: 200_000,
+            linkedAccountId: 'loan-11',
+            apr: 3.875,
+        };
+
+        const result = reconstituteAccount(serialized) as PropertyAccount;
+
+        expect(result.apr).toBeCloseTo(3.875);
+    });
+
+    it('reconstitute: missing apr defaults to 0 (owned property)', () => {
+        const serialized = {
+            className: 'PropertyAccount',
+            id: 'p4',
+            name: 'Cabin',
+            amount: 200_000,
+            ownershipType: 'Owned',
+            loanAmount: 0,
+            startingLoanBalance: 0,
+            linkedAccountId: '',
+            // apr intentionally absent
+        };
+
+        const result = reconstituteAccount(serialized) as PropertyAccount;
+
+        expect(result.apr).toBe(0);
+    });
+});
+
+// ─── Finding 9 ────────────────────────────────────────────────────────────────
+
+describe('Finding 9 – reconstituteAccount: customROR null → undefined', () => {
+    describe('InvestedAccount', () => {
+        it('customROR: null serialized value restores as undefined (not 0)', () => {
+            const serialized = {
+                className: 'InvestedAccount',
+                id: 'i1',
+                name: 'Brokerage',
+                amount: 50_000,
+                customROR: null, // persisted as null in localStorage
+            };
+
+            const result = reconstituteAccount(serialized) as InvestedAccount;
+
+            // BUG: before fix, result.customROR would be 0 because Number(null)=0
+            expect(result.customROR).toBeUndefined();
+        });
+
+        it('customROR: numeric value round-trips correctly', () => {
+            const serialized = {
+                className: 'InvestedAccount',
+                id: 'i2',
+                name: 'Roth IRA',
+                amount: 100_000,
+                customROR: 6,
+            };
+
+            const result = reconstituteAccount(serialized) as InvestedAccount;
+
+            expect(result.customROR).toBe(6);
+        });
+
+        it('customROR: absent value stays undefined', () => {
+            const serialized = {
+                className: 'InvestedAccount',
+                id: 'i3',
+                name: 'Traditional 401k',
+                amount: 200_000,
+                // customROR not present at all
+            };
+
+            const result = reconstituteAccount(serialized) as InvestedAccount;
+
+            expect(result.customROR).toBeUndefined();
+        });
+    });
+
+    describe('ESPPAccount', () => {
+        it('customROR: null serialized value restores as undefined (not 0)', () => {
+            const serialized = {
+                className: 'ESPPAccount',
+                id: 'espp1',
+                name: 'Company ESPP',
+                amount: 20_000,
+                customROR: null, // persisted as null
+            };
+
+            const result = reconstituteAccount(serialized) as ESPPAccount;
+
+            // BUG: before fix, result.customROR would be 0
+            expect(result.customROR).toBeUndefined();
+        });
+
+        it('customROR: numeric value round-trips correctly', () => {
+            const serialized = {
+                className: 'ESPPAccount',
+                id: 'espp2',
+                name: 'Company ESPP',
+                amount: 20_000,
+                customROR: 8,
+            };
+
+            const result = reconstituteAccount(serialized) as ESPPAccount;
+
+            expect(result.customROR).toBe(8);
+        });
+
+        it('customROR: absent value stays undefined', () => {
+            const serialized = {
+                className: 'ESPPAccount',
+                id: 'espp3',
+                name: 'Company ESPP',
+                amount: 20_000,
+                // customROR not present
+            };
+
+            const result = reconstituteAccount(serialized) as ESPPAccount;
+
+            expect(result.customROR).toBeUndefined();
+        });
+    });
+});

--- a/src/__tests__/Components/Objects/Accounts/useFileManager.test.tsx
+++ b/src/__tests__/Components/Objects/Accounts/useFileManager.test.tsx
@@ -7,7 +7,14 @@ import { AccountProvider } from '../../../../components/Objects/Accounts/Account
 import { IncomeProvider } from '../../../../components/Objects/Income/IncomeContext';
 import { ExpenseProvider } from '../../../../components/Objects/Expense/ExpenseContext';
 import { TaxProvider } from '../../../../components/Objects/Taxes/TaxContext';
-import { AssumptionsProvider, defaultAssumptions } from '../../../../components/Objects/Assumptions/AssumptionsContext';
+import {
+  AssumptionsProvider,
+  defaultAssumptions,
+  migrateAssumptions,
+  getBirthYear,
+  getRetirementAge,
+  getLifeExpectancy,
+} from '../../../../components/Objects/Assumptions/AssumptionsContext';
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -606,6 +613,33 @@ describe('useFileManager', () => {
         'stag_balance_account_map',
         JSON.stringify(map)
       );
+    });
+  });
+
+  // Findings #8 + #12: handleGlobalImport routes data.assumptions through
+  // migrateAssumptions (instead of a hand-rolled spread) so importing an OLD
+  // backup — legacy demographics.{birthYear,retirementAge,lifeExpectancy} with no
+  // `milestones` array — synthesizes the built-in milestones from those legacy
+  // values rather than resetting the age timeline to defaults (1990/65/90), and
+  // deep-merges every section (display + arrays). This focused test proves the
+  // legacy->milestone path that the import now relies on.
+  describe('migrateAssumptions legacy demographics -> milestones', () => {
+    it('synthesizes built-in milestones from legacy birthYear/retirementAge/lifeExpectancy', () => {
+      const legacy = {
+        demographics: { birthYear: 1975, retirementAge: 60, lifeExpectancy: 95 },
+        // No milestones array at all (old backup shape).
+      };
+
+      const result = migrateAssumptions(legacy, defaultAssumptions);
+
+      expect(getBirthYear(result.milestones)).toBe(1975);
+      expect(getRetirementAge(result.milestones)).toBe(60);
+      expect(getLifeExpectancy(result.milestones)).toBe(95);
+    });
+
+    it('falls back to defaults when a non-object is passed', () => {
+      const result = migrateAssumptions(undefined, defaultAssumptions);
+      expect(result).toBe(defaultAssumptions);
     });
   });
 

--- a/src/__tests__/Components/Objects/Assumptions/GoalFundingGateUtcYear.test.tsx
+++ b/src/__tests__/Components/Objects/Assumptions/GoalFundingGateUtcYear.test.tsx
@@ -2,16 +2,14 @@
  * Bug #11 regression: the goal sinking-fund funding gate must read the goal's
  * target/start year with the SAME calendar convention as the purchase gate.
  *
- * Goal dates are stored as UTC-midnight. `isGoalDueInYear` (and the lump-sum
- * purchase, which flows through it) reads them with `getUTCFullYear()`. The
- * funding gate in SimulationEngine previously read them with the local
- * `getFullYear()`. In a negative-UTC timezone (e.g. US), a `YYYY-01-01` target
- * read locally slips to the prior year, so the funding priority was capped to
- * $0 ("already purchased") a full year BEFORE the lump actually fired — leaving
- * the goal underfunded.
- *
- * These tests pin the two readers together at the year boundary, and exercise
- * the real engine through a UTC-midnight target date.
+ * Goal dates are stored as LOCAL-midnight (parseDate / the expense form build
+ * them with `new Date(y, m-1, d)`). Both the funding gate (getGoalFundMonthlyCap)
+ * and the purchase gate (isGoalDueInYear) read them with `getFullYear()`. If the
+ * two readers ever drift apart (one local, one UTC), a `YYYY-01-01` target slips
+ * a year in one of them, so the funding priority is capped to $0 ("already
+ * purchased") a full year before — or after — the lump actually fires, leaving
+ * the goal mis-funded. These tests pin the two readers together at the year
+ * boundary and exercise the real engine through a Jan-1 target date.
  */
 import { describe, it, expect } from 'vitest';
 import { AssumptionsState, defaultAssumptions, createBuiltinMilestones } from '../../../../components/Objects/Assumptions/AssumptionsContext';
@@ -23,24 +21,24 @@ import { runSimulation } from '../../../../components/Objects/Assumptions/useSim
 
 // Replicates the funding-gate predicate from getGoalFundMonthlyCap (used by
 // SimulationEngine's per-year priority derivation). Kept in lockstep with the
-// source so this test fails if either reader drifts back to a local
-// getFullYear(). A goal's endDate IS its target date.
+// source so this test fails if either reader drifts to a UTC getUTCFullYear().
+// A goal's endDate IS its target date.
 function fundingGateInactive(
     e: { startDate?: Date | null; goalType?: string; endDate?: Date | null },
     year: number,
 ): boolean {
-    const goalStartYear = (e.startDate ? new Date(e.startDate) : new Date()).getUTCFullYear();
+    const goalStartYear = (e.startDate ? new Date(e.startDate) : new Date()).getFullYear();
     if (year < goalStartYear) return true;
     if (e.goalType === 'targetDate' && e.endDate
-        && new Date(e.endDate).getUTCFullYear() < year) return true;
+        && new Date(e.endDate).getFullYear() < year) return true;
     return false;
 }
 
-describe('Bug #11 — goal funding gate UTC year', () => {
-    it('funding gate and isGoalDueInYear agree on the year for a UTC-midnight target', () => {
-        const goal = new OtherExpense('exp-car', 'Car', 30000, 'Monthly', new Date(Date.UTC(2025, 0, 1)));
+describe('Bug #11 — goal funding gate year', () => {
+    it('funding gate and isGoalDueInYear agree on the year for a Jan-1 target', () => {
+        const goal = new OtherExpense('exp-car', 'Car', 30000, 'Monthly', new Date(2025, 0, 1));
         goal.goalType = 'targetDate';
-        goal.endDate = new Date(Date.UTC(2030, 0, 1)); // endDate IS the target
+        goal.endDate = new Date(2030, 0, 1); // endDate IS the target
         goal.goalAccountId = 'acc-car-fund';
 
         // The gate must NOT mark the goal "already purchased" until AFTER the
@@ -61,7 +59,7 @@ describe('Bug #11 — goal funding gate UTC year', () => {
         expect(isGoalDueInYear(goal, 2031)).toBe(false);
     });
 
-    it('end-to-end: a UTC-midnight target goal accrues through the prior year and buys in the target year', () => {
+    it('end-to-end: a Jan-1 target goal accrues through the prior year and buys in the target year', () => {
         const startYear = 2025;
         const targetYear = 2030;
 
@@ -82,14 +80,14 @@ describe('Bug #11 — goal funding gate UTC year', () => {
         const income = new WorkIncome(
             'inc-work', 'Salary', 90000, 'Annually', 'Yes',
             0, 0, 0, 0, '', null, 'FIXED',
-            new Date(Date.UTC(startYear, 0, 1)), new Date(Date.UTC(startYear + 40, 11, 31)),
+            new Date(startYear, 0, 1), new Date(startYear + 40, 11, 31),
         );
-        const living = new FoodExpense('exp-living', 'Living', 20000, 'Annually', new Date(Date.UTC(startYear, 0, 1)));
+        const living = new FoodExpense('exp-living', 'Living', 20000, 'Annually', new Date(startYear, 0, 1));
 
-        // UTC-midnight target — this is the date shape that triggered the bug.
-        const carGoal = new OtherExpense('exp-car', 'Car', 12000, 'Monthly', new Date(Date.UTC(startYear, 0, 1)));
+        // Jan-1 (local-midnight) target — the date shape that triggered the bug.
+        const carGoal = new OtherExpense('exp-car', 'Car', 12000, 'Monthly', new Date(startYear, 0, 1));
         carGoal.goalType = 'targetDate';
-        carGoal.endDate = new Date(Date.UTC(targetYear, 0, 1)); // endDate IS the target
+        carGoal.endDate = new Date(targetYear, 0, 1); // endDate IS the target
         carGoal.goalAccountId = 'acc-car-fund';
 
         const sim = runSimulation(8, [carFund], [income], [living, carGoal], assumptions, taxState)

--- a/src/__tests__/Components/Objects/Budget/budgetImport.test.ts
+++ b/src/__tests__/Components/Objects/Budget/budgetImport.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { reconstituteBudgetState, generateId } from '../../../../components/Objects/Budget/BudgetContext';
+
+// Finding #10: generateId('MONTH') = `MONTH-${Date.now()}-${rand(1000)}` collided
+// when several months were minted in one synchronous tick (Date.now() is ms-coarse,
+// rand has only 1000 buckets). The minter must be collision-free within a tick.
+describe('generateId collision-free within a tick (Finding #10)', () => {
+  it('produces 1000 unique ids in a tight synchronous loop', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      ids.add(generateId('MONTH'));
+    }
+    expect(ids.size).toBe(1000);
+  });
+});
+
+// Finding #9: the global backup import (useFileManager.handleGlobalImport) used to
+// dispatch SET_BULK_DATA with the raw JSON.parse'd budget, leaving transactions'
+// date/statementDate and months' createdAt/updatedAt as STRINGS under Date-typed
+// fields (bypassing hydrateBudgetState). reconstituteBudgetState rehydrates them.
+describe('reconstituteBudgetState (Finding #9)', () => {
+  it('rehydrates month + transaction date fields from ISO strings to Date', () => {
+    // Shape that JSON.parse of an exported budget produces: dates are strings.
+    const parsed = {
+      months: [
+        {
+          id: 'M1',
+          month: 1,
+          year: 2026,
+          spending: {},
+          accountBalances: {},
+          contributions: {},
+          reconciled: false,
+          createdAt: '2026-01-15T10:00:00.000Z',
+          updatedAt: '2026-01-20T12:00:00.000Z',
+          transactions: [
+            {
+              id: 't1',
+              date: '2026-01-05T00:00:00.000Z',
+              statementDate: '2026-01-10T00:00:00.000Z',
+              description: 'WHOLE FOODS',
+              amount: -42,
+            },
+          ],
+        },
+      ],
+      importSettings: {
+        dateColumn: 'Date',
+        amountColumn: 'Amount',
+        descriptionColumn: 'Description',
+        categoryMappings: [],
+        savedCSVFormats: [
+          { id: 'f1', name: 'Chase', lastUsed: '2026-01-01T00:00:00.000Z', createdAt: '2025-12-01T00:00:00.000Z' },
+        ],
+        autoCreateRules: false,
+      },
+    };
+
+    const result = reconstituteBudgetState(parsed);
+
+    const month = result.months![0];
+    const txn = month.transactions[0];
+
+    expect(txn.date instanceof Date).toBe(true);
+    expect(txn.statementDate instanceof Date).toBe(true);
+    expect(month.createdAt instanceof Date).toBe(true);
+    expect(month.updatedAt instanceof Date).toBe(true);
+
+    // Instant round-trips exactly (no UTC date-only shifting introduced).
+    expect((txn.date as Date).toISOString()).toBe('2026-01-05T00:00:00.000Z');
+
+    // Saved CSV format dates are rehydrated too.
+    const fmt = result.importSettings!.savedCSVFormats[0];
+    expect(fmt.lastUsed instanceof Date).toBe(true);
+    expect(fmt.createdAt instanceof Date).toBe(true);
+  });
+
+  it('tolerates a transaction with no statementDate (leaves it undefined)', () => {
+    const parsed = {
+      months: [
+        {
+          id: 'M1', month: 2, year: 2026,
+          spending: {}, accountBalances: {}, contributions: {}, reconciled: false,
+          transactions: [{ id: 't1', date: '2026-02-01T00:00:00.000Z', description: 'X', amount: -1 }],
+        },
+      ],
+    };
+    const result = reconstituteBudgetState(parsed);
+    const txn = result.months![0].transactions[0];
+    expect(txn.date instanceof Date).toBe(true);
+    expect(txn.statementDate).toBeUndefined();
+  });
+});

--- a/src/__tests__/Components/Objects/Expense/bugs.test.tsx
+++ b/src/__tests__/Components/Objects/Expense/bugs.test.tsx
@@ -1,0 +1,285 @@
+/**
+ * Bug-regression tests for confirmed findings in Expense/models.tsx.
+ * Each section references the finding number from the audit.
+ *
+ * Run with default TZ for most tests.
+ * For Finding 1 (timezone safety), run explicitly:
+ *   TZ=Australia/Sydney npx vitest run src/__tests__/Components/Objects/Expense/bugs.test.tsx
+ *   TZ=America/New_York npx vitest run src/__tests__/Components/Objects/Expense/bugs.test.tsx
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  LoanExpense,
+  MortgageExpense,
+  OtherExpense,
+  AnyExpense,
+  getExpenseActiveMultiplier,
+  isGoalDueInYear,
+  getGoalFundAnnualSetAside,
+  getGoalFundMonthlyCap,
+} from '../../../../components/Objects/Expense/models';
+
+// ============================================================
+// FINDING 2: LoanExpense.getAnnualAmount uncapped → Sankey imbalance
+// ============================================================
+describe('Finding 2: LoanExpense.getAnnualAmount must be capped at calculateAnnualAmortization', () => {
+  /**
+   * Construct a loan that will pay off mid-year.
+   * Balance = $1,200. Monthly payment = $1,000. APR = 0% (simple).
+   * At 0% the monthly interest = 0, so every dollar of payment goes to principal.
+   * Month 1: pays $1,000 → balance = $200.
+   * Month 2: pays $200 (capped) → balance = 0. Loan done.
+   * calculateAnnualAmortization.totalPayment = $1,200.
+   * Old getAnnualAmount = $1,000 * 12 = $12,000 (WRONG).
+   */
+  const startDate = new Date(2030, 0, 1);  // Jan 1 2030 local
+  const endDate   = new Date(2035, 0, 1);  // far enough that loan isn't considered "ended" mid-year
+
+  // Override endDate so the amortization loop runs; the balance itself controls early exit.
+  // We want a loan whose balance pays off early.
+  // $1,200 balance, $1,000/mo, 0% APR → paid off after 2 payments.
+  const loan = new LoanExpense(
+    'l-payoff', 'Payoff Loan', 1200, 'Monthly',
+    0,          // apr = 0%
+    'Simple',
+    1000,       // explicit payment = $1,000/month
+    'No', 0, 'a1',
+    startDate,
+    endDate,
+  );
+
+  it('calculateAnnualAmortization caps total payment at balance (not full year)', () => {
+    const { totalPayment } = loan.calculateAnnualAmortization(2030);
+    // Only $1,200 is actually paid (the balance), not $12,000.
+    expect(totalPayment).toBeCloseTo(1200, 2);
+    expect(totalPayment).toBeLessThan(loan.payment * 12);
+  });
+
+  it('getAnnualAmount(payoffYear) equals calculateAnnualAmortization(payoffYear).totalPayment', () => {
+    const { totalPayment } = loan.calculateAnnualAmortization(2030);
+    expect(loan.getAnnualAmount(2030)).toBeCloseTo(totalPayment, 2);
+  });
+
+  it('getAnnualAmount(payoffYear) is LESS than payment * 12', () => {
+    expect(loan.getAnnualAmount(2030)).toBeLessThan(loan.payment * 12);
+  });
+
+  it('getMonthlyAmount(payoffYear) equals getAnnualAmount(payoffYear) / 12', () => {
+    expect(loan.getMonthlyAmount(2030)).toBeCloseTo(loan.getAnnualAmount(2030) / 12, 8);
+  });
+
+  it('getAnnualAmount in a normal (non-payoff) year still returns payment * active_months', () => {
+    // In a later year after the loan is paid (balance=0 from the start of the year),
+    // calculateAnnualAmortization returns 0 and so should getAnnualAmount.
+    // But for a running year with full balance, it should match active months × payment.
+    // Use a fresh loan that won't pay off in 2030 to test non-payoff path.
+    const bigLoan = new LoanExpense(
+      'l-big', 'Big Loan', 100000, 'Monthly',
+      5, 'Compounding', 1000, 'No', 0, 'a1',
+      new Date(2030, 0, 1),
+      new Date(2040, 0, 1),
+    );
+    // Full year — getAnnualAmount should equal payment * 12 (no early payoff).
+    const { totalPayment } = bigLoan.calculateAnnualAmortization(2030);
+    expect(bigLoan.getAnnualAmount(2030)).toBeCloseTo(totalPayment, 2);
+  });
+});
+
+// ============================================================
+// FINDING 5: MortgageExpense.calculatePayment adds PMI with no LTV gate
+// ============================================================
+describe('Finding 5: MortgageExpense.calculatePayment must gate PMI on LTV > 80%', () => {
+  /**
+   * Mortgage with 50% LTV (loan_balance / valuation = 0.5).
+   * PMI rate is non-zero (0.5%). LTV <= 80% → PMI must be $0.
+   * The bug: calculatePayment() includes PMI unconditionally.
+   */
+  const mortgageLowLTV = new MortgageExpense(
+    'm-ltv', 'Low LTV', 'Monthly',
+    400000,   // valuation
+    200000,   // loan_balance  → LTV = 0.50 (50%)
+    200000,   // starting_loan_balance
+    4,        // apr
+    30,       // term
+    0, 0, 0, 0,   // taxes, deduction, maintenance, utilities
+    0,        // home_owners_insurance
+    0.5,      // pmi rate (0.5%) — should NOT apply at 50% LTV
+    0,        // hoa_fee
+    'No', 0, 'a1',
+    new Date(2025, 0, 1),
+  );
+
+  // Same mortgage with PMI = 0 to get the "no-PMI" payment for comparison.
+  const mortgageNoPMI = new MortgageExpense(
+    'm-nopmi', 'No PMI', 'Monthly',
+    400000,
+    200000,
+    200000,
+    4,
+    30,
+    0, 0, 0, 0,
+    0,
+    0,        // pmi = 0
+    0,
+    'No', 0, 'a1',
+    new Date(2025, 0, 1),
+  );
+
+  it('LTV=50% (well below 80%): calculatePayment equals the no-PMI payment', () => {
+    // When LTV <= 80%, PMI should not be included, so both payments should be equal.
+    expect(mortgageLowLTV.calculatePayment()).toBeCloseTo(mortgageNoPMI.calculatePayment(), 2);
+  });
+
+  it('LTV=50%: PMI is NOT included in calculatePayment', () => {
+    const pmiMonthly = mortgageLowLTV.valuation * mortgageLowLTV.pmi / 100 / 12;
+    expect(pmiMonthly).toBeGreaterThan(0); // confirm PMI rate is non-zero
+    // The payment should NOT include PMI.
+    expect(mortgageLowLTV.calculatePayment()).toBeLessThan(
+      mortgageNoPMI.calculatePayment() + pmiMonthly
+    );
+  });
+
+  it('LTV=90% (above 80%): calculatePayment DOES include PMI', () => {
+    const mortgageHighLTV = new MortgageExpense(
+      'm-high-ltv', 'High LTV', 'Monthly',
+      400000,
+      360000,   // loan_balance → LTV = 0.90
+      360000,
+      4, 30,
+      0, 0, 0, 0,
+      0,
+      0.5,      // pmi rate
+      0,
+      'No', 0, 'a1',
+      new Date(2025, 0, 1),
+    );
+    const mortgageHighNoPMI = new MortgageExpense(
+      'm-high-nopmi', 'High LTV No PMI', 'Monthly',
+      400000,
+      360000,
+      360000,
+      4, 30,
+      0, 0, 0, 0,
+      0,
+      0,        // pmi = 0
+      0,
+      'No', 0, 'a1',
+      new Date(2025, 0, 1),
+    );
+    const pmiMonthly = 400000 * 0.005 / 12;
+    expect(mortgageHighLTV.calculatePayment()).toBeCloseTo(
+      mortgageHighNoPMI.calculatePayment() + pmiMonthly, 2
+    );
+  });
+});
+
+// ============================================================
+// FINDING 8: getGoalFundAnnualSetAside double-counts shared fund accounts
+// ============================================================
+describe('Finding 8: getGoalFundAnnualSetAside must sum across ALL goals sharing an accountId', () => {
+  /**
+   * Two targetDate goals sharing the same goalAccountId.
+   * Goal A: $24,000 over 24 months (2026–2028)  → $1,000/mo.
+   * Goal B: $48,000 over 24 months (2026–2028)  → $2,000/mo.
+   * Combined set-aside: $3,000/mo, $36,000/year.
+   *
+   * The bug: expenses.find() returns only the FIRST matching goal, so
+   * getGoalFundAnnualSetAside returns $1,000/mo × 12 = $12,000 instead of $36,000.
+   */
+  const makeGoal = (id: string, amount: number): AnyExpense => {
+    const g = new OtherExpense(id, `Goal ${id}`, amount, 'Monthly',
+      new Date(2026, 0, 1), new Date(2028, 0, 1));
+    g.goalType = 'targetDate';
+    // endDate IS the target for targetDate goals.
+    g.endDate = new Date(2028, 0, 1);
+    g.goalAccountId = 'fund1';
+    return g;
+  };
+
+  const goalA = makeGoal('ga', 24000); // $1,000/mo over 24 months
+  const goalB = makeGoal('gb', 48000); // $2,000/mo over 24 months
+  const expenses: AnyExpense[] = [goalA, goalB];
+
+  it('getGoalFundAnnualSetAside sums both goals (not just the first)', () => {
+    // 2027: both goals are fully active (12 months each).
+    // Expected: $1,000 × 12 + $2,000 × 12 = $36,000.
+    const total = getGoalFundAnnualSetAside(expenses, 'fund1', 2027);
+    expect(total).toBeCloseTo(36000, 2);
+  });
+
+  it('summed set-aside is NOT equal to 2× the first goal alone', () => {
+    const firstGoalOnly = getGoalFundAnnualSetAside([goalA], 'fund1', 2027)!;
+    const bothGoals = getGoalFundAnnualSetAside(expenses, 'fund1', 2027)!;
+    // Bug would return firstGoalOnly (= 12000) for bothGoals; correct is 36000.
+    expect(bothGoals).not.toBeCloseTo(firstGoalOnly, 2);
+    expect(bothGoals).toBeCloseTo(firstGoalOnly * 3, 2); // $12,000 × 3 = $36,000
+  });
+
+  it('getGoalFundMonthlyCap sums both goals', () => {
+    const cap = getGoalFundMonthlyCap(expenses, 'fund1', 2027);
+    // $1,000 + $2,000 = $3,000/mo.
+    expect(cap).toBeCloseTo(3000, 2);
+  });
+
+  it('returns undefined when no goal targets the account', () => {
+    expect(getGoalFundAnnualSetAside(expenses, 'other-fund', 2027)).toBeUndefined();
+    expect(getGoalFundMonthlyCap(expenses, 'other-fund', 2027)).toBeUndefined();
+  });
+
+  it('single-goal case still works correctly after fix', () => {
+    const singleGoal = getGoalFundAnnualSetAside([goalA], 'fund1', 2027);
+    expect(singleGoal).toBeCloseTo(12000, 2);
+  });
+});
+
+// ============================================================
+// FINDING 1: date readers use getUTC* on local-midnight dates (timezone safety)
+// ============================================================
+describe('Finding 1: local-midnight dates must use local (not UTC) accessors', () => {
+  /**
+   * parseDate (and direct code) builds LOCAL-midnight dates via new Date(y, m-1, d).
+   * Readers in models.tsx currently use getUTCFullYear()/getUTCMonth(), which shifts
+   * the window in positive-UTC timezones (e.g. Sydney, UTC+10/11):
+   *   new Date(2030,0,1) in Sydney = 2029-12-31T13:00:00Z
+   *   getUTCFullYear() → 2029  (WRONG, should be 2030)
+   *   getUTCMonth()    → 11    (WRONG, should be 0)
+   *
+   * After the fix all readers use getFullYear()/getMonth() (local accessors).
+   * These tests use new Date(y,m,d) (local midnight) to match how parseDate works.
+   */
+
+  describe('isGoalDueInYear — local-midnight endDate', () => {
+    it('targetDate goal with local Jan 1 2030 endDate is due in 2030', () => {
+      const g = new OtherExpense('g1', 'Goal', 10000, 'Monthly', new Date(2025, 0, 1));
+      g.goalType = 'targetDate';
+      g.endDate = new Date(2030, 0, 1);  // local midnight Jan 1 2030
+      expect(isGoalDueInYear(g, 2030)).toBe(true);
+      expect(isGoalDueInYear(g, 2029)).toBe(false);
+    });
+  });
+
+  describe('getExpenseActiveMultiplier — local-midnight startDate', () => {
+    it('expense starting local Jan 1 2030 is fully active in 2030 (multiplier=1)', () => {
+      const e = new OtherExpense('e1', 'Test', 100, 'Annually', new Date(2030, 0, 1));
+      // Should be 1 (active all 12 months). Would be 1/12 if getUTCMonth() returned 11.
+      expect(getExpenseActiveMultiplier(e, 2030)).toBe(1);
+    });
+
+    it('expense starting local Jan 1 2030 is NOT active in 2029', () => {
+      const e = new OtherExpense('e1', 'Test', 100, 'Annually', new Date(2030, 0, 1));
+      expect(getExpenseActiveMultiplier(e, 2029)).toBe(0);
+    });
+  });
+
+  describe('goalMonthsActiveInYear via getGoalFundAnnualSetAside — local-midnight dates', () => {
+    it('full-year goal active Jan–Dec 2030 gives 12 months of set-aside', () => {
+      // $12,000 over 12 months = $1,000/mo.
+      const g = new OtherExpense('g2', 'Goal', 12000, 'Monthly', new Date(2030, 0, 1));
+      g.goalType = 'targetDate';
+      g.endDate = new Date(2031, 0, 1);  // 12 months exactly
+      g.goalAccountId = 'acc';
+      const annual = getGoalFundAnnualSetAside([g], 'acc', 2030);
+      expect(annual).toBeCloseTo(12000, 2);
+    });
+  });
+});

--- a/src/__tests__/Components/Objects/Expense/models.test.tsx
+++ b/src/__tests__/Components/Objects/Expense/models.test.tsx
@@ -361,14 +361,14 @@ describe('Expense Models', () => {
         // P&I ≈ $1,799 (from $300k at 6%, 30yr)
         // + taxes $400/mo (property_taxes as % of valuation)
         // + insurance $150/mo
-        // + PMI $100/mo
+        // + PMI: LTV = 300k/400k = 75% <= 80%, so PMI does NOT apply (bug fix)
         // + repairs $200/mo
         // + utilities $300
         // + extra $0
         const mortgageWithAll = new MortgageExpense(
           'm-full', 'Full Payment', 'Monthly',
           400000,   // valuation
-          300000,   // loan_balance
+          300000,   // loan_balance → LTV = 75% (no PMI should apply)
           300000,   // starting_loan_balance
           6,        // apr
           30,       // term
@@ -377,7 +377,7 @@ describe('Expense Models', () => {
           0.6,      // maintenance (0.6% of valuation = $2400/yr = $200/mo)
           300,      // utilities
           0.45,     // insurance (0.45% of valuation = $1800/yr = $150/mo)
-          0.3,      // pmi (0.3% of valuation = $1200/yr = $100/mo)
+          0.3,      // pmi rate, but LTV <= 80% so PMI = $0
           0,        // hoa_fee
           'Yes', 0, 'a1',
           new Date('2024-01-01')
@@ -388,11 +388,11 @@ describe('Expense Models', () => {
         // P&I ≈ $1,798.65
         // taxes = 400000 × 0.012 / 12 = $400
         // insurance = 400000 × 0.0045 / 12 = $150
-        // pmi = 400000 × 0.003 / 12 = $100
+        // PMI = $0 (LTV 75% is ≤ 80%; PMI gate prevents inclusion)
         // repairs = 400000 × 0.006 / 12 = $200
         // utilities = $300
-        // Total ≈ $2,949
-        expect(payment).toBeCloseTo(2949, 0);
+        // Total ≈ $2,849 (was $2,949 before the PMI gate fix)
+        expect(payment).toBeCloseTo(2849, 0);
       });
     });
 
@@ -1043,101 +1043,90 @@ describe('Expense Models', () => {
     });
   });
 
-  // --- UTC date-only convention regression tests (bugs #5, #8) ---
-  // Date-only values are stored as UTC-midnight Dates. In a negative-UTC (US)
-  // timezone, new Date(Date.UTC(2030,0,1)) is 2029-12-31T19:00 local, so local
-  // getMonth()/getFullYear() read Dec 2029 (off by a month AND a year) while
-  // getUTC* correctly reads Jan 2030. These methods must use getUTC*.
-  describe('UTC date-only handling (timezone safety)', () => {
-    // 2030-01-01 at UTC midnight — reads as Dec 2029 with LOCAL accessors in US TZs.
-    const utcStart = new Date(Date.UTC(2030, 0, 1));
-    // 2035-06-01 at UTC midnight — reads as May 2035 with LOCAL accessors in US TZs.
-    const utcEnd = new Date(Date.UTC(2035, 5, 1));
+  // --- Local-midnight date convention regression tests ---
+  // Date-only values are built by parseDate via new Date(y, m-1, d) — LOCAL midnight.
+  // Readers now use getFullYear()/getMonth() (local) so they work correctly in any
+  // timezone: positive-UTC (Sydney) and negative-UTC (US) alike. Tests use
+  // new Date(y, m, d) (local midnight) to match production date construction.
+  describe('local-midnight date handling (timezone safety)', () => {
+    // Jan 1 2030 local midnight — matches parseDate('2030-01-01').
+    const localStart = new Date(2030, 0, 1);
+    // Jun 1 2035 local midnight.
+    const localEnd = new Date(2035, 5, 1);
 
-    describe('MortgageExpense.calculateAnnualAmortization (#5)', () => {
-      it('treats a UTC-midnight startDate as Jan 2030, not Dec 2029', () => {
+    describe('MortgageExpense.calculateAnnualAmortization', () => {
+      it('treats a local-midnight Jan 1 2030 startDate as Jan 2030', () => {
         const mortgage = new MortgageExpense(
-          'm-utc', 'UTC Home', 'Monthly',
+          'm-local', 'Local Home', 'Monthly',
           350000, 300000, 300000,
           6, 30,
           0, 0, 0, 0, 0,
           0, 0, 'Yes', 0, 'a1',
-          utcStart
+          localStart
         );
-        // year before start -> nothing.
+        // Year before start → nothing.
         expect(mortgage.calculateAnnualAmortization(2029).totalPayment).toBe(0);
-        // start year -> active (would be skipped if read as 2029 via local accessors,
-        // and the purchaseMonth would be 11 instead of 0).
+        // Start year → active.
         const startYear = mortgage.calculateAnnualAmortization(2030);
         expect(startYear.totalPayment).toBeGreaterThan(0);
-        // Jan start => full 12 months. A local read (Dec) would only count 1 month.
+        // Jan start → full 12 months equals a plain full year.
         const fullYear = mortgage.calculateAnnualAmortization(2031);
         expect(startYear.totalPayment).toBeCloseTo(fullYear.totalPayment, 0);
       });
     });
 
-    describe('LoanExpense.calculateAnnualAmortization (#5)', () => {
-      it('uses UTC accessors for start/end year and month boundaries', () => {
+    describe('LoanExpense.calculateAnnualAmortization', () => {
+      it('uses local accessors for start/end year and month boundaries', () => {
         const loan = new LoanExpense(
-          'l-utc', 'UTC Loan', 30000, 'Monthly',
+          'l-local', 'Local Loan', 30000, 'Monthly',
           6, 'Compounding', 600, 'No', 0, 'a1',
-          utcStart, // 2030-01-01 UTC
-          utcEnd    // 2035-06-01 UTC
+          localStart, // Jan 1 2030 local
+          localEnd    // Jun 1 2035 local
         );
-        // Before start year: zero. Local read would think start is Dec 2029.
+        // Before start year → zero.
         expect(loan.calculateAnnualAmortization(2029).totalPayment).toBe(0);
-        // Start year active and starts in January (full run of months from index 0).
+        // Start year active and starts in January.
         const startYear = loan.calculateAnnualAmortization(2030);
         expect(startYear.totalPayment).toBeGreaterThan(0);
-        // End year is 2035 (UTC), not 2035 misread as something else; past end => 0.
+        // End year is 2035 local; past end → 0.
         expect(loan.calculateAnnualAmortization(2036).totalPayment).toBe(0);
       });
     });
 
-    describe('getMonthsUntilPaidOff (#8)', () => {
-      it('computes whole months using UTC accessors', () => {
-        // Start on the 1st (UTC) — rolls back a month with local accessors in a
-        // US TZ. End mid-month (the 15th, UTC) — does NOT roll back. So a local
-        // read shifts only the start, giving 66 instead of the correct 65.
+    describe('getMonthsUntilPaidOff', () => {
+      it('computes whole months using local accessors', () => {
+        // Jan 2030 to Jun 2035 = 65 months: (2035-2030)*12 + (5-0) = 65.
         const loan = new LoanExpense(
-          'l-months-utc', 'UTC Loan', 30000, 'Monthly',
+          'l-months-local', 'Local Loan', 30000, 'Monthly',
           6, 'Compounding', 600, 'No', 0, 'a1',
-          new Date(Date.UTC(2030, 0, 1)),  // 2030-01-01 UTC
-          new Date(Date.UTC(2035, 5, 15))  // 2035-06-15 UTC
+          new Date(2030, 0, 1),  // Jan 2030 local
+          new Date(2035, 5, 15)  // Jun 15 2035 local (mid-month — getMonth still 5)
         );
         // (2035-2030)*12 + (5-0) = 65 months.
         expect(loan.getMonthsUntilPaidOff()).toBe(65);
       });
     });
 
-    describe('isExpenseActiveInCurrentMonth (#8)', () => {
-      it('agrees with getExpenseActiveMultiplier on the current year for UTC dates', () => {
-        // Build a UTC-midnight start on the 1st of the current month. With LOCAL
-        // accessors in a US TZ this would read as the previous month, but the
-        // expense is genuinely active now.
+    describe('isExpenseActiveInCurrentMonth', () => {
+      it('agrees with getExpenseActiveMultiplier on the current year for local dates', () => {
+        // Local-midnight start on the 1st of the current month — genuinely active.
         const now = new Date();
-        const utcThisMonth = new Date(Date.UTC(now.getFullYear(), now.getMonth(), 1));
-        const expense = new OtherExpense('e-utc', 'UTC active', 100, 'Monthly', utcThisMonth);
+        const localThisMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+        const expense = new OtherExpense('e-local', 'Local active', 100, 'Monthly', localThisMonth);
 
         expect(isExpenseActiveInCurrentMonth(expense)).toBe(true);
-        // Cross-check with the file's getUTC*-based multiplier: active this year.
         expect(getExpenseActiveMultiplier(expense, now.getFullYear())).toBeGreaterThan(0);
       });
 
-      it('treats a next-month UTC start as inactive (not pulled into this month)', () => {
-        // A UTC-midnight start on the 1st of NEXT month reads, in a US TZ, as the
-        // last day of THIS month with local accessors — which would wrongly mark
-        // it active now. With getUTC* it stays correctly inactive. (When run on
-        // the last day of a month the local roll-back lands in the current month
-        // too; the assertion holds either way since UTC start is still future.)
+      it('treats a next-month local start as inactive', () => {
         const now = new Date();
-        const nextMonthStart = new Date(Date.UTC(now.getFullYear(), now.getMonth() + 1, 1));
+        const nextMonthStart = new Date(now.getFullYear(), now.getMonth() + 1, 1);
         const expense = new OtherExpense('e-next', 'Next month', 100, 'Monthly', nextMonthStart);
         expect(isExpenseActiveInCurrentMonth(expense)).toBe(false);
       });
 
-      it('treats a future UTC start as inactive', () => {
-        const future = new Date(Date.UTC(new Date().getFullYear() + 2, 0, 1));
+      it('treats a future local start as inactive', () => {
+        const future = new Date(new Date().getFullYear() + 2, 0, 1);
         const expense = new OtherExpense('e-future', 'Future', 100, 'Monthly', future);
         expect(isExpenseActiveInCurrentMonth(expense)).toBe(false);
       });
@@ -1149,10 +1138,11 @@ describe('Expense Models', () => {
     // from the goal each year (getGoalFundMonthlyCap) so edits to the goal's
     // amount/dates propagate — the priority's stored capValue is only a
     // creation-time snapshot that nothing should trust.
+    // Dates use local midnight (new Date(y, m, d)) to match parseDate output.
     const makeGoal = (amount: number, startYear: number, targetYear: number) => {
-      const goal = new OtherExpense('exp-g', 'Goal', amount, 'Monthly', new Date(Date.UTC(startYear, 0, 1)));
+      const goal = new OtherExpense('exp-g', 'Goal', amount, 'Monthly', new Date(startYear, 0, 1));
       goal.goalType = 'targetDate';
-      goal.endDate = new Date(Date.UTC(targetYear, 0, 1));
+      goal.endDate = new Date(targetYear, 0, 1);
       goal.goalAccountId = 'acc-fund';
       return goal;
     };
@@ -1174,16 +1164,17 @@ describe('Expense Models', () => {
       const goal = makeGoal(36000, 2025, 2028);
       goal.amount = 72000; // user doubles the goal after creation
       expect(getGoalFundMonthlyCap([goal], 'acc-fund', 2026)).toBeCloseTo(2000, 5);
-      goal.endDate = new Date(Date.UTC(2031, 0, 1)); // user pushes the target out (72 months)
+      goal.endDate = new Date(2031, 0, 1); // user pushes the target out (72 months, local midnight)
       expect(getGoalFundMonthlyCap([goal], 'acc-fund', 2026)).toBeCloseTo(1000, 5);
     });
 
     it('getGoalFundAnnualSetAside prorates partial years and sums to the goal amount', () => {
       // Goal: $31,000 starting June 2026, due Jan 2029 → 31 months → $1,000/mo.
       // 2026 commits Jun–Dec (7 mo), 2027/2028 full years, 2029 (Jan target) 0.
-      const goal = new OtherExpense('exp-g', 'Goal', 31000, 'Monthly', new Date(Date.UTC(2026, 5, 1)));
+      // Dates are local midnight to match parseDate output.
+      const goal = new OtherExpense('exp-g', 'Goal', 31000, 'Monthly', new Date(2026, 5, 1));
       goal.goalType = 'targetDate';
-      goal.endDate = new Date(Date.UTC(2029, 0, 1));
+      goal.endDate = new Date(2029, 0, 1);
       goal.goalAccountId = 'acc-fund';
 
       expect(getGoalFundAnnualSetAside([goal], 'acc-fund', 2025)).toBe(0);
@@ -1199,10 +1190,10 @@ describe('Expense Models', () => {
     });
 
     it('getGoalFundAnnualSetAside prorates a mid-year target in the final year', () => {
-      // $24,000 from Jan 2026 to Jun 2028 → 29 months. 2028 commits Jan–May (5 mo).
-      const goal = new OtherExpense('exp-g', 'Goal', 29000, 'Monthly', new Date(Date.UTC(2026, 0, 1)));
+      // $29,000 from Jan 2026 to Jun 2028 → 29 months. 2028 commits Jan–May (5 mo).
+      const goal = new OtherExpense('exp-g', 'Goal', 29000, 'Monthly', new Date(2026, 0, 1));
       goal.goalType = 'targetDate';
-      goal.endDate = new Date(Date.UTC(2028, 5, 1));
+      goal.endDate = new Date(2028, 5, 1);
       goal.goalAccountId = 'acc-fund';
 
       expect(getGoalFundAnnualSetAside([goal], 'acc-fund', 2028)).toBeCloseTo(5000, 5);
@@ -1212,7 +1203,7 @@ describe('Expense Models', () => {
     });
 
     it('getGoalFundAnnualSetAside prorates a recurring goal start year, then runs full years', () => {
-      const goal = new OtherExpense('exp-g', 'Roof', 36000, 'Monthly', new Date(Date.UTC(2026, 9, 1))); // Oct
+      const goal = new OtherExpense('exp-g', 'Roof', 36000, 'Monthly', new Date(2026, 9, 1)); // Oct local
       goal.goalType = 'recurring';
       goal.intervalYears = 3; // $1,000/mo
       goal.goalAccountId = 'acc-fund';
@@ -1232,6 +1223,7 @@ describe('Expense Models', () => {
       // Pre-migration backups stored the target in a separate goalTargetDate
       // field (a duplicate of endDate that could drift). On load it must be
       // absorbed into endDate when endDate is missing.
+      // parseDate converts the ISO string to local midnight: new Date(2027, 0, 1).
       const legacy = {
         className: 'OtherExpense',
         id: 'exp-legacy', name: 'Legacy goal', amount: 12000, frequency: 'Monthly',
@@ -1241,7 +1233,8 @@ describe('Expense Models', () => {
         goalAccountId: 'acc-fund',
       };
       const expense = reconstituteExpense(legacy)!;
-      expect(expense.endDate?.getUTCFullYear()).toBe(2027);
+      // parseDate builds local midnight, so getFullYear() = 2027 regardless of TZ.
+      expect(expense.endDate?.getFullYear()).toBe(2027);
       expect(getGoalMonthlySetAside(expense)).toBeCloseTo(12000 / 24, 5);
     });
   });

--- a/src/__tests__/Components/Objects/Income/models.test.tsx
+++ b/src/__tests__/Components/Objects/Income/models.test.tsx
@@ -891,23 +891,25 @@ describe('Income Models', () => {
   describe('calculateSocialSecurityStartDate', () => {
     it('should return correct date for claiming age', () => {
       // Person born 1995 (age 30 in 2025), claiming at 67 in January
+      // calculateSocialSecurityStartDate builds a LOCAL-midnight date-only value
+      // (parseDate convention), so read it back with local accessors.
       const result = calculateSocialSecurityStartDate(1995, 67);
-      expect(result.getUTCFullYear()).toBe(2062);
-      expect(result.getUTCMonth()).toBe(0); // January
-      expect(result.getUTCDate()).toBe(1);
+      expect(result.getFullYear()).toBe(2062);
+      expect(result.getMonth()).toBe(0); // January
+      expect(result.getDate()).toBe(1);
     });
 
     it('should handle custom claiming month', () => {
       // Person born 1970 (age 55 in 2025), claiming at 62 in July
       const result = calculateSocialSecurityStartDate(1970, 62, 6);
-      expect(result.getUTCFullYear()).toBe(2032);
-      expect(result.getUTCMonth()).toBe(6); // July
+      expect(result.getFullYear()).toBe(2032);
+      expect(result.getMonth()).toBe(6); // July
     });
 
     it('should default to January when month not specified', () => {
       // Person born 1985 (age 40 in 2025), claiming at 67
       const result = calculateSocialSecurityStartDate(1985, 67);
-      expect(result.getUTCMonth()).toBe(0); // January
+      expect(result.getMonth()).toBe(0); // January
     });
   });
 
@@ -954,6 +956,62 @@ describe('Income Models', () => {
     it('should return 0 supplement for retirement at 62+', () => {
       const supplement = fersPension.calculateSupplement();
       expect(supplement).toBe(0);
+    });
+
+    // --- Finding 3: FERS Annuity Supplement must NOT grow with COLA ---
+    // The real FERS supplement is a fixed bridge payment from retirement to age 62;
+    // it receives no COLA. The increment() formula now uses the bare `this.fersSupplement`
+    // rather than `this.fersSupplement * (1 + cola)`.
+    //
+    // NOTE: getFERSCOLA() returns 0 for any age < 62, and FERS basic benefits also
+    // get no COLA before 62, so in the supplement's only active window (pre-62) BOTH
+    // values are flat under inflationAdjusted assumptions. The supplement must stay
+    // exactly 12000 across ages 58-61 (and the basic benefit stays flat too, per the
+    // FERS pre-62 no-COLA rule). This pins the fixed-supplement behavior as a guard.
+    it('keeps the FERS supplement fixed (no COLA) before age 62', () => {
+      let pension = new FERSPensionIncome(
+        'fers-supp', 'FERS Pension', 30, 100000, 57, 1975, 30000, 12000, 24000,
+        new Date(2032, 0, 1), new Date(2060, 11, 31)
+      );
+
+      for (const age of [58, 59, 60, 61]) {
+        pension = pension.increment(mockAssumptions, 2032 + (age - 57), age);
+        expect(pension.fersSupplement).toBe(12000); // fixed bridge payment, no COLA
+        // FERS basic benefit also gets no COLA before 62 (getFERSCOLA -> 0).
+        expect(pension.calculatedBenefit).toBeCloseTo(30000, 0);
+      }
+    });
+
+    // --- Finding 6: age-62 boundary verification (regression guard) ---
+    // increment(assumptions, year, currentAge) is called from IncomeProjection with
+    // currentAge = the age DURING `year`. So the supplement must drop to 0 in the
+    // SAME year the retiree turns 62, with no extra year of payment. This drives the
+    // increment chain the way the projection does and pins the exact boundary.
+    it('zeroes the FERS supplement in the age-62 year (no off-by-one overpayment)', () => {
+      // Retire at 57 in 2032 (born 1975). Age each year equals 57 + (year - 2032).
+      let pension = new FERSPensionIncome(
+        'fers-62', 'FERS Pension', 30, 100000, 57, 1975, 30000, 12000, 24000,
+        new Date(2032, 0, 1), new Date(2060, 11, 31)
+      );
+
+      // getTotalAnnualAmount at retirement (age 57): supplement is paid.
+      expect(pension.getTotalAnnualAmount(2032)).toBe(30000 + 12000);
+
+      const supplementByAge: Record<number, number> = {};
+      // Walk the increment chain exactly like IncomeProjection: produce the income
+      // object FOR each year from the prior year using currentAge = age during year.
+      for (let age = 58; age <= 64; age++) {
+        const year = 2032 + (age - 57);
+        pension = pension.increment(mockAssumptions, year, age);
+        supplementByAge[age] = pension.getTotalAnnualAmount(year) - pension.getAnnualAmount(year);
+      }
+
+      // Supplement still paid at 58-61...
+      expect(supplementByAge[58]).toBe(12000);
+      expect(supplementByAge[61]).toBe(12000);
+      // ...and drops to 0 starting AT age 62 (the year the retiree IS 62) — no extra year.
+      expect(supplementByAge[62]).toBe(0);
+      expect(supplementByAge[63]).toBe(0);
     });
 
     // DIRECT unit tests for FERSPensionIncome.calculateBenefit() - Batch 28
@@ -1289,44 +1347,49 @@ describe('Income Models', () => {
     });
   });
 
-  // --- UTC date-only convention regression tests (bug #8) ---
-  // Date-only values are stored as UTC-midnight Dates. In a US (negative-UTC)
-  // timezone, new Date(Date.UTC(2030,0,1)) is 2029-12-31 local, so LOCAL
-  // getMonth()/getFullYear() misread the month/year. isIncomeActiveInCurrentMonth
-  // must read stored dates with getUTC*.
-  describe('UTC date-only handling (timezone safety)', () => {
-    it('agrees with getIncomeActiveMultiplier on the current year for UTC dates', () => {
+  // --- LOCAL date-only convention regression tests (timezone safety) ---
+  // Income date-only values are stored as LOCAL-midnight Dates (parseDate builds
+  // `new Date(y, m-1, d)`), and the readers (getIncomeActiveMultiplier /
+  // isIncomeActiveInCurrentMonth) now read them with local accessors. A date
+  // entered as Y-M-D therefore round-trips to the same Y-M-D in ANY timezone.
+  // These cases construct dates the same way the app does (local) and assert the
+  // active/inactive outcomes hold under both positive- and negative-UTC TZs.
+  describe('LOCAL date-only handling (timezone safety)', () => {
+    it('agrees with getIncomeActiveMultiplier on the current year for local dates', () => {
       const now = new Date();
-      // UTC-midnight start on the 1st of the current month: genuinely active now,
-      // but a LOCAL read in a US TZ would place it in the previous month.
-      const utcThisMonth = new Date(Date.UTC(now.getFullYear(), now.getMonth(), 1));
-      const income = new PassiveIncome('i-utc', 'UTC active', 1000, 'Annually', 'No', 'Interest', utcThisMonth);
+      const localThisMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+      const income = new PassiveIncome('i-local', 'Local active', 1000, 'Annually', 'No', 'Interest', localThisMonth);
 
       expect(isIncomeActiveInCurrentMonth(income)).toBe(true);
       expect(getIncomeActiveMultiplier(income, now.getFullYear())).toBeGreaterThan(0);
     });
 
-    it('treats a next-month UTC start as inactive (not pulled into this month)', () => {
-      // A UTC-midnight start on the 1st of NEXT month reads, in a US TZ, as the
-      // last day of THIS month with local accessors — which would wrongly mark it
-      // active now. With getUTC* it stays correctly inactive.
+    it('treats a next-month local start as inactive (not pulled into this month)', () => {
       const now = new Date();
-      const nextMonthStart = new Date(Date.UTC(now.getFullYear(), now.getMonth() + 1, 1));
+      const nextMonthStart = new Date(now.getFullYear(), now.getMonth() + 1, 1);
       const income = new PassiveIncome('i-next', 'Next month', 1000, 'Annually', 'No', 'Interest', nextMonthStart);
       expect(isIncomeActiveInCurrentMonth(income)).toBe(false);
     });
 
-    it('treats a future UTC start as inactive', () => {
-      const future = new Date(Date.UTC(new Date().getFullYear() + 2, 0, 1));
+    it('treats a future local start as inactive', () => {
+      const future = new Date(new Date().getFullYear() + 2, 0, 1);
       const income = new PassiveIncome('i-future', 'Future', 1000, 'Annually', 'No', 'Interest', future);
       expect(isIncomeActiveInCurrentMonth(income)).toBe(false);
     });
 
-    it('treats a UTC end date in the past as inactive', () => {
-      const start = new Date(Date.UTC(new Date().getFullYear() - 3, 0, 1));
-      const end = new Date(Date.UTC(new Date().getFullYear() - 1, 0, 1));
+    it('treats a local end date in the past as inactive', () => {
+      const start = new Date(new Date().getFullYear() - 3, 0, 1);
+      const end = new Date(new Date().getFullYear() - 1, 0, 1);
       const income = new PassiveIncome('i-ended', 'Ended', 1000, 'Annually', 'No', 'Interest', start, end);
       expect(isIncomeActiveInCurrentMonth(income)).toBe(false);
+    });
+
+    // Finding 1: a Jan-1 local start is FULLY active in its start year (multiplier 1),
+    // not suppressed, in any timezone — the core round-trip guarantee.
+    it('start-of-year local start yields multiplier 1 in its start year', () => {
+      const start = new Date(2032, 0, 1); // local Jan 1 2032
+      const income = new PassiveIncome('i-jan', 'Jan start', 1000, 'Annually', 'No', 'Interest', start);
+      expect(getIncomeActiveMultiplier(income, 2032)).toBe(1);
     });
   });
 });

--- a/src/__tests__/Components/Objects/Taxes/TaxService.test.tsx
+++ b/src/__tests__/Components/Objects/Taxes/TaxService.test.tsx
@@ -982,7 +982,7 @@ describe('TaxService: Additional Functions', () => {
 
         it('should only include Medicare rate above SS wage base', () => {
             const result = getCombinedMarginalRate(
-                200000, // Above 2024 SS wage base of 168,600
+                175000, // Above 2024 SS wage base ($168,600), below the $200k Additional-Medicare threshold
                 0,
                 createTaxState({ stateResidency: 'Texas' }),
                 2024,
@@ -990,7 +990,8 @@ describe('TaxService: Additional Functions', () => {
                 true
             );
 
-            // Above SS wage base, only Medicare (1.45%) applies, not SS (6.2%)
+            // Above SS wage base, only Medicare (1.45%) applies, not SS (6.2%);
+            // below the $200k threshold so the 0.9% Additional Medicare surtax does not apply.
             expect(result.fica).toBe(0.0145); // Only Medicare rate
         });
 

--- a/src/__tests__/Components/Objects/Taxes/TaxService.test.tsx
+++ b/src/__tests__/Components/Objects/Taxes/TaxService.test.tsx
@@ -478,11 +478,12 @@ describe('TaxService: Additional Functions', () => {
             if (params) {
                 // Taxable income = 64,600 - 14,600 (standard deduction) = 50,000
                 const tax = calculateTax(64600, 0, params);
+                // PR#55 #3: corrected 2024 Single bracket to breakpoint convention
                 // 11600 * 0.10 = 1160
-                // (47151 - 11600) * 0.12 = 4266.12
-                // (50000 - 47151) * 0.22 = 626.78
-                // Total = 6052.9
-                expect(tax).toBeCloseTo(6052.9);
+                // (47150 - 11600) * 0.12 = 4266.00
+                // (50000 - 47150) * 0.22 = 627.00
+                // Total = 6053.00
+                expect(tax).toBeCloseTo(6053.00);
             }
         });
 
@@ -738,12 +739,13 @@ describe('TaxService: Additional Functions', () => {
             const income = new WorkIncome('w1', 'Job', 100000, 'Annually', 'Yes', 0, 0, 0, 0, 'acc1', 'Traditional 401k', 'FIXED', new Date('2020-01-01'));
             const taxState = createTaxState({ deductionMethod: 'Standard' });
             const fedTax = calculateFederalTaxFromIncomes(taxState, [income], [], 0, 2024, noInflationAssumptions);
+            // PR#55 #3: corrected 2024 Single bracket to breakpoint convention
             // Taxable income: 100k - 14.6k (std deduction) = 85.4k
             // 11600 * 0.10 = 1160
-            // (47151 - 11600) * 0.12 = 4266.12
-            // (85400 - 47151) * 0.22 = 8414.78
-            // Total = 13840.9
-            expect(fedTax).toBeCloseTo(13840.9);
+            // (47150 - 11600) * 0.12 = 4266.00
+            // (85400 - 47150) * 0.22 = 8415.00
+            // Total = 13841.00
+            expect(fedTax).toBeCloseTo(13841.00);
         });
 
         it('should calculate federal tax with itemized deductions', () => {
@@ -753,8 +755,9 @@ describe('TaxService: Additional Functions', () => {
             mortgage.loan_balance = mortgage.getBalanceAtDate('2024-01-02');
             const taxState = createTaxState({ deductionMethod: 'Itemized', stateResidency: 'DC' });
             const fedTax = calculateFederalTaxFromIncomes(taxState, [income], [mortgage], 0, 2024, noInflationAssumptions);
+            // PR#55 #3: corrected 2024 Single bracket to breakpoint convention (+$0.10 vs old +1 boundary)
             // Placeholder value. Actual tax depends on the calculated itemized deduction.
-            expect(fedTax).toBeCloseTo(13356.34);
+            expect(fedTax).toBeCloseTo(13356.44);
         });
 
         it('should use federal override when provided', () => {
@@ -906,12 +909,13 @@ describe('TaxService: Additional Functions', () => {
         it('should return correct marginal rate for income in 12% bracket', () => {
             const params = getTaxParameters(2024, 'Single', 'federal');
             if (params) {
-                // Taxable income of $30,000 is in the 12% bracket (11,600 - 47,151)
+                // PR#55 #3: corrected 2024 Single bracket to breakpoint convention
+                // Taxable income of $30,000 is in the 12% bracket (11,600 - 47,150)
                 const result = getMarginalTaxRate(30000, params);
                 expect(result.rate).toBe(0.12);
                 expect(result.bracketStart).toBe(11600);
-                expect(result.bracketEnd).toBe(47151);
-                expect(result.headroom).toBe(47151 - 30000);
+                expect(result.bracketEnd).toBe(47150);
+                expect(result.headroom).toBe(47150 - 30000);
             }
         });
 
@@ -1032,9 +1036,10 @@ describe('TaxService: Additional Functions', () => {
                 true
             );
 
-            // Taxable = 50000 - 14600 = 35400, in 12% bracket (11600-47151)
-            // Headroom = 47151 - 35400 = 11751
-            expect(result.federalHeadroom).toBeCloseTo(11751);
+            // PR#55 #3: corrected 2024 Single bracket to breakpoint convention
+            // Taxable = 50000 - 14600 = 35400, in 12% bracket (11600-47150)
+            // Headroom = 47150 - 35400 = 11750
+            expect(result.federalHeadroom).toBeCloseTo(11750);
         });
     });
 

--- a/src/__tests__/Components/Objects/modelUtils.test.ts
+++ b/src/__tests__/Components/Objects/modelUtils.test.ts
@@ -12,10 +12,10 @@ describe('modelUtils', () => {
       const result = parseDate('2024-06-15');
       expect(result).toBeInstanceOf(Date);
       expect(result?.getFullYear()).toBe(2024);
-      // Note: Date parsing of ISO strings creates UTC dates
-      // For local date comparison, use getUTC methods
-      expect(result?.getUTCMonth()).toBe(5); // June = 5 (0-indexed)
-      expect(result?.getUTCDate()).toBe(15);
+      // parseDate builds LOCAL-midnight date-only values (new Date(y, m-1, d)),
+      // so read them with local accessors — stable in any timezone.
+      expect(result?.getMonth()).toBe(5); // June = 5 (0-indexed)
+      expect(result?.getDate()).toBe(15);
     });
 
     it('should parse ISO datetime string as local date', () => {
@@ -84,9 +84,9 @@ describe('modelUtils', () => {
     it('should parse valid ISO date string', () => {
       const result = parseDateRequired('2024-06-15');
       expect(result).toBeInstanceOf(Date);
-      expect(result.getUTCFullYear()).toBe(2024);
-      expect(result.getUTCMonth()).toBe(5); // June
-      expect(result.getUTCDate()).toBe(15);
+      expect(result.getFullYear()).toBe(2024);
+      expect(result.getMonth()).toBe(5); // June
+      expect(result.getDate()).toBe(15);
     });
 
     it('should return current time for null', () => {

--- a/src/__tests__/hooks/useDebouncedLocalStorage.test.tsx
+++ b/src/__tests__/hooks/useDebouncedLocalStorage.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDebouncedLocalStorage } from '../../hooks/useDebouncedLocalStorage';
+
+describe('useDebouncedLocalStorage', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('debounces the write (nothing until the timer fires)', () => {
+        const key = 'test-key';
+        const { rerender } = renderHook(
+            ({ value }) => useDebouncedLocalStorage(key, value),
+            { initialProps: { value: { a: 1 } } },
+        );
+
+        rerender({ value: { a: 2 } });
+        // Before the debounce window elapses, nothing has been written.
+        expect(localStorage.getItem(key)).toBeNull();
+
+        vi.advanceTimersByTime(500);
+        expect(localStorage.getItem(key)).toBe(JSON.stringify({ a: 2 }));
+    });
+
+    it('flushes the pending write on pagehide (hard reload / tab close) before the timer fires', () => {
+        const key = 'pagehide-key';
+        const { rerender } = renderHook(
+            ({ value }) => useDebouncedLocalStorage(key, value),
+            { initialProps: { value: { a: 1 } } },
+        );
+
+        rerender({ value: { a: 2 } });
+
+        // Simulate a hard page unload BEFORE the 500ms debounce timer fires.
+        // The unmount-flush effect does NOT run on a real browser unload, so a
+        // pagehide handler must flush the latest value synchronously.
+        window.dispatchEvent(new Event('pagehide'));
+
+        expect(localStorage.getItem(key)).toBe(JSON.stringify({ a: 2 }));
+    });
+
+    it('removes the pagehide listener on unmount (no leak / no stale write)', () => {
+        const key = 'cleanup-key';
+        const addSpy = vi.spyOn(window, 'addEventListener');
+        const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+        const { unmount } = renderHook(
+            ({ value }) => useDebouncedLocalStorage(key, value),
+            { initialProps: { value: { a: 1 } } },
+        );
+
+        const pagehideAdds = addSpy.mock.calls.filter(c => c[0] === 'pagehide').length;
+        expect(pagehideAdds).toBeGreaterThan(0);
+
+        unmount();
+
+        const pagehideRemoves = removeSpy.mock.calls.filter(c => c[0] === 'pagehide').length;
+        expect(pagehideRemoves).toBe(pagehideAdds);
+
+        addSpy.mockRestore();
+        removeSpy.mockRestore();
+    });
+});

--- a/src/__tests__/services/BugCAndDBracketSpace.test.ts
+++ b/src/__tests__/services/BugCAndDBracketSpace.test.ts
@@ -168,13 +168,10 @@ describe('Bug D: Gap Year Input→Output Tests', () => {
                 25_000,     // ssAtRMD
                 0,          // passiveIncomeAtRMD
                 0,          // currentAGI = 0 (gap year)
-                0,          // socialSecurityThisYear = 0
-                0,          // ltcgIncome = 0
                 0.06,       // growthRate
                 75,         // rmdStartAge
                 taxParams,
-                singleTaxState,
-                null
+                singleTaxState
             );
 
             console.log('Test 2a - Gap year, small balance:', {
@@ -202,13 +199,10 @@ describe('Bug D: Gap Year Input→Output Tests', () => {
                 30_000,     // ssAtRMD
                 0,          // passiveIncomeAtRMD
                 0,          // currentAGI = 0 (gap year)
-                0,          // socialSecurityThisYear = 0
-                0,          // ltcgIncome = 0
                 0.07,       // growthRate
                 75,         // rmdStartAge
                 taxParams,
-                singleTaxState,
-                null
+                singleTaxState
             );
 
             console.log('Test 2b - Gap year, large balance, escalated ceiling:', {
@@ -238,13 +232,10 @@ describe('Bug D: Gap Year Input→Output Tests', () => {
                 35_000,     // ssAtRMD
                 0,          // passiveIncomeAtRMD
                 0,          // currentAGI = 0 (gap year)
-                0,          // socialSecurityThisYear = 0
-                0,          // ltcgIncome = 0
                 0.07,       // growthRate
                 75,         // rmdStartAge
                 taxParams,
-                singleTaxState,
-                null
+                singleTaxState
             );
 
             console.log('Test 2c - Gap year, very large balance, 24% ceiling:', {
@@ -344,13 +335,10 @@ describe('Bug D: bracketSpacePerYear calculation', () => {
                 30_000,     // SS at RMD
                 0,          // passiveIncomeAtRMD
                 0,          // currentAGI = $0 (gap years, no income)
-                0,          // SS this year = 0
-                0,          // LTCG = 0
                 0.06,       // growth rate
                 75,         // RMD start age
                 taxParams,
-                singleTaxState,
-                null        // no state params
+                singleTaxState
             );
 
             console.log('Bug D Test - Zero AGI, 12% ceiling:', {

--- a/src/__tests__/services/CSVImportService.test.ts
+++ b/src/__tests__/services/CSVImportService.test.ts
@@ -793,6 +793,24 @@ describe('applyMapping', () => {
             expect(transactions[0].date.getFullYear()).toBe(2025);
         });
     });
+
+    describe('unique transaction ids', () => {
+        it('should mint a unique id for every row in a large CSV (no collisions)', () => {
+            const rows: string[][] = [];
+            for (let i = 0; i < 500; i++) {
+                rows.push(['1/15/2025', `Merchant ${i}`, '-12.34']);
+            }
+            const csv: ParsedCSV = {
+                headers: ['Date', 'Description', 'Amount'],
+                rows,
+                hasHeaders: true,
+            };
+            const transactions = applyMapping(csv, baseMapping, baseOptions);
+            expect(transactions).toHaveLength(500);
+            const ids = transactions.map(t => t.id);
+            expect(new Set(ids).size).toBe(transactions.length);
+        });
+    });
 });
 
 // =============================================================================
@@ -925,6 +943,32 @@ describe('applyCategories', () => {
         date: new Date(),
         amount: -50,
         description,
+    });
+
+    it('should not throw on an invalid saved regex rule and still apply valid rules', () => {
+        const transactions = [createTransaction('STARBUCKS')];
+        const rules: CategoryMapping[] = [
+            { id: 'bad', pattern: '(', isRegex: true, expenseId: 'X' },
+            { id: 'good', pattern: 'starbucks', isRegex: true, expenseId: 'exp-coffee' },
+        ];
+        let result: ReturnType<typeof applyCategories>;
+        expect(() => {
+            result = applyCategories(transactions, rules);
+        }).not.toThrow();
+        // Invalid rule is treated as no-match; the valid regex rule still categorizes.
+        expect(result!.categorized).toHaveLength(1);
+        expect(result!.categorized[0].expenseId).toBe('exp-coffee');
+        expect(result!.autoCategorizedCount).toBe(1);
+    });
+
+    it('should leave a transaction uncategorized when the only rule has an invalid regex', () => {
+        const transactions = [createTransaction('STARBUCKS')];
+        const rules: CategoryMapping[] = [
+            { id: 'bad', pattern: '[a-', isRegex: true, expenseId: 'X' },
+        ];
+        const result = applyCategories(transactions, rules);
+        expect(result.categorized[0].expenseId).toBeUndefined();
+        expect(result.autoCategorizedCount).toBe(0);
     });
 
     it('should apply expenseId for matching string pattern', () => {

--- a/src/__tests__/services/IncomeClassifierDateFilter.test.ts
+++ b/src/__tests__/services/IncomeClassifierDateFilter.test.ts
@@ -12,8 +12,8 @@ describe('IncomeClassifier date filtering', () => {
         const endedIncome = new WorkIncome(
             'test-1', 'Ended Job', 100000, 'Annually', 'Yes',
             0, 0, 0, 0, '', null, 'FIXED',
-            new Date('2020-01-01'),  // start
-            new Date('2030-12-31')   // end
+            new Date(2020, 0, 1),  // start
+            new Date(2030, 11, 31) // end
         );
 
         const result = classifyIncome([endedIncome], 0, 0, 2035);
@@ -27,8 +27,8 @@ describe('IncomeClassifier date filtering', () => {
         const futureIncome = new WorkIncome(
             'test-2', 'Future Job', 100000, 'Annually', 'Yes',
             0, 0, 0, 0, '', null, 'FIXED',
-            new Date('2040-01-01'),  // start (future)
-            undefined                 // no end
+            new Date(2040, 0, 1),  // start (future)
+            undefined              // no end
         );
 
         const result = classifyIncome([futureIncome], 0, 0, 2035);
@@ -42,8 +42,8 @@ describe('IncomeClassifier date filtering', () => {
         const activeIncome = new WorkIncome(
             'test-3', 'Active Job', 100000, 'Annually', 'Yes',
             0, 0, 0, 0, '', null, 'FIXED',
-            new Date('2020-01-01'),  // start (past)
-            new Date('2040-12-31')   // end (future)
+            new Date(2020, 0, 1),  // start (past)
+            new Date(2040, 11, 31) // end (future)
         );
 
         const result = classifyIncome([activeIncome], 0, 0, 2035);
@@ -57,8 +57,8 @@ describe('IncomeClassifier date filtering', () => {
         const midYearIncome = new WorkIncome(
             'test-4', 'Mid-Year Job', 100000, 'Annually', 'Yes',
             0, 0, 0, 0, '', null, 'FIXED',
-            new Date('2035-07-01'),  // start mid-year (month index 6)
-            undefined                 // no end
+            new Date(2035, 6, 1),  // start mid-year (month index 6)
+            undefined              // no end
         );
 
         const result = classifyIncome([midYearIncome], 0, 0, 2035);

--- a/src/__tests__/services/QRUtils.test.ts
+++ b/src/__tests__/services/QRUtils.test.ts
@@ -260,12 +260,22 @@ describe('qrUtils', () => {
         expect('linkedAccountId' in result).toBe(false);
       });
 
-      it('should NOT strip empty conversionHistory array (reference comparison)', () => {
-        // Note: stripDefaults uses === for comparison, so [] === [] is false
-        // Empty arrays are NOT stripped because they're different references
+      it('should strip empty conversionHistory array (matches empty default)', () => {
+        // PR #58: corrected — empty default arrays are now compared structurally
+        // and stripped (restoreDefaults re-adds them), instead of bloating the payload.
         const input = { id: 'acc1', conversionHistory: [] };
         const result = stripDefaults(input, 'account');
-        expect(result).toEqual({ id: 'acc1', conversionHistory: [] });
+        expect(result).toEqual({ id: 'acc1' });
+        expect('conversionHistory' in result).toBe(false);
+        // Round-trips: restoreDefaults re-adds the empty array.
+        expect(restoreDefaults(result, 'account').conversionHistory).toEqual([]);
+      });
+
+      it('should strip empty lots array (matches empty default)', () => {
+        // PR #58: empty ESPP `lots: []` default also strips structurally.
+        const input = { id: 'acc1', lots: [] };
+        const result = stripDefaults(input, 'account');
+        expect('lots' in result).toBe(false);
       });
 
       it('should keep non-empty conversionHistory array', () => {
@@ -672,9 +682,11 @@ describe('qrUtils', () => {
       ]);
     });
 
-    it('should preserve non-empty withdrawalOrder array', () => {
+    // PR #58: corrected — the top-level Burn-Order array is `withdrawalStrategy`
+    // (there is no `withdrawalOrder` key), flattened under the synthetic `burnOrder` key.
+    it('should preserve non-empty withdrawalStrategy (burn-order) array under burnOrder', () => {
       const input = {
-        withdrawalOrder: [
+        withdrawalStrategy: [
           { accountId: 'acc1' },
           { accountId: 'acc2' },
         ],
@@ -682,7 +694,7 @@ describe('qrUtils', () => {
 
       const result = flattenAssumptions(input);
 
-      expect(result.withdrawalOrder).toEqual([
+      expect(result.burnOrder).toEqual([
         { accountId: 'acc1' },
         { accountId: 'acc2' },
       ]);
@@ -691,13 +703,14 @@ describe('qrUtils', () => {
     it('should exclude empty arrays', () => {
       const input = {
         priorities: [],
-        withdrawalOrder: [],
+        withdrawalStrategy: [],
       };
 
       const result = flattenAssumptions(input);
 
       expect('priorities' in result).toBe(false);
-      expect('withdrawalOrder' in result).toBe(false);
+      // PR #58: corrected — burn-order flattens to `burnOrder`, not `withdrawalOrder`
+      expect('burnOrder' in result).toBe(false);
     });
   });
 
@@ -801,25 +814,30 @@ describe('qrUtils', () => {
       expect(display.hsaEligible).toBe(true);
     });
 
-    it('should default priorities and withdrawalOrder to empty arrays', () => {
+    // PR #58: corrected — top-level array is `withdrawalStrategy` (burn order),
+    // restored from the flattened `burnOrder` key; `milestones` also defaults to [].
+    it('should default priorities and withdrawalStrategy to empty arrays', () => {
       const input = {};
 
       const result = expandAssumptions(input);
 
       expect(result.priorities).toEqual([]);
-      expect(result.withdrawalOrder).toEqual([]);
+      expect(result.withdrawalStrategy).toEqual([]);
+      expect(result.milestones).toEqual([]);
+      // No phantom withdrawalOrder key is emitted
+      expect('withdrawalOrder' in result).toBe(false);
     });
 
-    it('should preserve provided priorities and withdrawalOrder', () => {
+    it('should preserve provided priorities and withdrawalStrategy (burn order)', () => {
       const input = {
         priorities: [{ type: 'debt', accountId: 'acc1' }],
-        withdrawalOrder: [{ accountId: 'acc2' }],
+        burnOrder: [{ accountId: 'acc2' }],
       };
 
       const result = expandAssumptions(input);
 
       expect(result.priorities).toEqual([{ type: 'debt', accountId: 'acc1' }]);
-      expect(result.withdrawalOrder).toEqual([{ accountId: 'acc2' }]);
+      expect(result.withdrawalStrategy).toEqual([{ accountId: 'acc2' }]);
     });
 
     it('should preserve non-default values when provided', () => {
@@ -861,6 +879,8 @@ describe('qrUtils', () => {
           housingAppreciation: 1.4,
           rentInflation: 1.2,
         },
+        // PR #58: corrected — include the newer investments flags so the expanded
+        // output (which now restores them from defaults) deep-equals the original.
         investments: {
           returnRates: { ror: 5.9 },
           withdrawalStrategy: 'Fixed Real',
@@ -869,6 +889,11 @@ describe('qrUtils', () => {
           gkLowerGuardrail: 0.8,
           gkAdjustmentPercent: 10,
           autoRothConversions: false,
+          rothConversionStrategy: 'rate-match',
+          rothConversionMinRateGap: 0.05,
+          rothConversionDPBackloadDelta: 0.015,
+          taxOptimizationEnabled: false,
+          acaAware: true,
         },
         demographics: {
           birthYear: 1985,
@@ -882,7 +907,10 @@ describe('qrUtils', () => {
           hsaEligible: true,
         },
         priorities: [],
-        withdrawalOrder: [],
+        // PR #58: corrected — real shape uses top-level `withdrawalStrategy` (burn
+        // order) array + `milestones`, not the obsolete `withdrawalOrder` key.
+        withdrawalStrategy: [],
+        milestones: [],
       };
 
       const flattened = flattenAssumptions(original);
@@ -908,6 +936,7 @@ describe('qrUtils', () => {
           housingAppreciation: 2.0,
           rentInflation: 1.5,
         },
+        // PR #58: corrected — include the newer investments flags.
         investments: {
           returnRates: { ror: 7.0 },
           withdrawalStrategy: 'Guardrails',
@@ -916,6 +945,11 @@ describe('qrUtils', () => {
           gkLowerGuardrail: 0.7,
           gkAdjustmentPercent: 15,
           autoRothConversions: true,
+          rothConversionStrategy: 'rate-match',
+          rothConversionMinRateGap: 0.05,
+          rothConversionDPBackloadDelta: 0.015,
+          taxOptimizationEnabled: false,
+          acaAware: true,
         },
         demographics: {
           birthYear: 1990,
@@ -929,7 +963,9 @@ describe('qrUtils', () => {
           hsaEligible: false,
         },
         priorities: [{ type: 'debt', accountId: 'acc1' }],
-        withdrawalOrder: [{ accountId: 'acc2' }],
+        // PR #58: corrected — burn-order array is `withdrawalStrategy`; add `milestones`.
+        withdrawalStrategy: [{ accountId: 'acc2' }],
+        milestones: [],
       };
 
       const flattened = flattenAssumptions(original);
@@ -1015,17 +1051,21 @@ describe('qrUtils', () => {
       expect(priorities[0].cv).toBe(500); // capValue
     });
 
-    it('should exclude empty priorities and withdrawalOrder arrays', () => {
+    // PR #58: corrected — empty burn-order is the top-level `withdrawalStrategy`
+    // array, which flattens to `burnOrder` and must be excluded when empty.
+    it('should exclude empty priorities and withdrawalStrategy (burn-order) arrays', () => {
       const input = {
         macro: { inflationRate: 2.6 },
         priorities: [],
-        withdrawalOrder: [],
+        withdrawalStrategy: [],
+        milestones: [],
       };
 
       const result = compactAssumptions(input);
 
       expect('priorities' in result).toBe(false);
-      expect('withdrawalOrder' in result).toBe(false);
+      expect('bo' in result).toBe(false); // burnOrder short key absent
+      expect('ms' in result).toBe(false); // milestones short key absent
     });
   });
 
@@ -1141,6 +1181,7 @@ describe('qrUtils', () => {
           housingAppreciation: 2.0,
           rentInflation: 1.5,
         },
+        // PR #58: corrected — include the newer investments flags.
         investments: {
           returnRates: { ror: 7.5 },
           withdrawalStrategy: 'Guardrails',
@@ -1149,6 +1190,11 @@ describe('qrUtils', () => {
           gkLowerGuardrail: 0.75,
           gkAdjustmentPercent: 12,
           autoRothConversions: true,
+          rothConversionStrategy: 'rate-match',
+          rothConversionMinRateGap: 0.05,
+          rothConversionDPBackloadDelta: 0.015,
+          taxOptimizationEnabled: false,
+          acaAware: true,
         },
         demographics: {
           birthYear: 1988,
@@ -1164,9 +1210,11 @@ describe('qrUtils', () => {
         priorities: [
           { type: 'debt', accountId: 'acc1' },
         ],
-        withdrawalOrder: [
+        // PR #58: corrected — burn-order array is the top-level `withdrawalStrategy`.
+        withdrawalStrategy: [
           { accountId: 'acc2' },
         ],
+        milestones: [],
       };
 
       const compacted = compactAssumptions(original);
@@ -1773,6 +1821,7 @@ describe('qrUtils', () => {
             housingAppreciation: 1.4,
             rentInflation: 1.2,
           },
+          // PR #58: corrected — include the newer investments flags.
           investments: {
             returnRates: { ror: 5.9 },
             withdrawalStrategy: 'Fixed Real',
@@ -1781,6 +1830,11 @@ describe('qrUtils', () => {
             gkLowerGuardrail: 0.8,
             gkAdjustmentPercent: 10,
             autoRothConversions: false,
+            rothConversionStrategy: 'rate-match',
+            rothConversionMinRateGap: 0.05,
+            rothConversionDPBackloadDelta: 0.015,
+            taxOptimizationEnabled: false,
+            acaAware: true,
           },
           demographics: {
             birthYear: 1985,
@@ -1794,7 +1848,9 @@ describe('qrUtils', () => {
             hsaEligible: true,
           },
           priorities: [],
-          withdrawalOrder: [],
+          // PR #58: corrected — real shape uses top-level `withdrawalStrategy` array + `milestones`.
+          withdrawalStrategy: [],
+          milestones: [],
         },
         amountHistory: {
           acc1: [
@@ -1885,6 +1941,7 @@ describe('qrUtils', () => {
             housingAppreciation: 1.4,
             rentInflation: 1.2,
           },
+          // PR #58: corrected — include the newer investments flags.
           investments: {
             returnRates: { ror: 7.0 }, // non-default
             withdrawalStrategy: 'Guardrails', // non-default
@@ -1893,6 +1950,11 @@ describe('qrUtils', () => {
             gkLowerGuardrail: 0.8,
             gkAdjustmentPercent: 10,
             autoRothConversions: false,
+            rothConversionStrategy: 'rate-match',
+            rothConversionMinRateGap: 0.05,
+            rothConversionDPBackloadDelta: 0.015,
+            taxOptimizationEnabled: false,
+            acaAware: true,
           },
           demographics: {
             birthYear: 1990,
@@ -1906,7 +1968,9 @@ describe('qrUtils', () => {
             hsaEligible: true,
           },
           priorities: [],
-          withdrawalOrder: [],
+          // PR #58: corrected — real shape uses top-level `withdrawalStrategy` array + `milestones`.
+          withdrawalStrategy: [],
+          milestones: [],
         },
         amountHistory: {},
       };
@@ -1931,6 +1995,22 @@ describe('qrUtils', () => {
       expect(typeof result).toBe('string');
       // Base64 characters only
       expect(result).toMatch(/^[A-Za-z0-9+/=]+$/);
+    });
+
+    it('should not RangeError on a large, low-redundancy payload (PR #58)', () => {
+      // String.fromCharCode(...bytes) used to spread the whole deflated array as
+      // arguments and overflow the call stack for large inputs. Use random-ish,
+      // poorly-compressible data so the deflated byte array stays large (>64 KB).
+      const big = {
+        items: Array.from({ length: 20000 }, (_, i) => ({
+          id: `id-${i}-${(i * 2654435761 % 1e9).toString(36)}`,
+          v: Math.sin(i) * 1e6,
+        })),
+      };
+      let compressed = '';
+      expect(() => { compressed = compressData(big); }).not.toThrow();
+      // And it still round-trips.
+      expect(decompressData(compressed)).toEqual(big);
     });
 
     it('should produce smaller output for repetitive data', () => {
@@ -2142,6 +2222,245 @@ describe('qrUtils', () => {
 
       // Large data should exceed the limit
       expect(exceedsQRLimit(compressed)).toBe(true);
+    });
+  });
+
+  // ============================================
+  // PR #58: QR-backup data-loss regression tests
+  // ============================================
+  describe('PR #58 regressions', () => {
+    // FINDING #2: `pp` short-key collision between purchasePrice (ESPP lot)
+    // and projectedPIA (Social Security). An ESPP lot's purchasePrice must
+    // survive a QR round-trip and must NOT be renamed to projectedPIA.
+    it('should preserve ESPP lot purchasePrice through a full backup round-trip', () => {
+      const original = {
+        version: 1,
+        accounts: [
+          {
+            id: 'espp1',
+            className: 'ESPPAccount',
+            name: 'Company ESPP',
+            amount: 0,
+            lots: [
+              {
+                grantDate: '2023-01-01',
+                purchaseDate: '2023-06-30',
+                fmvAtGrant: 100,
+                fmvAtPurchase: 120,
+                purchasePrice: 85, // <-- must survive, must NOT become projectedPIA
+                shares: 50,
+                totalCost: 4250,
+                discountAmount: 750,
+              },
+            ],
+          },
+        ],
+        incomes: [],
+        expenses: [],
+        taxSettings: {
+          filingStatus: 'Single',
+          stateResidency: 'DC',
+          deductionMethod: 'Auto',
+          fedOverride: null,
+          ficaOverride: null,
+          stateOverride: null,
+        },
+        assumptions: {
+          macro: { inflationRate: 2.6, healthcareInflation: 3.9, inflationAdjusted: true },
+          income: { salaryGrowth: 1.0, qualifiesForSocialSecurity: true, socialSecurityFundingPercent: 100 },
+          expenses: { lifestyleCreep: 75.0, housingAppreciation: 1.4, rentInflation: 1.2 },
+          investments: {
+            returnRates: { ror: 5.9 },
+            withdrawalStrategy: 'Fixed Real',
+            withdrawalRate: 4.0,
+            gkUpperGuardrail: 1.2,
+            gkLowerGuardrail: 0.8,
+            gkAdjustmentPercent: 10,
+            autoRothConversions: false,
+            rothConversionStrategy: 'rate-match',
+            rothConversionMinRateGap: 0.05,
+            rothConversionDPBackloadDelta: 0.015,
+            taxOptimizationEnabled: false,
+            acaAware: true,
+          },
+          demographics: { priorYearMode: false },
+          display: { useCompactCurrency: true, showExperimentalFeatures: false, hsaEligible: true },
+          priorities: [],
+          withdrawalStrategy: [],
+          milestones: [],
+        },
+        amountHistory: {},
+      };
+
+      const compacted = createCompactBackup(original);
+      const expanded = expandCompactBackup(compacted);
+
+      const lot = (expanded.accounts[0] as Record<string, unknown>).lots as Array<Record<string, unknown>>;
+      expect(lot[0].purchasePrice).toBe(85);
+      expect('projectedPIA' in lot[0]).toBe(false);
+    });
+
+    it('should keep projectedPIA round-tripping on a Social Security income (no collision)', () => {
+      const income = {
+        className: 'SocialSecurityIncome',
+        id: 'ss1',
+        name: 'Social Security',
+        claimingAge: 67,
+        calculatedPIA: 2500,
+        calculationYear: 2026,
+        projectedPIA: 3100, // distinct from purchasePrice now
+      };
+
+      const shortened = shortenKeys(income) as Record<string, unknown>;
+      const expanded = expandKeys(shortened) as Record<string, unknown>;
+
+      expect(expanded.projectedPIA).toBe(3100);
+      expect('purchasePrice' in expanded).toBe(false);
+    });
+
+    // FINDINGS #1, #4, #6: milestones, top-level withdrawalStrategy burn order,
+    // demographics.priorEarnings, and the newer investments flags must all
+    // survive the compact assumptions round-trip.
+    it('should round-trip milestones, burn-order, priorEarnings, and investment flags', () => {
+      const original = {
+        macro: { inflationRate: 4.0, healthcareInflation: 5.0, inflationAdjusted: false },
+        income: { salaryGrowth: 2.5, qualifiesForSocialSecurity: false, socialSecurityFundingPercent: 75 },
+        expenses: { lifestyleCreep: 60, housingAppreciation: 2.0, rentInflation: 1.5 },
+        investments: {
+          returnRates: { ror: 7.5 },
+          withdrawalStrategy: 'Guardrails',
+          withdrawalRate: 3.5,
+          gkUpperGuardrail: 1.25,
+          gkLowerGuardrail: 0.75,
+          gkAdjustmentPercent: 12,
+          autoRothConversions: true,
+          rothConversionStrategy: 'dp-precomputed', // non-default
+          rothConversionMinRateGap: 0.08, // non-default
+          rothConversionDPBackloadDelta: 0.02, // non-default
+          taxOptimizationEnabled: true, // non-default
+          acaAware: false, // non-default
+        },
+        demographics: {
+          priorYearMode: true,
+          priorEarnings: [
+            { year: 2010, earnings: 50000 },
+            { year: 2011, earnings: 55000 },
+          ],
+        },
+        display: { useCompactCurrency: false, showExperimentalFeatures: true, hsaEligible: false },
+        priorities: [{ type: 'debt', accountId: 'acc1' }],
+        withdrawalStrategy: [
+          { id: 'w1', name: 'Brokerage', accountId: 'acc1' },
+          { id: 'w2', name: 'Roth', accountId: 'acc2', maxAmount: 10000 },
+        ],
+        milestones: [
+          {
+            id: 'BUILTIN_BIRTH',
+            name: 'Birth',
+            conditions: [{ type: 'YEAR', operator: '=', value: 1980 }],
+            color: 'var(--c-accent-soft)',
+          },
+          {
+            id: 'BUILTIN_RETIRE',
+            name: 'Retire',
+            conditions: [{ type: 'AGE', operator: '>=', value: 58 }],
+            color: 'var(--c-positive-soft)',
+          },
+          {
+            id: 'BUILTIN_END_OF_PLAN',
+            name: 'End of Plan',
+            conditions: [{ type: 'AGE', operator: '>=', value: 92 }],
+            color: 'var(--c-content-subtle)',
+          },
+        ],
+      };
+
+      const compacted = compactAssumptions(original);
+      const expanded = expandCompactAssumptions(compacted);
+
+      // Top-level burn-order array survives (and is NOT the investments string)
+      expect(expanded.withdrawalStrategy).toEqual(original.withdrawalStrategy);
+      expect((expanded.investments as Record<string, unknown>).withdrawalStrategy).toBe('Guardrails');
+      // Milestones survive
+      expect(expanded.milestones).toEqual(original.milestones);
+      // priorEarnings survive
+      expect((expanded.demographics as Record<string, unknown>).priorEarnings).toEqual(
+        original.demographics.priorEarnings
+      );
+      // Investment flags survive
+      const inv = expanded.investments as Record<string, unknown>;
+      expect(inv.rothConversionStrategy).toBe('dp-precomputed');
+      expect(inv.rothConversionMinRateGap).toBe(0.08);
+      expect(inv.rothConversionDPBackloadDelta).toBe(0.02);
+      expect(inv.taxOptimizationEnabled).toBe(true);
+      expect(inv.acaAware).toBe(false);
+
+      // No phantom withdrawalOrder key
+      expect('withdrawalOrder' in expanded).toBe(false);
+    });
+
+    it('should round-trip the new fields when embedded in a full backup', () => {
+      const original = {
+        version: 1,
+        accounts: [],
+        incomes: [],
+        expenses: [],
+        taxSettings: {
+          filingStatus: 'Single',
+          stateResidency: 'DC',
+          deductionMethod: 'Auto',
+          fedOverride: null,
+          ficaOverride: null,
+          stateOverride: null,
+        },
+        assumptions: {
+          macro: { inflationRate: 2.6, healthcareInflation: 3.9, inflationAdjusted: true },
+          income: { salaryGrowth: 1.0, qualifiesForSocialSecurity: true, socialSecurityFundingPercent: 100 },
+          expenses: { lifestyleCreep: 75.0, housingAppreciation: 1.4, rentInflation: 1.2 },
+          investments: {
+            returnRates: { ror: 5.9 },
+            withdrawalStrategy: 'Fixed Real',
+            withdrawalRate: 4.0,
+            gkUpperGuardrail: 1.2,
+            gkLowerGuardrail: 0.8,
+            gkAdjustmentPercent: 10,
+            autoRothConversions: false,
+            rothConversionStrategy: 'rate-match',
+            rothConversionMinRateGap: 0.05,
+            rothConversionDPBackloadDelta: 0.015,
+            taxOptimizationEnabled: true, // non-default
+            acaAware: false, // non-default
+          },
+          demographics: {
+            priorYearMode: false,
+            priorEarnings: [{ year: 2015, earnings: 80000 }],
+          },
+          display: { useCompactCurrency: true, showExperimentalFeatures: false, hsaEligible: true },
+          priorities: [],
+          withdrawalStrategy: [{ id: 'w1', name: 'Brokerage', accountId: 'acc1' }],
+          milestones: [
+            {
+              id: 'BUILTIN_BIRTH',
+              name: 'Birth',
+              conditions: [{ type: 'YEAR', operator: '=', value: 1992 }],
+              color: 'var(--c-accent-soft)',
+            },
+          ],
+        },
+        amountHistory: {},
+      };
+
+      const compacted = createCompactBackup(original);
+      const expanded = expandCompactBackup(compacted);
+      const a = expanded.assumptions as Record<string, unknown>;
+
+      expect(a.milestones).toEqual(original.assumptions.milestones);
+      expect(a.withdrawalStrategy).toEqual(original.assumptions.withdrawalStrategy);
+      expect((a.demographics as Record<string, unknown>).priorEarnings).toEqual(
+        original.assumptions.demographics.priorEarnings
+      );
+      expect((a.investments as Record<string, unknown>).taxOptimizationEnabled).toBe(true);
+      expect((a.investments as Record<string, unknown>).acaAware).toBe(false);
     });
   });
 });

--- a/src/__tests__/services/ReviewFixes_PR55_aggregation.test.ts
+++ b/src/__tests__/services/ReviewFixes_PR55_aggregation.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import {
+    getPreTaxExemptions,
+    getPostTaxExemptions,
+} from '../../components/Objects/Taxes/taxService/incomeAggregation';
+import {
+    getItemizedDeductions,
+    getYesDeductions,
+} from '../../components/Objects/Taxes/taxService/deductions';
+import { LoanExpense, MortgageExpense } from '../../components/Objects/Expense/models';
+import { WorkIncome } from '../../components/Objects/Income/models';
+
+/**
+ * Characterization tests for PR #55 review fixes #10 and #13.
+ *
+ * These are behavior-preserving refactors:
+ *  - #10: dedupe the 401k-field resolution in getPreTaxExemptions / getPostTaxExemptions.
+ *  - #13: type-safe `tax_deductible` narrowing in getItemizedDeductions / getYesDeductions.
+ *
+ * The numbers below were captured against the ORIGINAL (pre-refactor) code and must
+ * remain identical after the refactor. Do NOT loosen these assertions.
+ */
+describe('PR55 review fixes — incomeAggregation characterization', () => {
+    // Bi-Weekly => 26 pay periods/year. Per-period contribution fields are
+    // re-annualized via getProratedAnnual, so a long-active income (year far
+    // inside the start..end window) yields a full-year multiplier of 1.
+    const YEAR = 2030;
+
+    function makeWorkIncome(opts: { autoMax401k?: 'custom' | 'traditional' | 'roth' | 'disabled' } = {}) {
+        // ctor: (id, name, amount, frequency, earned_income,
+        //        preTax401k, insurance, roth401k, employerMatch, matchAccountId,
+        //        taxType, contributionGrowthStrategy, startDate, end_date,
+        //        hsaContribution, autoMax401k, ...)
+        return new WorkIncome(
+            'w1',
+            'Job',
+            3000,            // amount per period
+            'Bi-Weekly',
+            'Yes',
+            800,             // preTax401k per period
+            150,             // insurance per period
+            400,             // roth401k per period
+            300,             // employerMatch per period
+            'acc1',
+            'Traditional 401k',
+            'FIXED',
+            new Date('2010-01-01'),
+            new Date('2060-01-01'),
+            120,             // hsaContribution per period
+            opts.autoMax401k ?? 'custom',
+        );
+    }
+
+    describe('getPreTaxExemptions', () => {
+        it('useStoredValue=true returns the stored preTax401k + insurance + HSA (prorated)', () => {
+            const inc = makeWorkIncome();
+            const result = getPreTaxExemptions([inc], YEAR, undefined, true);
+            // 26 * (800 + 150 + 120) = 26 * 1070 = 27820
+            expect(result).toBe(27820);
+        });
+
+        it('age-based getEffective401k path (custom) matches stored value', () => {
+            const inc = makeWorkIncome({ autoMax401k: 'custom' });
+            const result = getPreTaxExemptions([inc], YEAR, 45, false);
+            // custom autoMax => getEffective401k returns stored preTax401k (800/period)
+            // 26 * (800 + 150 + 120) = 27820
+            expect(result).toBe(27820);
+        });
+
+        it('age-based getEffective401k path (traditional auto-max) uses IRS-limit-derived preTax', () => {
+            const inc = makeWorkIncome({ autoMax401k: 'traditional' });
+            const stored = getPreTaxExemptions([inc], YEAR, undefined, true);
+            const effective = getPreTaxExemptions([inc], YEAR, 45, false);
+            // traditional auto-max overrides the stored preTax401k with the
+            // per-period IRS limit, so the effective figure differs from stored.
+            expect(effective).not.toBe(stored);
+            // insurance + HSA portion is unchanged either way: 26 * (150 + 120) = 7020
+            const traditionalPreTaxAnnual = effective - 26 * (150 + 120);
+            expect(traditionalPreTaxAnnual).toBeGreaterThan(0);
+            // and stored - 7020 == 26 * 800 == 20800
+            expect(stored - 26 * (150 + 120)).toBe(20800);
+        });
+    });
+
+    describe('getPostTaxExemptions', () => {
+        it('useStoredValue=true returns the stored roth401k (prorated)', () => {
+            const inc = makeWorkIncome();
+            const result = getPostTaxExemptions([inc], YEAR, undefined, true);
+            // 26 * 400 = 10400
+            expect(result).toBe(10400);
+        });
+
+        it('age-based getEffective401k path (custom) matches stored value', () => {
+            const inc = makeWorkIncome({ autoMax401k: 'custom' });
+            const result = getPostTaxExemptions([inc], YEAR, 45, false);
+            expect(result).toBe(10400);
+        });
+
+        it('age-based getEffective401k path (roth auto-max) uses IRS-limit-derived roth', () => {
+            const inc = makeWorkIncome({ autoMax401k: 'roth' });
+            const stored = getPostTaxExemptions([inc], YEAR, undefined, true);
+            const effective = getPostTaxExemptions([inc], YEAR, 45, false);
+            expect(effective).not.toBe(stored);
+            expect(effective).toBeGreaterThan(0);
+        });
+    });
+});
+
+describe('PR55 review fixes — deductions characterization', () => {
+    const YEAR = 2024;
+
+    it('getItemizedDeductions: mortgage uses amortization interest', () => {
+        const mortgage = new MortgageExpense(
+            'm1', 'Home', 'Monthly', 500000, 400000, 400000, 3, 30, 1.2, 0, 1, 100, 0.3, 0, 50,
+            'Itemized', 0.8, 'a1', new Date('2020-01-01'),
+        );
+        const deductions = getItemizedDeductions([mortgage], YEAR);
+        expect(deductions).toBeCloseTo(mortgage.calculateAnnualAmortization(YEAR).totalInterest, 6);
+        expect(deductions).toBeGreaterThan(0);
+    });
+
+    it('getItemizedDeductions: non-mortgage itemized expense uses tax_deductible field', () => {
+        // LoanExpense ctor: (id, name, amount, frequency, apr, interest_type, payment,
+        //                    is_tax_deductible, tax_deductible, linkedAccountId, startDate, endDate)
+        const loan = new LoanExpense(
+            'l1', 'Student Loan', 20000, 'Monthly', 5, 'Compounding', 500,
+            'Itemized', 2500, 'acc1', new Date('2010-01-01'), new Date('2060-01-01'),
+        );
+        const deductions = getItemizedDeductions([loan], YEAR);
+        // tax_deductible=2500/period, Monthly => 12 periods, active multiplier 1 => 30000
+        expect(deductions).toBe(loan.getProratedAnnual(2500, YEAR));
+        expect(deductions).toBe(30000);
+    });
+
+    it('getItemizedDeductions: ignores non-itemized expenses', () => {
+        const loan = new LoanExpense(
+            'l1', 'Loan', 20000, 'Monthly', 5, 'Compounding', 500,
+            'No', 2500, 'acc1', new Date('2010-01-01'), new Date('2060-01-01'),
+        );
+        expect(getItemizedDeductions([loan], YEAR)).toBe(0);
+    });
+
+    it('getYesDeductions: mortgage uses amortization interest', () => {
+        const mortgage = new MortgageExpense(
+            'm1', 'Home', 'Monthly', 500000, 400000, 400000, 3, 30, 1.2, 0, 1, 100, 0.3, 0, 50,
+            'Yes', 0.8, 'a1', new Date('2020-01-01'),
+        );
+        const deductions = getYesDeductions([mortgage], YEAR);
+        expect(deductions).toBeCloseTo(mortgage.calculateAnnualAmortization(YEAR).totalInterest, 6);
+        expect(deductions).toBeGreaterThan(0);
+    });
+
+    it('getYesDeductions: non-mortgage Yes expense uses tax_deductible field', () => {
+        const loan = new LoanExpense(
+            'l1', 'Loan', 20000, 'Monthly', 5, 'Compounding', 500,
+            'Yes', 1800, 'acc1', new Date('2010-01-01'), new Date('2060-01-01'),
+        );
+        const deductions = getYesDeductions([loan], YEAR);
+        expect(deductions).toBe(loan.getProratedAnnual(1800, YEAR));
+        expect(deductions).toBe(21600);
+    });
+
+    it('getYesDeductions: ignores non-Yes expenses', () => {
+        const loan = new LoanExpense(
+            'l1', 'Loan', 20000, 'Monthly', 5, 'Compounding', 500,
+            'Itemized', 1800, 'acc1', new Date('2010-01-01'), new Date('2060-01-01'),
+        );
+        expect(getYesDeductions([loan], YEAR)).toBe(0);
+    });
+});

--- a/src/__tests__/services/ReviewFixes_PR55_marginalRates.test.ts
+++ b/src/__tests__/services/ReviewFixes_PR55_marginalRates.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { getCombinedMarginalRate } from '../../components/Objects/Taxes/TaxService';
+import { TaxState } from '../../components/Objects/Taxes/TaxContext';
+import { defaultAssumptions, AssumptionsState } from '../../components/Objects/Assumptions/AssumptionsContext';
+
+// --- Test Helpers (mirror TaxOptimization.test.ts) ---
+
+const createTaxState = (overrides: Partial<TaxState> = {}): TaxState => ({
+    filingStatus: 'Single',
+    stateResidency: 'Texas', // no state income tax -> isolate federal + FICA
+    deductionMethod: 'Standard',
+    fedOverride: null,
+    ficaOverride: null,
+    stateOverride: null,
+    year: 2025,
+    ...overrides,
+});
+
+const noInflationAssumptions: AssumptionsState = {
+    ...defaultAssumptions,
+    macro: {
+        ...defaultAssumptions.macro,
+        inflationAdjusted: false,
+        inflationRate: 0,
+    },
+};
+
+describe('PR #55 #1 — Additional Medicare 0.9% surtax in combined marginal rate', () => {
+    it('includes the 0.9% surtax above the Single threshold (260k => fica ≈ 0.0235)', () => {
+        const result = getCombinedMarginalRate(
+            260000,
+            0,
+            createTaxState({ filingStatus: 'Single' }),
+            2025,
+            noInflationAssumptions,
+            true,
+        );
+
+        // Above SS wage base: Medicare 1.45% + Additional Medicare 0.9% = 2.35%
+        expect(result.fica).toBeCloseTo(0.0235, 6);
+        // combined must include the surtax (fica is one of its addends)
+        expect(result.combined).toBeCloseTo(result.federal + result.state + result.fica, 6);
+        expect(result.combined).toBeGreaterThanOrEqual(0.0235);
+    });
+
+    it('does NOT include the 0.9% surtax below the threshold (150k)', () => {
+        const result = getCombinedMarginalRate(
+            150000,
+            0,
+            createTaxState({ filingStatus: 'Single' }),
+            2025,
+            noInflationAssumptions,
+            true,
+        );
+
+        // 150k < 200k Single threshold and < SS wage base:
+        // SS 6.2% + Medicare 1.45% = 7.65%, no 0.9% surtax.
+        expect(result.fica).toBeCloseTo(0.0765, 6);
+        // Explicitly: no surtax baked in.
+        expect(result.fica).toBeLessThan(0.0766);
+    });
+
+    it('respects the MFJ 250k threshold', () => {
+        const below = getCombinedMarginalRate(
+            240000,
+            0,
+            createTaxState({ filingStatus: 'Married Filing Jointly' }),
+            2025,
+            noInflationAssumptions,
+            true,
+        );
+        // 240k < 250k MFJ threshold but > SS wage base -> Medicare only, no surtax
+        expect(below.fica).toBeCloseTo(0.0145, 6);
+
+        const above = getCombinedMarginalRate(
+            260000,
+            0,
+            createTaxState({ filingStatus: 'Married Filing Jointly' }),
+            2025,
+            noInflationAssumptions,
+            true,
+        );
+        expect(above.fica).toBeCloseTo(0.0235, 6);
+    });
+
+    it('omits the surtax entirely when FICA is excluded', () => {
+        const result = getCombinedMarginalRate(
+            260000,
+            0,
+            createTaxState({ filingStatus: 'Single' }),
+            2025,
+            noInflationAssumptions,
+            false,
+        );
+        expect(result.fica).toBe(0);
+    });
+});

--- a/src/__tests__/services/ReviewFixes_PR55_parameters.test.ts
+++ b/src/__tests__/services/ReviewFixes_PR55_parameters.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression tests for PR #55 review fixes in getTaxParameters (parameters.ts):
+ *  - #2: inflation branch must also inflate seniorDeduction (dollar amount)
+ *  - #5: a partial assumptions object missing inflationRate must not poison
+ *        results with NaN (treat non-finite inflation as 0%)
+ *  - #9: nearest-year fallback (extracted findNearestYear helper) still resolves
+ *        a missing-year query to the closest present year
+ *
+ * #6 (newer-year tie-break, `<` -> `<=` in findNearestYear) is latent: no real
+ * TAX_DATABASE table has a gap that produces an exact equidistant tie, so it is
+ * intentionally NOT unit-tested here (noted in the PR report).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getTaxParameters } from '../../components/Objects/Taxes/taxService/parameters';
+import { defaultAssumptions } from '../../components/Objects/Assumptions/AssumptionsContext';
+import { max_year } from '../../data/TaxData';
+
+describe('PR55 getTaxParameters review fixes', () => {
+    describe('#2 inflation branch inflates seniorDeduction', () => {
+        it('inflates Virginia seniorDeduction by the same multiplier as brackets', () => {
+            const inflationRate = 2.5;
+            const targetYear = 2050;
+            const assumptions = {
+                ...defaultAssumptions,
+                macro: {
+                    ...defaultAssumptions.macro,
+                    inflationAdjusted: true,
+                    inflationRate,
+                },
+            };
+
+            const params = getTaxParameters(
+                targetYear,
+                'Married Filing Jointly',
+                'state',
+                'Virginia',
+                assumptions
+            );
+
+            expect(params).toBeDefined();
+
+            // Base year for Virginia is max_year (2026), which is present.
+            const multiplier = Math.pow(
+                1 + inflationRate / 100,
+                targetYear - max_year
+            );
+
+            // Nominal VA senior deduction is $12,000.
+            const expectedSenior = Math.round(12000 * multiplier);
+            expect(params!.seniorDeduction).toBeDefined();
+            // Allow $1 of rounding slack.
+            expect(Math.abs(params!.seniorDeduction! - expectedSenior)).toBeLessThanOrEqual(1);
+
+            // And a bracket threshold must be inflated by the same multiplier.
+            // VA MFJ has a $17,000 (5.75%) bracket threshold.
+            const inflatedBracket = params!.brackets.find(
+                (b) => Math.abs(b.threshold - Math.round(17000 * multiplier)) <= 1
+            );
+            expect(inflatedBracket).toBeDefined();
+
+            // seniorAge is an age, not dollars: must stay 65.
+            expect(params!.seniorAge).toBe(65);
+        });
+    });
+
+    describe('#5 NaN guard on missing inflationRate', () => {
+        it('returns finite numbers when inflationRate is absent from a partial assumptions object', () => {
+            const params = getTaxParameters(
+                2030,
+                'Single',
+                'federal',
+                undefined,
+                // Partial object: inflationAdjusted set but no inflationRate.
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                { macro: { inflationAdjusted: true } } as any
+            );
+
+            expect(params).toBeDefined();
+            expect(Number.isFinite(params!.standardDeduction)).toBe(true);
+            for (const bracket of params!.brackets) {
+                expect(Number.isFinite(bracket.threshold)).toBe(true);
+            }
+            expect(Number.isFinite(params!.socialSecurityWageBase)).toBe(true);
+            for (const bracket of params!.capitalGainsBrackets ?? []) {
+                expect(Number.isFinite(bracket.threshold)).toBe(true);
+            }
+        });
+    });
+
+    describe('#9 findNearestYear fallback characterization', () => {
+        it('resolves California 2024 (no entry) to the nearest present year', () => {
+            // California only has 2025 and 2026 entries; a 2024 query must fall
+            // back to the nearest present year rather than returning undefined.
+            const params = getTaxParameters(2024, 'Single', 'state', 'California');
+            expect(params).toBeDefined();
+            expect(Number.isFinite(params!.standardDeduction)).toBe(true);
+            expect(params!.brackets.length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/src/__tests__/services/ReviewFixes_PR55_stateTax.test.ts
+++ b/src/__tests__/services/ReviewFixes_PR55_stateTax.test.ts
@@ -158,9 +158,10 @@ describe('PR55 #7: calculateUnifiedStateTax(...,0,...) === calculateStateTax', (
 // but return the SAME number; Itemized/Auto must still apply SALT.
 // =============================================================================
 describe('PR55 #8: calculateFederalTaxFromIncomes characterization', () => {
-    it('Standard deduction path pins to 13840.9 (DC residency irrelevant on Standard)', () => {
+    it('Standard deduction path pins to 13841 (DC residency irrelevant on Standard)', () => {
+        // Value moved +$0.10 with the PR#55 #3 fix (2024 Single brackets → breakpoint convention).
         const s = createTaxState({ deductionMethod: 'Standard', stateResidency: 'DC' });
-        expect(calculateFederalTaxFromIncomes(s, [work(100000)], [], 0, 2024, noInflationAssumptions)).toBeCloseTo(13840.9, 4);
+        expect(calculateFederalTaxFromIncomes(s, [work(100000)], [], 0, 2024, noInflationAssumptions)).toBeCloseTo(13841, 4);
     });
 
     it('Standard path identical whether high-tax or no-tax state (SALT irrelevant)', () => {
@@ -169,10 +170,11 @@ describe('PR55 #8: calculateFederalTaxFromIncomes characterization', () => {
         expect(dc).toBe(tx);
     });
 
-    it('Itemized path applies SALT (pins to 13356.34)', () => {
+    it('Itemized path applies SALT (pins to 13356.44)', () => {
+        // Value moved +$0.10 with the PR#55 #3 fix (2024 Single brackets → breakpoint convention).
         const s = createTaxState({ deductionMethod: 'Itemized', stateResidency: 'DC' });
         const m = [itemizedMortgage()];
-        expect(calculateFederalTaxFromIncomes(s, [work(100000)], m, 0, 2024, noInflationAssumptions)).toBeCloseTo(13356.34, 2);
+        expect(calculateFederalTaxFromIncomes(s, [work(100000)], m, 0, 2024, noInflationAssumptions)).toBeCloseTo(13356.44, 2);
     });
 
     it('Auto path pins to its computed value (still applies SALT)', () => {
@@ -181,7 +183,8 @@ describe('PR55 #8: calculateFederalTaxFromIncomes characterization', () => {
         // Standard/Itemized calls. Pin the concrete value as a regression guard.
         const m = [itemizedMortgage()];
         const auto = calculateFederalTaxFromIncomes(createTaxState({ deductionMethod: 'Auto', stateResidency: 'DC' }), [work(100000)], m, 0, 2024, noInflationAssumptions);
-        expect(auto).toBeCloseTo(13426.980948654455, 4);
+        // Value moved +$0.10 with the PR#55 #3 fix (2024 Single brackets → breakpoint convention).
+        expect(auto).toBeCloseTo(13427.080948654457, 4);
     });
 
     it('Itemized path with additionalOrdinaryIncome>0 uses unified state tax', () => {

--- a/src/__tests__/services/ReviewFixes_PR55_stateTax.test.ts
+++ b/src/__tests__/services/ReviewFixes_PR55_stateTax.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import { TaxState } from '../../components/Objects/Taxes/TaxContext';
+import {
+    AssumptionsState,
+    defaultAssumptions,
+    createBuiltinMilestones,
+} from '../../components/Objects/Assumptions/AssumptionsContext';
+import {
+    calculateStateTax,
+    calculateUnifiedStateTax,
+    calculateFederalTaxFromIncomes,
+} from '../../components/Objects/Taxes/TaxService';
+import { WorkIncome, CurrentSocialSecurityIncome, AnyIncome } from '../../components/Objects/Income/models';
+import { MortgageExpense, AnyExpense } from '../../components/Objects/Expense/models';
+
+/**
+ * CHARACTERIZATION tests for PR #55 review fixes #7, #8, #11.
+ *
+ * These pin the EXACT numeric outputs of calculateStateTax /
+ * calculateUnifiedStateTax / calculateFederalTaxFromIncomes for a spread of
+ * states, ages, filing statuses, deduction methods, and SS presence. They must
+ * pass BEFORE the refactor (against the original code) and remain green AFTER —
+ * the refactor must be behavior-preserving (byte-identical numbers).
+ */
+
+// --- HELPERS (mirror the existing tax test fixtures) ---
+
+const createTaxState = (overrides: Partial<TaxState> = {}): TaxState => ({
+    filingStatus: 'Single',
+    stateResidency: 'Texas',
+    deductionMethod: 'Standard',
+    fedOverride: null,
+    ficaOverride: null,
+    stateOverride: null,
+    year: 2024,
+    ...overrides,
+});
+
+const noInflationAssumptions: AssumptionsState = {
+    ...defaultAssumptions,
+    macro: {
+        ...defaultAssumptions.macro,
+        inflationAdjusted: false,
+        inflationRate: 0,
+    },
+};
+
+// Born 1959 -> age 65 in tax year 2024 (exercises senior-deduction doubling for MFJ)
+const seniorAssumptions: AssumptionsState = {
+    ...noInflationAssumptions,
+    milestones: createBuiltinMilestones(1959, 1, 15),
+};
+
+const work = (amount: number) =>
+    new WorkIncome('w1', 'Job', amount, 'Annually', 'Yes', 0, 0, 0, 0, 'acc1', 'Traditional 401k', 'FIXED', new Date('2020-01-01'));
+
+const ss = (annual: number) =>
+    new CurrentSocialSecurityIncome('ss1', 'SS', annual, 'Annually', new Date('2020-01-01'));
+
+const itemizedMortgage = () => {
+    const m = new MortgageExpense('m1', 'Home', 'Monthly', 500000, 400000, 400000, 3, 30, 1.2, 0, 1, 100, 0.3, 0, 50, 'Itemized', 0.8, 'a1', new Date(2020, 0, 1));
+    m.loan_balance = m.getBalanceAtDate('2024-01-02');
+    return m;
+};
+
+// =============================================================================
+// calculateStateTax — pinned outputs across the matrix
+// =============================================================================
+describe('PR55 #7/#11: calculateStateTax characterization', () => {
+    it('California, no SS, Standard (2025)', () => {
+        const s = createTaxState({ stateResidency: 'California' });
+        expect(calculateStateTax(s, [work(100000)], [], 2025, noInflationAssumptions)).toBeCloseTo(5327, 0);
+    });
+
+    it('DC, no SS, Standard', () => {
+        const s = createTaxState({ stateResidency: 'DC' });
+        expect(calculateStateTax(s, [work(100000)], [], 2024, noInflationAssumptions)).toBeCloseTo(5659, 4);
+    });
+
+    it('Texas, no SS, Standard (no income tax)', () => {
+        const s = createTaxState({ stateResidency: 'Texas' });
+        expect(calculateStateTax(s, [work(100000)], [], 2024, noInflationAssumptions)).toBe(0);
+    });
+
+    it('Virginia, age 66 MFJ senior doubling, no SS, Standard', () => {
+        const s = createTaxState({ stateResidency: 'Virginia', filingStatus: 'Married Filing Jointly' });
+        expect(calculateStateTax(s, [work(100000)], [], 2024, seniorAssumptions)).toBeCloseTo(3135, 4);
+    });
+
+    it('Virginia, age 66 Single senior, no SS, Standard', () => {
+        const s = createTaxState({ stateResidency: 'Virginia' });
+        expect(calculateStateTax(s, [work(100000)], [], 2024, seniorAssumptions)).toBeCloseTo(4313.75, 4);
+    });
+
+    it('Virginia, with SS (exempt), Standard', () => {
+        const s = createTaxState({ stateResidency: 'Virginia' });
+        expect(calculateStateTax(s, [work(50000), ss(30000)], [], 2024, noInflationAssumptions)).toBeCloseTo(2128.75, 4);
+    });
+
+    it('DC, with SS (exempt) === DC taxed on work-only base', () => {
+        const s = createTaxState({ stateResidency: 'DC' });
+        const ref = calculateStateTax(createTaxState({ stateResidency: 'DC' }), [work(60000)], [], 2024, noInflationAssumptions);
+        expect(calculateStateTax(s, [work(60000), ss(30000)], [], 2024, noInflationAssumptions)).toBeCloseTo(ref, 6);
+    });
+
+    it('DC, no SS, Itemized vs Standard vs Auto', () => {
+        const m = [itemizedMortgage()];
+        const std = calculateStateTax(createTaxState({ stateResidency: 'DC', deductionMethod: 'Standard' }), [work(100000)], m, 2024, noInflationAssumptions);
+        const item = calculateStateTax(createTaxState({ stateResidency: 'DC', deductionMethod: 'Itemized' }), [work(100000)], m, 2024, noInflationAssumptions);
+        const auto = calculateStateTax(createTaxState({ stateResidency: 'DC', deductionMethod: 'Auto' }), [work(100000)], m, 2024, noInflationAssumptions);
+        expect(auto).toBe(Math.min(std, item));
+        expect(std).toBeCloseTo(5659, 4);
+    });
+});
+
+// =============================================================================
+// calculateUnifiedStateTax(..., additionalOrdinaryIncome=0, ...) must equal
+// calculateStateTax for the same inputs (the #7 delegation contract).
+// =============================================================================
+describe('PR55 #7: calculateUnifiedStateTax(...,0,...) === calculateStateTax', () => {
+    const cases: Array<{ name: string; state: Partial<TaxState>; incomes: () => AnyIncome[]; expenses: () => AnyExpense[]; year: number; a: AssumptionsState }> = [
+        { name: 'California Standard no SS', state: { stateResidency: 'California' }, incomes: () => [work(100000)], expenses: () => [], year: 2025, a: noInflationAssumptions },
+        { name: 'DC Standard no SS', state: { stateResidency: 'DC' }, incomes: () => [work(100000)], expenses: () => [], year: 2024, a: noInflationAssumptions },
+        { name: 'Texas no tax', state: { stateResidency: 'Texas' }, incomes: () => [work(100000)], expenses: () => [], year: 2024, a: noInflationAssumptions },
+        { name: 'Virginia MFJ senior no SS', state: { stateResidency: 'Virginia', filingStatus: 'Married Filing Jointly' }, incomes: () => [work(100000)], expenses: () => [], year: 2024, a: seniorAssumptions },
+        { name: 'Virginia Single senior with SS', state: { stateResidency: 'Virginia' }, incomes: () => [work(50000), ss(30000)], expenses: () => [], year: 2024, a: seniorAssumptions },
+        { name: 'DC Auto with mortgage', state: { stateResidency: 'DC', deductionMethod: 'Auto' }, incomes: () => [work(100000)], expenses: () => [itemizedMortgage()], year: 2024, a: noInflationAssumptions },
+        { name: 'DC Itemized with mortgage', state: { stateResidency: 'DC', deductionMethod: 'Itemized' }, incomes: () => [work(100000)], expenses: () => [itemizedMortgage()], year: 2024, a: noInflationAssumptions },
+        { name: 'California with SS Standard', state: { stateResidency: 'California' }, incomes: () => [work(40000), ss(24000)], expenses: () => [], year: 2025, a: noInflationAssumptions },
+    ];
+
+    cases.forEach(({ name, state, incomes, expenses, year, a }) => {
+        it(name, () => {
+            const s = createTaxState(state);
+            const direct = calculateStateTax(s, incomes(), expenses(), year, a);
+            const unified = calculateUnifiedStateTax(s, incomes(), expenses(), 0, year, a);
+            expect(unified).toBe(direct);
+        });
+    });
+
+    it('state override short-circuits in both functions', () => {
+        const s = createTaxState({ stateResidency: 'California', stateOverride: 3000 });
+        expect(calculateStateTax(s, [work(100000)], [], 2024, noInflationAssumptions)).toBe(3000);
+        expect(calculateUnifiedStateTax(s, [work(100000)], [], 0, 2024, noInflationAssumptions)).toBe(3000);
+        expect(calculateUnifiedStateTax(s, [work(100000)], [], 50000, 2024, noInflationAssumptions)).toBe(3000);
+    });
+
+    it('additionalOrdinaryIncome folds into the base (DC)', () => {
+        const s = createTaxState({ stateResidency: 'DC' });
+        const unified = calculateUnifiedStateTax(s, [work(50000)], [], 50000, 2024, noInflationAssumptions);
+        const direct = calculateStateTax(s, [work(100000)], [], 2024, noInflationAssumptions);
+        expect(unified).toBeCloseTo(direct, 6);
+    });
+});
+
+// =============================================================================
+// calculateFederalTaxFromIncomes — #8: Standard path must skip SALT/state work
+// but return the SAME number; Itemized/Auto must still apply SALT.
+// =============================================================================
+describe('PR55 #8: calculateFederalTaxFromIncomes characterization', () => {
+    it('Standard deduction path pins to 13840.9 (DC residency irrelevant on Standard)', () => {
+        const s = createTaxState({ deductionMethod: 'Standard', stateResidency: 'DC' });
+        expect(calculateFederalTaxFromIncomes(s, [work(100000)], [], 0, 2024, noInflationAssumptions)).toBeCloseTo(13840.9, 4);
+    });
+
+    it('Standard path identical whether high-tax or no-tax state (SALT irrelevant)', () => {
+        const dc = calculateFederalTaxFromIncomes(createTaxState({ deductionMethod: 'Standard', stateResidency: 'DC' }), [work(100000)], [], 0, 2024, noInflationAssumptions);
+        const tx = calculateFederalTaxFromIncomes(createTaxState({ deductionMethod: 'Standard', stateResidency: 'Texas' }), [work(100000)], [], 0, 2024, noInflationAssumptions);
+        expect(dc).toBe(tx);
+    });
+
+    it('Itemized path applies SALT (pins to 13356.34)', () => {
+        const s = createTaxState({ deductionMethod: 'Itemized', stateResidency: 'DC' });
+        const m = [itemizedMortgage()];
+        expect(calculateFederalTaxFromIncomes(s, [work(100000)], m, 0, 2024, noInflationAssumptions)).toBeCloseTo(13356.34, 2);
+    });
+
+    it('Auto path pins to its computed value (still applies SALT)', () => {
+        // NOTE: Auto computes its own standard vs itemized branches internally and
+        // returns the min of those; this is NOT identical to min of the standalone
+        // Standard/Itemized calls. Pin the concrete value as a regression guard.
+        const m = [itemizedMortgage()];
+        const auto = calculateFederalTaxFromIncomes(createTaxState({ deductionMethod: 'Auto', stateResidency: 'DC' }), [work(100000)], m, 0, 2024, noInflationAssumptions);
+        expect(auto).toBeCloseTo(13426.980948654455, 4);
+    });
+
+    it('Itemized path with additionalOrdinaryIncome>0 uses unified state tax', () => {
+        const s = createTaxState({ deductionMethod: 'Itemized', stateResidency: 'DC' });
+        const m = [itemizedMortgage()];
+        const v = calculateFederalTaxFromIncomes(s, [work(60000)], m, 40000, 2024, noInflationAssumptions);
+        expect(v).toBeGreaterThan(0);
+        const ref = calculateFederalTaxFromIncomes(s, [work(100000)], m, 0, 2024, noInflationAssumptions);
+        expect(v).toBeCloseTo(ref, 6);
+    });
+});

--- a/src/__tests__/services/ReviewFixes_PR55_taxData.test.ts
+++ b/src/__tests__/services/ReviewFixes_PR55_taxData.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { TAX_DATABASE } from '../../data/TaxData';
+
+// PR#55 #3: The 2024 federal Single brackets previously used the IRS "+1"
+// convention (47151/100526/191951/243726) while the model treats `threshold`
+// as a continuous breakpoint (bracket walk uses `> current.threshold`). Every
+// other row (2024 MFS, 2025/2026 Single) uses the plain breakpoint value, so
+// 2024 Single was the lone outlier with each boundary $1 too high.
+describe('PR#55 #3 — 2024 Single federal brackets use breakpoint convention', () => {
+  it('2024 Single thresholds equal the breakpoint values', () => {
+    const thresholds = TAX_DATABASE.federal[2024].Single.brackets.map((b) => b.threshold);
+    expect(thresholds).toEqual([0, 11600, 47150, 100525, 191950, 243725, 609350]);
+  });
+
+  it('2024 Single and MFS share identical 22%/24%/32%/35% thresholds', () => {
+    const single = TAX_DATABASE.federal[2024].Single.brackets;
+    const mfs = TAX_DATABASE.federal[2024]['Married Filing Separately'].brackets;
+
+    // The two rows differ only in the top 37% bracket; the 22/24/32/35 rate
+    // boundaries should be identical.
+    const sharedRates = [0.22, 0.24, 0.32, 0.35];
+    for (const rate of sharedRates) {
+      const s = single.find((b) => b.rate === rate)?.threshold;
+      const m = mfs.find((b) => b.rate === rate)?.threshold;
+      expect(s).toBe(m);
+    }
+  });
+});

--- a/src/__tests__/services/SSAImportService.test.ts
+++ b/src/__tests__/services/SSAImportService.test.ts
@@ -158,7 +158,8 @@ describe('SSAImportService', () => {
 
       const result = validateEarningsImport(earnings, 1990);
 
-      expect(result.valid).toBe(false);
+      // Non-blocking advisory warning: it must surface but not block the import.
+      expect(result.valid).toBe(true);
       expect(result.warnings.length).toBeGreaterThan(0);
       expect(result.warnings[0]).toContain('age');
     });
@@ -178,7 +179,8 @@ describe('SSAImportService', () => {
 
       const result = validateEarningsImport(earnings, 1930);
 
-      expect(result.valid).toBe(false);
+      // Non-blocking advisory warning: it must surface but not block the import.
+      expect(result.valid).toBe(true);
       expect(result.warnings.some(w => w.includes('1951'))).toBe(true);
     });
 
@@ -192,6 +194,8 @@ describe('SSAImportService', () => {
       const result = validateEarningsImport(earnings, 1990);
 
       expect(result.warnings.some(w => w.includes('future'))).toBe(true);
+      // A benign, non-blocking future-year warning must NOT flip valid to false.
+      expect(result.valid).toBe(true);
     });
   });
 

--- a/src/__tests__/services/backupMerge.test.ts
+++ b/src/__tests__/services/backupMerge.test.ts
@@ -114,6 +114,32 @@ describe('applyTransactions', () => {
         expect(credit.isPossibleCredit).toBe(true);
     });
 
+    it('mints distinct month ids when one merge creates several months in a tick (Finding #10)', () => {
+        // generateMonthId used to be `MONTH-${Date.now()}-${rand(1000)}`, which
+        // collided when several months were created in one synchronous merge.
+        const blob: MergeBlob = { version: 1, accounts: [], amountHistory: {} };
+        const incoming: Transaction[] = [];
+        // One transaction in each of many distinct months -> each forces a new snapshot.
+        for (let i = 0; i < 24; i++) {
+            const year = 2026 + Math.floor(i / 12);
+            const monthNum = (i % 12) + 1;
+            incoming.push(
+                txn({
+                    id: `t${i}`,
+                    date: `${year}-${String(monthNum).padStart(2, '0')}-15`,
+                    amount: -10,
+                    description: `TXN ${i}`,
+                })
+            );
+        }
+
+        applyTransactions(blob, incoming, { dedup: 'id' });
+
+        const ids = blob.budget!.months.map(m => m.id);
+        expect(ids.length).toBe(24);
+        expect(new Set(ids).size).toBe(24); // all distinct
+    });
+
     it('tolerates a v1 blob with no budget container', () => {
         const blob: MergeBlob = { version: 1, accounts: [], amountHistory: {} };
         const report = applyTransactions(blob, [

--- a/src/__tests__/services/simulation/GoalFundingMilestone.test.ts
+++ b/src/__tests__/services/simulation/GoalFundingMilestone.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Goal Funding: milestone gating + shared-account double-count reconciliation
+ * (FINDING 4 + #8)
+ *
+ * Verifies two engine-level behaviors of long-term goal sinking-fund funding in
+ * simulateOneYear:
+ *
+ *  (a) Milestone gating — a goal whose startMilestoneId is NOT active this year
+ *      is neither funded (its fund account balance does not grow) nor purchased.
+ *      Once its milestone becomes active, it funds normally.
+ *
+ *  (b) Shared account — two goals that share one goalAccountId credit the fund
+ *      with the SUM of both set-asides exactly ONCE per year (not 2x). This is
+ *      the regression guard for the double-count that existed when the funding
+ *      loop accumulated the (now per-account-total) helper result per-goal.
+ *
+ * Also exercises the date-only straggler fix: a targetDate goal whose endDate is
+ * Jan 1 2030 (built local-midnight) must resolve to year 2030 even under a
+ * positive-UTC timezone (run the suite with TZ=Australia/Sydney to confirm).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { simulateOneYear } from '../../../components/Objects/Assumptions/SimulationEngine';
+import { InvestedAccount, SavedAccount } from '../../../components/Objects/Accounts/models';
+import {
+    AssumptionsState,
+    defaultAssumptions,
+    createBuiltinMilestones,
+} from '../../../components/Objects/Assumptions/AssumptionsContext';
+import { TaxState } from '../../../components/Objects/Taxes/TaxContext';
+import { OtherExpense, getGoalFundAnnualSetAside } from '../../../components/Objects/Expense/models';
+import { CustomMilestone } from '../../../services/simulation/types';
+
+// =============================================================================
+// FIXTURES
+// =============================================================================
+
+const BIRTH_YEAR = 1985; // Age 40 in 2025
+
+function makeAssumptions(extraMilestones: CustomMilestone[] = []): AssumptionsState {
+    return {
+        ...defaultAssumptions,
+        // Retire far in the future so these years are working years (income > expenses).
+        milestones: [...createBuiltinMilestones(BIRTH_YEAR, 65, 95), ...extraMilestones],
+        macro: {
+            ...defaultAssumptions.macro,
+            inflationAdjusted: false, // keep numbers static for clean assertions
+            inflationRate: 0,
+        },
+        investments: {
+            ...defaultAssumptions.investments,
+            returnRates: { ror: 0 }, // no growth so fund deltas == set-asides exactly
+        },
+        withdrawalStrategy: [
+            { id: 'ws-1', name: 'Brokerage', accountId: 'brokerage-1' },
+        ],
+    };
+}
+
+function makeTaxState(year: number): TaxState {
+    return {
+        filingStatus: 'Single',
+        stateResidency: 'Texas',
+        deductionMethod: 'Standard',
+        fedOverride: null,
+        ficaOverride: null,
+        stateOverride: null,
+        year,
+    };
+}
+
+// A long-term targetDate goal: $36,000 saved from start over 3 years (Jan 2027 →
+// Jan 2030) = $1,000/month = $12,000/year while active.
+function makeTargetDateGoal(
+    id: string,
+    goalAccountId: string,
+    opts: { startMilestoneId?: string } = {},
+): OtherExpense {
+    const g = new OtherExpense(
+        id, `Goal ${id}`, 36000, 'Annually', new Date(2027, 0, 1), new Date(2030, 0, 1),
+    );
+    g.goalType = 'targetDate';
+    g.goalAccountId = goalAccountId;
+    if (opts.startMilestoneId) g.startMilestoneId = opts.startMilestoneId;
+    return g;
+}
+
+function makeAccounts(funds: { id: string; amount: number }[]) {
+    const brokerage = new InvestedAccount(
+        'brokerage-1', 'Brokerage', 1_000_000, 0, 5, 0.0, 'Brokerage', true, 0.2, 1_000_000,
+    );
+    const fundAccounts = funds.map(f => new SavedAccount(f.id, `Fund ${f.id}`, f.amount, 0));
+    return [brokerage, ...fundAccounts];
+}
+
+function fundBalance(result: { accounts: { id: string; amount: number }[] }, id: string): number {
+    const acc = result.accounts.find(a => a.id === id);
+    if (!acc) throw new Error(`fund ${id} not found in result`);
+    return acc.amount;
+}
+
+// =============================================================================
+// (a) MILESTONE GATING
+// =============================================================================
+
+describe('Goal funding — milestone gating (FINDING 4)', () => {
+    // Custom start milestone: becomes active once YEAR >= 2028.
+    const startMilestone: CustomMilestone = {
+        id: 'GOAL_START',
+        name: 'Goal Start',
+        conditions: [{ type: 'YEAR', operator: '>=', value: 2028 }],
+    };
+
+    it('does NOT fund a goal whose start milestone is inactive this year', () => {
+        const year = 2027; // milestone not yet active (needs YEAR >= 2028)
+        const accounts = makeAccounts([{ id: 'fund-1', amount: 0 }]);
+        const goal = makeTargetDateGoal('A', 'fund-1', { startMilestoneId: 'GOAL_START' });
+
+        const result = simulateOneYear(
+            year, [], [goal], accounts, makeAssumptions([startMilestone]),
+            makeTaxState(year),
+        );
+
+        // Fund balance must NOT increase — the goal is milestone-gated off.
+        expect(fundBalance(result, 'fund-1')).toBe(0);
+    });
+
+    it('funds the goal normally once its start milestone is active', () => {
+        const year = 2028; // milestone active (YEAR >= 2028)
+        const accounts = makeAccounts([{ id: 'fund-1', amount: 0 }]);
+        const goal = makeTargetDateGoal('A', 'fund-1', { startMilestoneId: 'GOAL_START' });
+
+        // Sanity: the helper's per-account total for this year.
+        const expected = getGoalFundAnnualSetAside([goal], 'fund-1', year) ?? 0;
+        expect(expected).toBeGreaterThan(0);
+
+        const result = simulateOneYear(
+            year, [], [goal], accounts, makeAssumptions([startMilestone]),
+            makeTaxState(year),
+            [], undefined,
+            ['GOAL_START'], // previously active milestones — milestone already reached
+        );
+
+        expect(fundBalance(result, 'fund-1')).toBeCloseTo(expected, 2);
+    });
+
+    it('does NOT purchase (spend the lump from) a milestone-gated goal in its due year', () => {
+        const year = 2030; // targetDate due year, but milestone inactive (we omit it)
+        const accounts = makeAccounts([{ id: 'fund-1', amount: 50000 }]); // pre-loaded fund
+        const goal = makeTargetDateGoal('A', 'fund-1', { startMilestoneId: 'GOAL_START' });
+
+        // Pass NO active milestones and a milestone that won't be met (YEAR >= 9999)
+        const neverMilestone: CustomMilestone = {
+            id: 'GOAL_START',
+            name: 'Goal Start',
+            conditions: [{ type: 'YEAR', operator: '>=', value: 9999 }],
+        };
+
+        const result = simulateOneYear(
+            year, [], [goal], accounts, makeAssumptions([neverMilestone]),
+            makeTaxState(year),
+        );
+
+        // Lump must NOT be spent: fund stays at its pre-loaded balance.
+        expect(fundBalance(result, 'fund-1')).toBe(50000);
+    });
+});
+
+// =============================================================================
+// (b) SHARED ACCOUNT — no double-count
+// =============================================================================
+
+describe('Goal funding — shared account double-count guard (FINDING 8)', () => {
+    it('credits the fund the SUM of both goals\' set-asides exactly once', () => {
+        const year = 2028; // both goals active and saving (2027 → 2030)
+        const accounts = makeAccounts([{ id: 'fund-shared', amount: 0 }]);
+        const goalA = makeTargetDateGoal('A', 'fund-shared'); // $12k/yr
+        const goalB = makeTargetDateGoal('B', 'fund-shared'); // $12k/yr
+        const expenses = [goalA, goalB];
+
+        // The helper already SUMS across both goals on this account.
+        const expectedTotal = getGoalFundAnnualSetAside(expenses, 'fund-shared', year) ?? 0;
+
+        // Cross-check it equals the sum of the two individual set-asides.
+        const setAsideA = getGoalFundAnnualSetAside([goalA], 'fund-shared', year) ?? 0;
+        const setAsideB = getGoalFundAnnualSetAside([goalB], 'fund-shared', year) ?? 0;
+        expect(expectedTotal).toBeCloseTo(setAsideA + setAsideB, 2);
+        expect(expectedTotal).toBeGreaterThan(0);
+
+        const result = simulateOneYear(
+            year, [], expenses, accounts, makeAssumptions(),
+            makeTaxState(year),
+        );
+
+        const credited = fundBalance(result, 'fund-shared');
+
+        // Must be the SUM (once), NOT double-counted (2x the per-account total).
+        expect(credited).toBeCloseTo(expectedTotal, 2);
+        expect(credited).not.toBeCloseTo(expectedTotal * 2, 2);
+    });
+});
+
+// =============================================================================
+// DATE-ONLY STRAGGLER (TZ-robust)
+// =============================================================================
+
+describe('Goal funding — local-midnight endDate resolves correctly under any TZ', () => {
+    it('purchases a Jan 1 2030 targetDate goal in 2030 (not 2029) regardless of TZ', () => {
+        const year = 2030;
+        const accounts = makeAccounts([{ id: 'fund-1', amount: 36000 }]); // fully funded
+        const goal = makeTargetDateGoal('A', 'fund-1'); // endDate Jan 1 2030 (local)
+
+        const result = simulateOneYear(
+            year, [], [goal], accounts, makeAssumptions(),
+            makeTaxState(year),
+        );
+
+        // The lump comes due in 2030: the fund is spent down to 0.
+        expect(fundBalance(result, 'fund-1')).toBe(0);
+    });
+});

--- a/src/__tests__/services/simulation/IncomeProjection.test.ts
+++ b/src/__tests__/services/simulation/IncomeProjection.test.ts
@@ -893,12 +893,13 @@ describe('IncomeProjection', () => {
                 expect(interest.isReinvested).toBe(true);
             });
 
-            it('should construct interest dates as UTC so it is active the full calendar year', () => {
-                // Regression (Bug #13): interest income was built with local
-                // new Date(year, 0, 1) / new Date(year, 11, 31), but
-                // getIncomeActiveMultiplier reads start/end with getUTC*. In
-                // positive-UTC timezones the local Jan-1 is the prior year's Dec-31
-                // in UTC, shrinking/shifting the active window below a full year.
+            it('should construct interest dates locally so it is active the full calendar year', () => {
+                // Income date-only values follow the repo-wide LOCAL convention
+                // (parseDate builds new Date(y, m-1, d)), and getIncomeActiveMultiplier
+                // now reads them with local accessors. Interest income is therefore
+                // built with local new Date(year, 0, 1) / new Date(year, 11, 31), which
+                // reads back as the same calendar year and yields a clean full-year
+                // active window (multiplier 1.0) in ANY timezone.
                 const year = 2025;
                 const savingsAccount = new SavedAccount('sav1', 'HYSA', 100000, 5);
                 const assumptions = createTestAssumptions();
@@ -916,11 +917,11 @@ describe('IncomeProjection', () => {
                 );
 
                 const interest = result.interestIncomes[0];
-                // Dates must read as the intended calendar year in UTC.
-                expect(interest.startDate?.getUTCFullYear()).toBe(year);
-                expect(interest.startDate?.getUTCMonth()).toBe(0);
-                expect(interest.end_date?.getUTCFullYear()).toBe(year);
-                expect(interest.end_date?.getUTCMonth()).toBe(11);
+                // Dates must read as the intended calendar year with LOCAL accessors.
+                expect(interest.startDate?.getFullYear()).toBe(year);
+                expect(interest.startDate?.getMonth()).toBe(0);
+                expect(interest.end_date?.getFullYear()).toBe(year);
+                expect(interest.end_date?.getMonth()).toBe(11);
 
                 // The whole point: the consumer must see a clean full-year window.
                 expect(getIncomeActiveMultiplier(interest, year)).toBe(1.0);

--- a/src/__tests__/services/simulation/ReviewFixes_PR54.test.ts
+++ b/src/__tests__/services/simulation/ReviewFixes_PR54.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Regression tests for the PR #54 code-review fixes.
+ *
+ * Each test asserts on stable, public YearPlanTax fields so it compiles against
+ * both the pre-fix and post-fix sources — that is what makes it a valid
+ * red-before / green-after regression guard.
+ *
+ * Fix #1 — ESPP bargain-element ordinary tax was misrouted into the LTCG
+ *   pass-through: it was subtracted from cash-in (via actualLTCGTax) and dropped
+ *   from `withdrawalOrdinaryTax` / `tax.total`. A retirement year funded by an
+ *   ESPP sale must report that ordinary tax in `tax.withdrawalOrdinaryTax`
+ *   (which was 0 before the fix, since the ESPP draw was the only withdrawal).
+ *
+ * Fix #2 — solveWorkingYear hardcoded `niit: 0`, so capital gains realized to
+ *   fund a deficit escaped the 3.8% NIIT. A high-income working year with a
+ *   deficit-driven brokerage sale must report `tax.niit > 0` (was 0 before).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { solveRetirementYear, solveWorkingYear, YearSolverInput } from '../../../services/simulation/YearSolver';
+import { planWithdrawals, createAccountSnapshot } from '../../../services/simulation/WithdrawalPlanner';
+import { ESPPAccount, InvestedAccount, SavedAccount, ESPPLot } from '../../../components/Objects/Accounts/models';
+import { WorkIncome } from '../../../components/Objects/Income/models';
+import { OtherExpense } from '../../../components/Objects/Expense/models';
+import { AssumptionsState, defaultAssumptions, createBuiltinMilestones } from '../../../components/Objects/Assumptions/AssumptionsContext';
+import { TaxState } from '../../../components/Objects/Taxes/TaxContext';
+
+const YEAR = 2025;
+
+function singleTexas(): TaxState {
+    return {
+        filingStatus: 'Single',
+        stateResidency: 'Texas', // no state income tax → isolates the federal effect
+        deductionMethod: 'Standard',
+        fedOverride: null,
+        ficaOverride: null,
+        stateOverride: null,
+        year: YEAR,
+    };
+}
+
+// =============================================================================
+// Fix #1 — ESPP bargain-element ordinary tax routing
+// =============================================================================
+
+describe('PR #54 fix #1 — ESPP bargain-element ordinary tax routing', () => {
+    function esppAccounts() {
+        // Same lot shape as Scenario 9: both lots have a real bargain element.
+        const lotA: ESPPLot = {
+            id: 'lot-a', shares: 100, purchasePrice: 15,
+            purchaseDate: new Date('2022-06-30'), grantDate: new Date('2021-01-01'),
+            fmvAtPurchase: 20, fmvAtGrant: 20, totalCost: 1500, discountAmount: 5,
+        };
+        const lotB: ESPPLot = {
+            id: 'lot-b', shares: 50, purchasePrice: 34,
+            purchaseDate: new Date('2024-06-30'), grantDate: new Date('2024-01-01'),
+            fmvAtPurchase: 40, fmvAtGrant: 40, totalCost: 1700, discountAmount: 6,
+        };
+        const espp = new ESPPAccount(
+            'espp-1', 'Company ESPP', (100 * 200) + (50 * 400), [lotA, lotB],
+            null, undefined, 'ACME', 200,
+        );
+        const traditional = new InvestedAccount('trad-1', 'Traditional IRA', 300000, 0, 10, 0.05, 'Traditional IRA');
+        const savings = new SavedAccount('savings-1', 'Savings', 10000, 2.0);
+        return [espp, traditional, savings];
+    }
+
+    function esppAssumptions(): AssumptionsState {
+        return {
+            ...defaultAssumptions,
+            milestones: createBuiltinMilestones(1980, 40, 95), // age 45 in 2025, retired
+            investments: {
+                ...defaultAssumptions.investments,
+                taxOptimizationEnabled: false,
+                returnRates: { ror: 7 },
+            },
+            withdrawalStrategy: [],
+        };
+    }
+
+    it('reports the ESPP ordinary tax in withdrawalOrdinaryTax instead of dropping it', () => {
+        const input: YearSolverInput = {
+            year: YEAR,
+            currentAge: 45,
+            isRetired: true,
+            incomes: [],
+            expenses: [new OtherExpense('living-1', 'Living', 35000, 'Annually', new Date('2020-01-01'))],
+            totalLivingExpenses: 35000,
+            rmdAmount: 0,
+            accounts: esppAccounts(),
+            withdrawalOrder: [{ accountId: 'espp-1' }, { accountId: 'trad-1' }, { accountId: 'savings-1' }],
+            taxState: singleTexas(),
+            assumptions: esppAssumptions(),
+            taxOptimizationEnabled: false,
+            acaAware: false,
+        };
+
+        const plan = solveRetirementYear(input);
+
+        // ESPP ($40k) covers the $35k deficit on its own — no Traditional draw —
+        // so any ordinary withdrawal tax must be the ESPP bargain element.
+        expect(plan.withdrawals.some(w => w.source === 'espp')).toBe(true);
+        expect(plan.withdrawals.some(w => w.source.startsWith('traditional'))).toBe(false);
+
+        // Pre-fix: 0 (ESPP ordinary tax swept into the LTCG pass-through).
+        expect(plan.tax.withdrawalOrdinaryTax).toBeGreaterThan(0);
+    });
+});
+
+// =============================================================================
+// Fix #2 — NIIT on working-year capital gains
+// =============================================================================
+
+describe('PR #54 fix #2 — NIIT on working-year capital gains', () => {
+    it('assesses the 3.8% NIIT on gains realized to fund a working-year deficit', () => {
+        const work = new WorkIncome(
+            'work-1', 'Job', 250000, 'Annually', 'Yes',
+            0, 0, 0, 0, '', 'Traditional 401k', 'FIXED',
+            new Date('2015-01-01'), undefined,
+        );
+        // Brokerage with ~90% unrealized gains (costBasis 20k of 200k) so a sale
+        // realizes substantial LTCG; income is well above the $200k NIIT threshold.
+        const brokerage = new InvestedAccount('brokerage-1', 'Brokerage', 200000, 0, 10, 0.07, 'Brokerage', true, 0.25, 20000);
+
+        const input: YearSolverInput = {
+            year: YEAR,
+            currentAge: 45,
+            isRetired: false,
+            incomes: [work],
+            expenses: [new OtherExpense('living-1', 'Living', 230000, 'Annually', new Date('2020-01-01'))],
+            totalLivingExpenses: 230000,
+            rmdAmount: 0,
+            accounts: [brokerage],
+            withdrawalOrder: [{ accountId: 'brokerage-1' }],
+            taxState: singleTexas(),
+            assumptions: {
+                ...defaultAssumptions,
+                milestones: createBuiltinMilestones(1980, 65, 95), // age 45, still working
+                investments: { ...defaultAssumptions.investments, taxOptimizationEnabled: false },
+                withdrawalStrategy: [],
+            },
+            taxOptimizationEnabled: false,
+            acaAware: false,
+        };
+
+        const plan = solveWorkingYear(input);
+
+        // Sanity: the year ran a deficit funded by a gain-bearing brokerage sale.
+        expect(plan.withdrawals.some(w => w.source === 'brokerage')).toBe(true);
+        expect(plan.tax.capitalGainsLT).toBeGreaterThan(0);
+
+        // Pre-fix: niit was hardcoded to 0.
+        expect(plan.tax.niit).toBeGreaterThan(0);
+    });
+});
+
+// =============================================================================
+// Fix #4 — per-account LTCG rate must stack on already-realized gains
+// =============================================================================
+// Unit test directly on the exported planWithdrawals (the bug washes out of the
+// integration path because YearSolver iterates on total LTCG, but the per-account
+// gross-up rate is wrong within a single pass).
+
+describe('PR #54 fix #4 — LTCG rate stacks on cumulative realized gains', () => {
+    it('taxes a later gain-bearing account at 15% once earlier gains fill the 0% bracket', () => {
+        // Two fully-appreciated brokerage accounts (costBasis 0 → gainRatio ~1).
+        // currentOrdinaryIncome = 0, so the first ~$48k of LTCG is in the 0%
+        // bracket and the remainder is 15%.
+        const broker1 = new InvestedAccount('b1', 'Brokerage 1', 60000, 0, 20, 0.05, 'Brokerage', true, 1.0, 0);
+        const broker2 = new InvestedAccount('b2', 'Brokerage 2', 60000, 0, 20, 0.05, 'Brokerage', true, 1.0, 0);
+
+        const snapshots = [createAccountSnapshot(broker1), createAccountSnapshot(broker2)];
+
+        // $100k net needed: broker1 fully covers ~$60k (taxed at 0%, pushing
+        // cumulative LTCG past the 0% ceiling), broker2 covers the remaining ~$40k.
+        const result = planWithdrawals(
+            100000,
+            snapshots,
+            50, // age — brokerage has no early-withdrawal penalty
+            YEAR,
+            singleTexas(),
+            0, // currentOrdinaryIncome
+            defaultAssumptions,
+            'Spending deficit',
+        );
+
+        const draw1 = result.withdrawals.find(w => w.accountId === 'b1');
+        const draw2 = result.withdrawals.find(w => w.accountId === 'b2');
+        expect(draw1).toBeDefined();
+        expect(draw2).toBeDefined();
+
+        // broker1's gains sit in the 0% bracket → ~no tax (true before and after).
+        expect(draw1!.tax).toBeLessThan(1);
+
+        // broker2's gains stack above broker1's realized LTCG → 15% bracket.
+        // Pre-fix the rate lookup ignored cumulativeLTCG and returned 0% → tax 0.
+        expect(draw2!.tax).toBeGreaterThan(0);
+    });
+});

--- a/src/__tests__/services/simulation/ReviewFixes_PR56.test.ts
+++ b/src/__tests__/services/simulation/ReviewFixes_PR56.test.ts
@@ -22,7 +22,7 @@ import {
     createBuiltinMilestones,
 } from '../../../components/Objects/Assumptions/AssumptionsContext';
 import { TaxState } from '../../../components/Objects/Taxes/TaxContext';
-import { PassiveIncome, WorkIncome, FERSPensionIncome, AnyIncome } from '../../../components/Objects/Income/models';
+import { PassiveIncome, WorkIncome, FERSPensionIncome, FutureSocialSecurityIncome, AnyIncome } from '../../../components/Objects/Income/models';
 import { ESPPAccount, InvestedAccount } from '../../../components/Objects/Accounts/models';
 import { get415cLimit } from '../../../data/ContributionLimits';
 import { calculateFERSSupplement, checkCSRSEligibility } from '../../../data/PensionData';
@@ -402,5 +402,108 @@ describe('PR #56 #6 — CSRS eligibility message matches the capped reductionPer
         expect(result.reductionPercent).toBe(10);
         expect(result.message).toContain(`${result.reductionPercent}%`);
         expect(result.message).not.toContain('20%');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// PR #56 #2 — SS earnings-test reduction must NOT compound year-over-year.
+//
+// For a pre-FRA claimant who keeps earning above the earnings-test limit, the
+// earnings test withholds part of the benefit each year. The reduction must be
+// computed off the FULL benefit (projectedPIA) every year, producing a STABLE
+// payable (full − withheld). The bug computed it off the running, already-reduced
+// `inc.amount` (= calculatedPIA × 12); because the earnings-test rebuild stored
+// `monthlyReduced` back into calculatedPIA and the next year's increment carried
+// that reduced value forward, the reduction re-applied to a smaller base each
+// year and the payable ratcheted DOWN — compounding.
+// ---------------------------------------------------------------------------
+const SS_BIRTH_YEAR = 1960; // FRA = 67
+const SS_CLAIMING_AGE = 62; // claimed before FRA
+const SS_MONTHLY_PIA = 2000; // $24,000/yr full benefit
+
+function createSSAssumptions(): AssumptionsState {
+    return {
+        ...defaultAssumptions,
+        // Disable COLA so the ONLY year-over-year movement in the payable benefit
+        // is whatever the earnings-test logic does — a clean signal for compounding.
+        macro: { ...defaultAssumptions.macro, inflationAdjusted: false, inflationRate: 2.5 },
+        milestones: createBuiltinMilestones(SS_BIRTH_YEAR, 62, 90),
+    };
+}
+
+/** An already-activated pre-FRA SS income: calculatedPIA = projectedPIA = full benefit. */
+function createActivatedSS(): FutureSocialSecurityIncome {
+    const claimingYear = SS_BIRTH_YEAR + SS_CLAIMING_AGE; // 2022
+    return new FutureSocialSecurityIncome(
+        'ss1',
+        'Social Security',
+        SS_CLAIMING_AGE,
+        SS_MONTHLY_PIA,                       // calculatedPIA → amount = PIA*12
+        claimingYear,                         // calculationYear
+        new Date(Date.UTC(claimingYear, 0, 1)),
+        new Date(Date.UTC(SS_BIRTH_YEAR + 90, 11, 31)),
+        undefined,
+        undefined,
+        SS_MONTHLY_PIA,                       // projectedPIA = full, un-reduced benefit
+    );
+}
+
+/** Steady WorkIncome with earnings well above the pre-FRA earnings-test limit. */
+function createSteadyWork(): WorkIncome {
+    // Earnings only MODESTLY above the pre-FRA limit (~$21k in 2023), so the
+    // withholding is a PARTIAL cut. A huge salary would zero the benefit outright
+    // (floored at 0), hiding the year-over-year ratchet we want to expose.
+    return new WorkIncome(
+        'work1', 'Job', 29240, 'Annually', 'Yes',
+        0, 0, 0, 0, '',
+        null, 'FIXED',
+        new Date('2000-01-01'), undefined,
+    );
+}
+
+describe('PR #56 #2 — SS earnings-test reduction does not compound year-over-year', () => {
+    it('keeps the pre-FRA payable benefit stable across two earning years (not ratcheting down)', () => {
+        const assumptions = createSSAssumptions();
+        const logs: string[] = [];
+
+        // Year N: age 63 (pre-FRA, already activated).
+        const yearN = SS_BIRTH_YEAR + 63; // 2023
+        const resultN = projectIncomes(
+            yearN,
+            [createActivatedSS(), createSteadyWork()],
+            [],
+            assumptions,
+            [],
+            63,    // currentAge < FRA(67)
+            false, // still working pre-FRA, not retired (keeps WorkIncome active)
+            logs,
+        );
+        const ssN = resultN.nextIncomes.find(i => i.id === 'ss1') as FutureSocialSecurityIncome;
+        const payableN = ssN.getAnnualAmount(yearN);
+
+        // Year N+1: feed year N's incomes back in, age 64 (still pre-FRA, earning).
+        const yearN1 = yearN + 1; // 2024
+        const resultN1 = projectIncomes(
+            yearN1,
+            resultN.nextIncomes,
+            [],
+            assumptions,
+            [],
+            64,    // currentAge < FRA(67)
+            false, // still working pre-FRA, not retired (keeps WorkIncome active)
+            logs,
+        );
+        const ssN1 = resultN1.nextIncomes.find(i => i.id === 'ss1') as FutureSocialSecurityIncome;
+        const payableN1 = ssN1.getAnnualAmount(yearN1);
+
+        // Sanity: the earnings test actually fired in year N (benefit was reduced
+        // below the full $24k). Otherwise the test proves nothing.
+        expect(payableN).toBeLessThan(SS_MONTHLY_PIA * 12);
+        expect(payableN).toBeGreaterThan(0);
+
+        // The reduction must be STABLE, not compounding: year N+1's payable must
+        // not be materially below year N's. With COLA disabled the two should be
+        // essentially equal; allow a tiny tolerance for limit-table drift.
+        expect(payableN1).toBeGreaterThanOrEqual(payableN - 1);
     });
 });

--- a/src/__tests__/services/simulation/ReviewFixes_PR56.test.ts
+++ b/src/__tests__/services/simulation/ReviewFixes_PR56.test.ts
@@ -22,7 +22,8 @@ import {
 } from '../../../components/Objects/Assumptions/AssumptionsContext';
 import { TaxState } from '../../../components/Objects/Taxes/TaxContext';
 import { PassiveIncome, WorkIncome } from '../../../components/Objects/Income/models';
-import { ESPPAccount } from '../../../components/Objects/Accounts/models';
+import { ESPPAccount, InvestedAccount } from '../../../components/Objects/Accounts/models';
+import { get415cLimit } from '../../../data/ContributionLimits';
 
 // Born 1955 → RMD start age 73. In 2030 this person is 75 (well into RMD age).
 const BIRTH_YEAR = 1955;
@@ -239,5 +240,52 @@ describe('PR #56 #3 — same-year ESPP purchase does not mask a sale in growAcco
         const existingLotAfter = updated.lots.find(l => l.id === 'existing-lot');
         expect(existingLotAfter).toBeDefined();
         expect(existingLotAfter!.shares).toBeCloseTo(50, 4);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// PR #56 #5 — §415(c) cap must also trim employee deferrals when the match
+// can't absorb the excess.
+//
+// When MULTIPLE incomes feed the SAME 401k account, their combined EMPLOYEE
+// deferrals alone can exceed §415(c) with little/no match to trim. The old code
+// only reduced the employer match, leaving the account over-funded.
+// ---------------------------------------------------------------------------
+describe('PR #56 #5 — §415(c) trims employee deferrals when match cannot absorb excess', () => {
+    it('keeps combined additions within the §415(c) limit for two incomes on one 401k', () => {
+        const accountId = '401k-shared';
+        const account = new InvestedAccount('401k-shared', '401k', 0, 0, 0, 0, 'Traditional 401k');
+
+        // Two jobs, each deferring under the §402(g) elective limit on their own,
+        // but together exceeding §415(c). Negligible employer match.
+        const job1 = new WorkIncome(
+            'job1', 'Job One', 200000, 'Annually', 'Yes',
+            40000, 0, 0, 0, accountId,
+            null, 'FIXED', new Date('2020-01-01'), undefined, 0
+        );
+        const job2 = new WorkIncome(
+            'job2', 'Job Two', 200000, 'Annually', 'Yes',
+            35000, 0, 0, 0, accountId,
+            null, 'FIXED', new Date('2020-01-01'), undefined, 0
+        );
+
+        const withdrawalState = createWithdrawalState();
+        const assumptions = createGrowthAssumptions();
+        const logs: string[] = [];
+        const year = 2025;
+        const age = 40;
+
+        processInflows(
+            [job1, job2], [account], assumptions, year, withdrawalState,
+            0, undefined, 0, age, logs
+        );
+
+        const limit = get415cLimit(year, age, assumptions.macro.inflationAdjusted);
+        const totalAdditions =
+            (withdrawalState.userInflows[accountId] || 0) +
+            (withdrawalState.employerInflows[accountId] || 0);
+
+        // Combined $75k of employee deferrals must be clamped to the ~$70k limit.
+        expect(totalAdditions).toBeLessThanOrEqual(limit + 0.001);
     });
 });

--- a/src/__tests__/services/simulation/ReviewFixes_PR56.test.ts
+++ b/src/__tests__/services/simulation/ReviewFixes_PR56.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildDPYearContexts } from '../../../services/simulation/RothConversionDP';
 import { processInflows, growAccounts } from '../../../services/simulation/AccountGrowth';
+import { projectIncomes } from '../../../services/simulation/IncomeProjection';
 import { SimulationYear, WithdrawalState } from '../../../services/simulation/types';
 import {
     AssumptionsState,
@@ -21,9 +22,10 @@ import {
     createBuiltinMilestones,
 } from '../../../components/Objects/Assumptions/AssumptionsContext';
 import { TaxState } from '../../../components/Objects/Taxes/TaxContext';
-import { PassiveIncome, WorkIncome } from '../../../components/Objects/Income/models';
+import { PassiveIncome, WorkIncome, FERSPensionIncome, AnyIncome } from '../../../components/Objects/Income/models';
 import { ESPPAccount, InvestedAccount } from '../../../components/Objects/Accounts/models';
 import { get415cLimit } from '../../../data/ContributionLimits';
+import { calculateFERSSupplement } from '../../../data/PensionData';
 
 // Born 1955 → RMD start age 73. In 2030 this person is 75 (well into RMD age).
 const BIRTH_YEAR = 1955;
@@ -287,5 +289,102 @@ describe('PR #56 #5 — §415(c) trims employee deferrals when match cannot abso
 
         // Combined $75k of employee deferrals must be clamped to the ~$70k limit.
         expect(totalAdditions).toBeLessThanOrEqual(limit + 0.001);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// PR #56 #4 — FERS MRA-to-62 supplement must be auto-computed on activation.
+//
+// When a FERS pension is auto-configured (autoCalculateHigh3 + linkedIncomeId)
+// and the user retires before 62, the activation branch in IncomeProjection
+// constructed the new FERSPensionIncome passing `inc.fersSupplement` verbatim.
+// That value is left at its default 0 for auto pensions, so the bridge
+// supplement was never paid. The model's getSupplement()/calculateSupplement()
+// formula (which would derive it) is dead code in this path. The fix computes
+// the supplement at activation when retiring before 62.
+// ---------------------------------------------------------------------------
+function createFersTestAssumptions(birthYear: number, retirementAge: number): AssumptionsState {
+    return {
+        ...defaultAssumptions,
+        macro: { ...defaultAssumptions.macro, inflationAdjusted: false, inflationRate: 2.6 },
+        milestones: createBuiltinMilestones(birthYear, retirementAge, 90),
+    };
+}
+
+function createFersWorkIncome(id: string, salary: number): WorkIncome {
+    return new WorkIncome(
+        id, 'Fed Job', salary, 'Annually', 'Yes',
+        0, 0, 0, 0, '',
+        null, 'FIXED',
+        new Date('2020-01-01'), undefined,
+        0, 'custom', 'NONE', 0, 15, true, 6, null, 7, 'FERS'
+    );
+}
+
+function createFersSimYear(year: number, incomes: AnyIncome[]): SimulationYear {
+    return {
+        year,
+        incomes,
+        expenses: [],
+        accounts: [],
+        cashflow: {
+            totalIncome: 0, totalExpense: 0, livingExpenses: 0, discretionary: 0,
+            investedUser: 0, investedMatch: 0, totalInvested: 0,
+            bucketAllocations: 0, bucketDetail: {}, withdrawals: 0, withdrawalDetail: {},
+        },
+        taxDetails: {
+            fed: 0, state: 0, fica: 0, preTax: 0, insurance: 0, postTax: 0,
+            capitalGains: 0, withdrawalOrdinaryTax: 0, niit: 0,
+        },
+        logs: [],
+    };
+}
+
+describe('PR #56 #4 — FERS MRA-to-62 supplement is auto-computed on activation', () => {
+    it('computes the supplement for a pre-62 auto FERS pension even when fersSupplement defaults to 0', () => {
+        // Born 1968 → MRA 57. Retiring at 57 with 30 years is a full unreduced
+        // MRA+30 retirement (no early-reduction), so the bridge supplement applies.
+        const birthYear = 1968;
+        const retirementAge = 57;
+        const yearsOfService = 30;
+        const estimatedSSAt62Annual = 24000; // stored as an ANNUAL figure on the model
+
+        const fersPension = new FERSPensionIncome(
+            'fers1', 'FERS Pension', yearsOfService, 0, retirementAge, birthYear,
+            0,                       // calculatedBenefit
+            0,                       // fersSupplement (default — never edited for auto pensions)
+            estimatedSSAt62Annual,   // estimatedSSAt62 (annual)
+            undefined, undefined,
+            true, 'work1'            // autoCalculateHigh3=true, linkedIncomeId='work1'
+        );
+
+        // Salary history so the High-3 / activation branch runs.
+        const previousSimulation: SimulationYear[] = [
+            createFersSimYear(2022, [createFersWorkIncome('work1', 100000)]),
+            createFersSimYear(2023, [createFersWorkIncome('work1', 100000)]),
+            createFersSimYear(2024, [createFersWorkIncome('work1', 100000)]),
+        ];
+
+        const assumptions = createFersTestAssumptions(birthYear, retirementAge);
+        const logs: string[] = [];
+
+        const result = projectIncomes(
+            2025,
+            [fersPension], // linked work income already filtered out at retirement
+            [],
+            assumptions,
+            previousSimulation,
+            retirementAge, // currentAge === retirementAge → activation
+            true,
+            logs
+        );
+
+        const updatedFers = result.nextIncomes.find(inc => inc.id === 'fers1') as FERSPensionIncome;
+
+        // Convention: model stores estimatedSSAt62 as ANNUAL and feeds /12 (monthly)
+        // into calculateFERSSupplement. (30/40) * 2000/mo * 12 = $18,000/yr.
+        const expected = calculateFERSSupplement(yearsOfService, estimatedSSAt62Annual / 12);
+        expect(expected).toBeGreaterThan(0);
+        expect(updatedFers.fersSupplement).toBeCloseTo(expected, 2);
     });
 });

--- a/src/__tests__/services/simulation/ReviewFixes_PR56.test.ts
+++ b/src/__tests__/services/simulation/ReviewFixes_PR56.test.ts
@@ -25,7 +25,7 @@ import { TaxState } from '../../../components/Objects/Taxes/TaxContext';
 import { PassiveIncome, WorkIncome, FERSPensionIncome, AnyIncome } from '../../../components/Objects/Income/models';
 import { ESPPAccount, InvestedAccount } from '../../../components/Objects/Accounts/models';
 import { get415cLimit } from '../../../data/ContributionLimits';
-import { calculateFERSSupplement } from '../../../data/PensionData';
+import { calculateFERSSupplement, checkCSRSEligibility } from '../../../data/PensionData';
 
 // Born 1955 → RMD start age 73. In 2030 this person is 75 (well into RMD age).
 const BIRTH_YEAR = 1955;
@@ -386,5 +386,21 @@ describe('PR #56 #4 — FERS MRA-to-62 supplement is auto-computed on activation
         const expected = calculateFERSSupplement(yearsOfService, estimatedSSAt62Annual / 12);
         expect(expected).toBeGreaterThan(0);
         expect(updatedFers.fersSupplement).toBeCloseTo(expected, 2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// PR #56 #6 — CSRS early-retirement message must use the CAPPED reduction.
+//
+// checkCSRSEligibility caps the benefit cut at 10% (reductionPercent) but
+// interpolated the UNCAPPED reduction into the message. age 45 / 25 yrs returns
+// 10% but the message read "20% reduction". The two must agree.
+// ---------------------------------------------------------------------------
+describe('PR #56 #6 — CSRS eligibility message matches the capped reductionPercent', () => {
+    it('shows the capped 10% in the message, not the uncapped 20%', () => {
+        const result = checkCSRSEligibility(45, 25);
+        expect(result.reductionPercent).toBe(10);
+        expect(result.message).toContain(`${result.reductionPercent}%`);
+        expect(result.message).not.toContain('20%');
     });
 });

--- a/src/__tests__/services/simulation/ReviewFixes_PR56.test.ts
+++ b/src/__tests__/services/simulation/ReviewFixes_PR56.test.ts
@@ -13,14 +13,16 @@
  */
 import { describe, it, expect } from 'vitest';
 import { buildDPYearContexts } from '../../../services/simulation/RothConversionDP';
-import { SimulationYear } from '../../../services/simulation/types';
+import { processInflows, growAccounts } from '../../../services/simulation/AccountGrowth';
+import { SimulationYear, WithdrawalState } from '../../../services/simulation/types';
 import {
     AssumptionsState,
     defaultAssumptions,
     createBuiltinMilestones,
 } from '../../../components/Objects/Assumptions/AssumptionsContext';
 import { TaxState } from '../../../components/Objects/Taxes/TaxContext';
-import { PassiveIncome } from '../../../components/Objects/Income/models';
+import { PassiveIncome, WorkIncome } from '../../../components/Objects/Income/models';
+import { ESPPAccount } from '../../../components/Objects/Accounts/models';
 
 // Born 1955 → RMD start age 73. In 2030 this person is 75 (well into RMD age).
 const BIRTH_YEAR = 1955;
@@ -130,5 +132,112 @@ describe('PR #56 #1 — buildDPYearContexts does not double-subtract RMD', () =>
         // plan-independent ordinary-income base must equal that $40k — NOT 0,
         // which is what the double-subtraction produced (40k − 0 − 60k → floored).
         expect(ctx!.nonSSOrdinaryIncomeExclRMD).toBeCloseTo(PENSION_AMOUNT, 2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Shared helpers for the AccountGrowth (processInflows / growAccounts) tests.
+// ---------------------------------------------------------------------------
+function createWithdrawalState(overrides: Partial<WithdrawalState> = {}): WithdrawalState {
+    return {
+        userInflows: {},
+        employerInflows: {},
+        withdrawalTaxes: 0,
+        capitalGainsTaxTotal: 0,
+        withdrawalOrdinaryTaxTotal: 0,
+        strategyWithdrawalExecuted: 0,
+        totalWithdrawals: 0,
+        withdrawalDetail: {},
+        withdrawalPenalties: 0,
+        totalGrossIncome: 0,
+        traditionalWithdrawals: 0,
+        longTermCapitalGains: 0,
+        shortTermCapitalGains: 0,
+        stateCapitalGainsTax: 0,
+        ...overrides,
+    };
+}
+
+function createGrowthAssumptions(): AssumptionsState {
+    return {
+        ...defaultAssumptions,
+        macro: { ...defaultAssumptions.macro, inflationAdjusted: false },
+        investments: {
+            ...defaultAssumptions.investments,
+            returnRates: { ror: 0 },
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// PR #56 #3 — ESPP purchase must not mask a same-year sale in growAccounts.
+//
+// SimulationEngine records an ESPP SALE as a NEGATIVE userInflows entry, while
+// processInflows previously added a POSITIVE userInflows entry for a same-year
+// PURCHASE. growAccounts reads the NET userInflows as its sale signal, so when
+// purchase >= sale the net was non-negative and the sale was silently dropped —
+// the ESPP balance/shares never decreased.
+// ---------------------------------------------------------------------------
+describe('PR #56 #3 — same-year ESPP purchase does not mask a sale in growAccounts', () => {
+    it('still removes sold shares when a larger purchase happens the same year', () => {
+        const esppId = 'espp1';
+        // Pre-existing ESPP holding: 100 shares @ $100 FMV = $10,000 balance.
+        const existingLot = {
+            id: 'existing-lot',
+            grantDate: new Date(Date.UTC(2020, 0, 1)),
+            purchaseDate: new Date(Date.UTC(2020, 5, 28)),
+            fmvAtGrant: 100,
+            fmvAtPurchase: 100,
+            purchasePrice: 85,
+            shares: 100,
+            totalCost: 8500,
+            discountAmount: 15,
+        };
+        const esppAccount = new ESPPAccount('espp1', 'Company ESPP', 10000, [existingLot]);
+
+        // WorkIncome configured to buy ESPP this year (FIXED $/period contribution).
+        const income = new WorkIncome(
+            'job1', 'Test Job', 100000, 'Annually', 'Yes',
+            0, 0, 0, 0, '',
+            null, 'FIXED',
+            new Date('2020-01-01'), undefined,
+            0,
+            'custom',
+            'FIXED',          // esppContributionType
+            8000,             // esppContributionAmount ($/period -> annual since Annually)
+            15,               // esppDiscountPercent
+            false,            // esppHasLookback
+            6,                // esppOfferingPeriodMonths
+            esppId,           // esppAccountId
+            7,                // esppExpectedStockGrowth
+        );
+
+        const withdrawalState = createWithdrawalState();
+        // Pre-seed a SALE of $5,000 (negative), SMALLER than the purchase about to
+        // be recorded — this is what SimulationEngine writes for an ESPP withdrawal.
+        withdrawalState.userInflows[esppId] = -5000;
+
+        const assumptions = createGrowthAssumptions();
+        const logs: string[] = [];
+
+        // Drive the REAL purchase path: this adds a POSITIVE purchase to userInflows.
+        const inflowResult = processInflows(
+            [income], [esppAccount], assumptions, 2025, withdrawalState,
+            0, undefined, 0, 40, logs
+        );
+
+        const result = growAccounts(
+            [esppAccount], [], withdrawalState,
+            {}, inflowResult.esppLots, 0, undefined,
+            assumptions, 2025, 0, logs
+        );
+
+        const updated = result.find(a => a.id === esppId) as ESPPAccount;
+
+        // The pre-existing lot started with 100 shares. A $5,000 sale at $100/share
+        // FMV must remove 50 shares from it, regardless of the same-year purchase.
+        const existingLotAfter = updated.lots.find(l => l.id === 'existing-lot');
+        expect(existingLotAfter).toBeDefined();
+        expect(existingLotAfter!.shares).toBeCloseTo(50, 4);
     });
 });

--- a/src/__tests__/services/simulation/ReviewFixes_PR56.test.ts
+++ b/src/__tests__/services/simulation/ReviewFixes_PR56.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Review-fix regression tests for PR #56.
+ *
+ * Scope 3, finding #1: buildDPYearContexts double-subtracted the baseline RMD
+ * amount from the plan-independent ordinary-income base. The stored
+ * `SimulationYear.incomes` already EXCLUDES RMD-sourced PassiveIncome (the
+ * engine filters it out of `returnedIncomes`), so `getGrossIncome(incomes)` is
+ * already RMD-free. Subtracting `rmdDetails.totalRMD` on top of that removed RMD
+ * a second time, wrongly zeroing out pension/wage/passive ordinary income in
+ * post-RMD years whenever the RMD exceeded that ordinary income.
+ *
+ * The fix: nonSSOrdinaryIncomeExclRMD = max(0, grossIncome − ssBenefits).
+ */
+import { describe, it, expect } from 'vitest';
+import { buildDPYearContexts } from '../../../services/simulation/RothConversionDP';
+import { SimulationYear } from '../../../services/simulation/types';
+import {
+    AssumptionsState,
+    defaultAssumptions,
+    createBuiltinMilestones,
+} from '../../../components/Objects/Assumptions/AssumptionsContext';
+import { TaxState } from '../../../components/Objects/Taxes/TaxContext';
+import { PassiveIncome } from '../../../components/Objects/Income/models';
+
+// Born 1955 → RMD start age 73. In 2030 this person is 75 (well into RMD age).
+const BIRTH_YEAR = 1955;
+const RETIREMENT_YEAR = 2030;
+const PENSION_AMOUNT = 40_000; // non-SS ordinary income (a pension, NOT RMD)
+const RMD_AMOUNT = 60_000;     // RMD > pension, so the buggy subtraction floors to 0
+
+function createAssumptions(): AssumptionsState {
+    return {
+        ...defaultAssumptions,
+        // Born 1955, retire at 65 (2020), end at 95.
+        milestones: createBuiltinMilestones(BIRTH_YEAR, 65, 95),
+        investments: {
+            ...defaultAssumptions.investments,
+            returnRates: { ror: 7 },
+        },
+    };
+}
+
+function createTaxState(): TaxState {
+    return {
+        filingStatus: 'Married Filing Jointly',
+        stateResidency: 'Texas',
+        deductionMethod: 'Standard',
+        fedOverride: null,
+        ficaOverride: null,
+        stateOverride: null,
+        year: RETIREMENT_YEAR,
+    };
+}
+
+/**
+ * Minimal baseline year mirroring reality: the stored `incomes` array contains
+ * the user's $40k pension (a non-RMD PassiveIncome) but NOT the RMD income —
+ * the engine strips RMD-sourced PassiveIncome from the returned year. The RMD
+ * lives only in `rmdDetails.totalRMD`.
+ */
+function createPostRMDBaselineYear(): SimulationYear {
+    // Pension: $40k/yr, started long ago so it's fully active in every test year.
+    const pension = new PassiveIncome(
+        'pension-1',
+        'Pension',
+        PENSION_AMOUNT,
+        'Annually',
+        'No',
+        'Other',
+        new Date('2000-01-01'),
+    );
+
+    return {
+        year: RETIREMENT_YEAR,
+        incomes: [pension], // NOTE: deliberately excludes RMD income (mirrors engine)
+        expenses: [],
+        accounts: [],
+        cashflow: {
+            totalIncome: PENSION_AMOUNT,
+            totalExpense: 0,
+            livingExpenses: 0,
+            discretionary: 0,
+            investedUser: 0,
+            investedMatch: 0,
+            totalInvested: 0,
+            bucketAllocations: 0,
+            bucketDetail: {},
+            withdrawals: 0,
+            withdrawalDetail: {},
+        },
+        taxDetails: {
+            fed: 0,
+            state: 0,
+            fica: 0,
+            preTax: 0,
+            insurance: 0,
+            postTax: 0,
+            capitalGains: 0,
+            withdrawalOrdinaryTax: 0,
+            niit: 0,
+            longTermCapitalGains: 0,
+        },
+        logs: [],
+        rmdDetails: {
+            totalRMD: RMD_AMOUNT,
+            totalWithdrawn: RMD_AMOUNT,
+            accountBreakdown: [],
+            shortfall: 0,
+            penalty: 0,
+        },
+    };
+}
+
+describe('PR #56 #1 — buildDPYearContexts does not double-subtract RMD', () => {
+    it('uses the real non-SS ordinary income (pension) as the base, not 0', () => {
+        const baseline = [createPostRMDBaselineYear()];
+
+        const contexts = buildDPYearContexts(
+            baseline,
+            createAssumptions(),
+            createTaxState(),
+            RETIREMENT_YEAR,
+            0, // startingBrokerageBalance
+        );
+
+        const ctx = contexts.find(c => c.year === RETIREMENT_YEAR);
+        expect(ctx).toBeDefined();
+
+        // The stored incomes hold only the $40k pension (RMD is excluded), so the
+        // plan-independent ordinary-income base must equal that $40k — NOT 0,
+        // which is what the double-subtraction produced (40k − 0 − 60k → floored).
+        expect(ctx!.nonSSOrdinaryIncomeExclRMD).toBeCloseTo(PENSION_AMOUNT, 2);
+    });
+});

--- a/src/__tests__/services/simulation/WithdrawalService.test.ts
+++ b/src/__tests__/services/simulation/WithdrawalService.test.ts
@@ -108,16 +108,6 @@ describe('processDeficitDebt', () => {
             expect(result.existingDeficitDebt).toBeInstanceOf(DeficitDebtAccount);
         });
 
-        it('should return deficitDebtPayment', () => {
-            const accounts: AnyAccount[] = [];
-            const logs: string[] = [];
-
-            const result = processDeficitDebt(-1000, accounts, logs);
-
-            expect(result.deficitDebtPayment).toBeDefined();
-            expect(typeof result.deficitDebtPayment).toBe('number');
-        });
-
         it('should set discretionaryCash to 0 after debt creation', () => {
             const accounts: AnyAccount[] = [];
             const logs: string[] = [];

--- a/src/components/Objects/Accounts/AccountContext.tsx
+++ b/src/components/Objects/Accounts/AccountContext.tsx
@@ -193,6 +193,7 @@ export function AccountProvider({ children }: { children: ReactNode }): React.Re
     a.href = url;
     a.download = `stag_backup_${new Date().toISOString().split('T')[0]}.json`;
     a.click();
+    URL.revokeObjectURL(url);
   }, []);
 
   const importData = useCallback((json: string) => {

--- a/src/components/Objects/Accounts/QRTransfer/qrUtils.ts
+++ b/src/components/Objects/Accounts/QRTransfer/qrUtils.ts
@@ -33,7 +33,7 @@ const KEY_MAP: Record<string, string> = {
     // Passive income
     sourceType: 'O', isReinvested: 'R', end_date: 'Z',
     // Social security
-    claimingAge: 'C', calculatedPIA: 'P', calculationYear: 'W', projectedPIA: 'pp',
+    claimingAge: 'C', calculatedPIA: 'P', calculationYear: 'W', projectedPIA: 'Pi',
     // Expenses
     payment: 'J', utilities: 'U', interest_type: 'T', is_tax_deductible: 'B', tax_deductible: 'Q',
     // Tax
@@ -47,8 +47,15 @@ const KEY_MAP: Record<string, string> = {
     gkUpperGuardrail: 'gu', gkLowerGuardrail: 'gl', gkAdjustmentPercent: 'ga', autoRothConversions: 'ar',
     retirementAge: 'ra', lifeExpectancy: 'le', birthYear: 'by', priorYearMode: 'pm',
     useCompactCurrency: 'cc', showExperimentalFeatures: 'ef', hsaEligible: 'he',
+    // Assumptions - Roth conversion / tax optimization flags
+    rothConversionStrategy: 'rs', rothConversionMinRateGap: 'rg', rothConversionDPBackloadDelta: 'rd',
+    taxOptimizationEnabled: 'to', acaAware: 'aa',
+    // Assumptions - top-level arrays (priorEarnings, milestones, and the Burn-Order
+    // withdrawal-strategy array which is flattened under the synthetic `burnOrder` key
+    // so it does not collide with the investments `withdrawalStrategy` string)
+    priorEarnings: 'pe', milestones: 'ms', burnOrder: 'bo',
     // Priorities/Withdrawal
-    type: 't', accountId: 'ai', capType: 'ct', capValue: 'cv',
+    type: 't', accountId: 'ai', capType: 'ct', capValue: 'cv', maxAmount: 'mx',
 };
 
 // Create reverse mapping
@@ -119,6 +126,11 @@ const ASSUMPTIONS_DEFAULTS: Record<string, unknown> = {
     gkLowerGuardrail: 0.8,
     gkAdjustmentPercent: 10,
     autoRothConversions: false,
+    rothConversionStrategy: 'rate-match',
+    rothConversionMinRateGap: 0.05,
+    rothConversionDPBackloadDelta: 0.015,
+    taxOptimizationEnabled: false,
+    acaAware: true,
     // Demographics
     retirementAge: 65,
     lifeExpectancy: 90,
@@ -198,13 +210,24 @@ export function expandKeys(obj: unknown): unknown {
 
 /**
  * Strips default values and null from an object.
+ *
+ * A field is dropped when it is null, or when it matches its type default.
+ * Default *arrays* (e.g. `conversionHistory: []`, `lots: []`) are compared
+ * structurally rather than by reference, so an empty default array is stripped
+ * (and re-added by restoreDefaults) instead of bloating the payload.
  */
 export function stripDefaults(obj: Record<string, unknown>, type: string): Record<string, unknown> {
     const typeDefaults = DEFAULTS[type] || {};
+    const matchesDefault = (key: string, value: unknown): boolean => {
+        if (!(key in typeDefaults)) return false;
+        const def = typeDefaults[key];
+        if (value === def) return true;
+        // [] !== [] by reference — treat an empty array as equal to an empty default array.
+        if (Array.isArray(value) && Array.isArray(def) && value.length === 0 && def.length === 0) return true;
+        return false;
+    };
     return Object.fromEntries(
-        Object.entries(obj).filter(([key, value]) =>
-            value !== null && !(key in typeDefaults && typeDefaults[key] === value)
-        )
+        Object.entries(obj).filter(([key, value]) => value !== null && !matchesDefault(key, value))
     );
 }
 
@@ -223,18 +246,26 @@ export function flattenAssumptions(assumptions: Record<string, unknown>): Record
     const flat: Record<string, unknown> = {};
 
     for (const [category, values] of Object.entries(assumptions)) {
-        if (category === 'priorities' || category === 'withdrawalOrder') {
-            // Keep arrays as-is
+        if (category === 'priorities' || category === 'milestones') {
+            // Top-level arrays kept as-is under their own key
             if (Array.isArray(values) && values.length > 0) {
                 flat[category] = values;
             }
+        } else if (category === 'withdrawalStrategy') {
+            // Top-level Burn-Order array. Flattened under the synthetic `burnOrder`
+            // key so it does NOT collide with the investments `withdrawalStrategy`
+            // STRING that is flattened out of the investments object below.
+            if (Array.isArray(values) && values.length > 0) {
+                flat['burnOrder'] = values;
+            }
         } else if (typeof values === 'object' && values !== null) {
-            // Flatten nested object (macro, income, etc.)
+            // Flatten nested object (macro, income, investments, demographics, ...)
             for (const [key, value] of Object.entries(values as Record<string, unknown>)) {
                 // Handle nested returnRates.ror
                 if (key === 'returnRates' && typeof value === 'object' && value !== null) {
                     flat['ror'] = (value as Record<string, unknown>).ror;
                 } else {
+                    // Includes demographics.priorEarnings and the investments flags
                     flat[key] = value;
                 }
             }
@@ -248,6 +279,18 @@ export function flattenAssumptions(assumptions: Record<string, unknown>): Record
  * Expands a flattened assumptions object back to nested structure.
  */
 export function expandAssumptions(flat: Record<string, unknown>): Record<string, unknown> {
+    const demographics: Record<string, unknown> = {
+        birthYear: flat.birthYear, // No default - must be provided (legacy flat field)
+        retirementAge: flat.retirementAge ?? ASSUMPTIONS_DEFAULTS.retirementAge,
+        lifeExpectancy: flat.lifeExpectancy ?? ASSUMPTIONS_DEFAULTS.lifeExpectancy,
+        priorYearMode: flat.priorYearMode ?? ASSUMPTIONS_DEFAULTS.priorYearMode,
+    };
+    // priorEarnings (SSA earnings history) is optional - only restore when present
+    // so we don't fabricate an empty array that would break deep-equal round-trips.
+    if (flat.priorEarnings !== undefined) {
+        demographics.priorEarnings = flat.priorEarnings;
+    }
+
     return {
         macro: {
             inflationRate: flat.inflationRate ?? ASSUMPTIONS_DEFAULTS.inflationRate,
@@ -266,26 +309,30 @@ export function expandAssumptions(flat: Record<string, unknown>): Record<string,
         },
         investments: {
             returnRates: { ror: flat.ror ?? ASSUMPTIONS_DEFAULTS.ror },
+            // This is the investments STRING (Fixed Real / Guardrails / ...), distinct
+            // from the top-level `withdrawalStrategy` Burn-Order array restored below.
             withdrawalStrategy: flat.withdrawalStrategy ?? ASSUMPTIONS_DEFAULTS.withdrawalStrategy,
             withdrawalRate: flat.withdrawalRate ?? ASSUMPTIONS_DEFAULTS.withdrawalRate,
             gkUpperGuardrail: flat.gkUpperGuardrail ?? ASSUMPTIONS_DEFAULTS.gkUpperGuardrail,
             gkLowerGuardrail: flat.gkLowerGuardrail ?? ASSUMPTIONS_DEFAULTS.gkLowerGuardrail,
             gkAdjustmentPercent: flat.gkAdjustmentPercent ?? ASSUMPTIONS_DEFAULTS.gkAdjustmentPercent,
             autoRothConversions: flat.autoRothConversions ?? ASSUMPTIONS_DEFAULTS.autoRothConversions,
+            rothConversionStrategy: flat.rothConversionStrategy ?? ASSUMPTIONS_DEFAULTS.rothConversionStrategy,
+            rothConversionMinRateGap: flat.rothConversionMinRateGap ?? ASSUMPTIONS_DEFAULTS.rothConversionMinRateGap,
+            rothConversionDPBackloadDelta: flat.rothConversionDPBackloadDelta ?? ASSUMPTIONS_DEFAULTS.rothConversionDPBackloadDelta,
+            taxOptimizationEnabled: flat.taxOptimizationEnabled ?? ASSUMPTIONS_DEFAULTS.taxOptimizationEnabled,
+            acaAware: flat.acaAware ?? ASSUMPTIONS_DEFAULTS.acaAware,
         },
-        demographics: {
-            birthYear: flat.birthYear, // No default - must be provided
-            retirementAge: flat.retirementAge ?? ASSUMPTIONS_DEFAULTS.retirementAge,
-            lifeExpectancy: flat.lifeExpectancy ?? ASSUMPTIONS_DEFAULTS.lifeExpectancy,
-            priorYearMode: flat.priorYearMode ?? ASSUMPTIONS_DEFAULTS.priorYearMode,
-        },
+        demographics,
         display: {
             useCompactCurrency: flat.useCompactCurrency ?? ASSUMPTIONS_DEFAULTS.useCompactCurrency,
             showExperimentalFeatures: flat.showExperimentalFeatures ?? ASSUMPTIONS_DEFAULTS.showExperimentalFeatures,
             hsaEligible: flat.hsaEligible ?? ASSUMPTIONS_DEFAULTS.hsaEligible,
         },
         priorities: flat.priorities ?? [],
-        withdrawalOrder: flat.withdrawalOrder ?? [],
+        // Top-level Burn-Order array was flattened under the synthetic `burnOrder` key.
+        withdrawalStrategy: flat.burnOrder ?? [],
+        milestones: flat.milestones ?? [],
     };
 }
 
@@ -495,7 +542,15 @@ export function isCompactFormat(data: unknown): data is CompactBackup {
 export function compressData(data: object): string {
     const jsonString = JSON.stringify(data);
     const compressed = pako.deflate(jsonString);
-    return btoa(String.fromCharCode(...compressed));
+    // Build the binary string in chunks: String.fromCharCode(...bytes) spreads the
+    // whole array as arguments and throws RangeError (call-stack overflow) for large
+    // payloads. Chunking keeps each spread well under the argument limit.
+    let binary = '';
+    const CHUNK = 0x8000; // 32 KB
+    for (let i = 0; i < compressed.length; i += CHUNK) {
+        binary += String.fromCharCode(...compressed.subarray(i, i + CHUNK));
+    }
+    return btoa(binary);
 }
 
 /**

--- a/src/components/Objects/Accounts/models.tsx
+++ b/src/components/Objects/Accounts/models.tsx
@@ -836,9 +836,10 @@ export class PropertyAccount extends BaseAccount {
       this.name,
       nextValue,
       this.ownershipType,
-      nextLoan, 
+      nextLoan,
       this.startingLoanBalance,
-      this.linkedAccountId
+      this.linkedAccountId,
+      this.apr
     );
   }
 }
@@ -960,7 +961,7 @@ export function reconstituteAccount(data: unknown): AnyAccount | null {
                 (data.isContributionEligible as boolean) ?? true,
                 Number(data.vestedPerYear ?? 0.2),
                 costBasis,
-                data.customROR !== undefined ? Number(data.customROR) : undefined,
+                data.customROR != null ? Number(data.customROR) : undefined,
                 conversionHistory
             );
         }
@@ -981,7 +982,7 @@ export function reconstituteAccount(data: unknown): AnyAccount | null {
             return new ESPPAccount(
                 id, name, amount, lots,
                 data.linkedIncomeId ? String(data.linkedIncomeId) : null,
-                data.customROR !== undefined ? Number(data.customROR) : undefined,
+                data.customROR != null ? Number(data.customROR) : undefined,
                 data.stockTicker ? String(data.stockTicker) : undefined,
                 data.currentSharePrice !== undefined ? Number(data.currentSharePrice) : undefined,
                 (data.withdrawalPreference as ESPPWithdrawalPreference) ?? 'fifo',
@@ -995,7 +996,8 @@ export function reconstituteAccount(data: unknown): AnyAccount | null {
                 (data.ownershipType as 'Financed' | 'Owned') ?? 'Owned',
                 Number(data.loanAmount) || 0,
                 Number(data.startingLoanBalance) || 0,
-                String(data.linkedAccountId ?? '')
+                String(data.linkedAccountId ?? ''),
+                Number(data.apr) || 0
             );
 
         case 'DebtAccount':

--- a/src/components/Objects/Accounts/useFileManager.ts
+++ b/src/components/Objects/Accounts/useFileManager.ts
@@ -3,14 +3,14 @@ import { AccountContext, AccountDispatchContext } from './AccountContext';
 import { IncomeContext, IncomeDispatchContext } from '../Income/IncomeContext';
 import { ExpenseContext, ExpenseDispatchContext } from '../Expense/ExpenseContext';
 import { TaxContext } from '../../Objects/Taxes/TaxContext';
-import { AssumptionsContext, AssumptionsState, defaultAssumptions } from '../Assumptions/AssumptionsContext';
+import { AssumptionsContext, AssumptionsState, defaultAssumptions, migrateAssumptions } from '../Assumptions/AssumptionsContext';
 import { AnyAccount, reconstituteAccount } from './models';
 import { AmountHistoryEntry } from './AccountContext';
 import { AnyIncome, reconstituteIncome } from '../Income/models';
 import { AnyExpense, reconstituteExpense } from '../Expense/models';
 import { TaxState, defaultTaxState } from '../../Objects/Taxes/TaxContext';
 import { ImportKeyContext } from './ImportKeyContext';
-import { BudgetContext, BudgetState } from '../Budget/BudgetContext';
+import { BudgetContext, BudgetState, reconstituteBudgetState } from '../Budget/BudgetContext';
 import { loadAccountMap, saveAccountMap } from '../../../services/simplefinBalances';
 
 export interface FullBackup {
@@ -88,31 +88,23 @@ export const useFileManager = () => {
             };
             taxesDispatch({ type: 'SET_BULK_DATA', payload: mergedTaxSettings });
             if (data.assumptions) { // Check if assumptions exist in the backup data
-                const mergedAssumptions = {
-                    ...defaultAssumptions,
-                    ...data.assumptions,
-                    macro: { ...defaultAssumptions.macro, ...(data.assumptions.macro || {}) },
-                    income: { ...defaultAssumptions.income, ...(data.assumptions.income || {}) },
-                    expenses: { ...defaultAssumptions.expenses, ...(data.assumptions.expenses || {}) },
-                    investments: {
-                        ...defaultAssumptions.investments,
-                        ...(data.assumptions.investments || {}),
-                        returnRates: {
-                            ...defaultAssumptions.investments.returnRates,
-                            ...((data.assumptions.investments && data.assumptions.investments.returnRates) || {}),
-                        },
-                    },
-                    demographics: { ...defaultAssumptions.demographics, ...(data.assumptions.demographics || {}) },
-                    priorities: data.assumptions.priorities || defaultAssumptions.priorities
-                };
+                // Route through migrateAssumptions so OLD backups (legacy
+                // demographics.birthYear/retirementAge/lifeExpectancy with no
+                // milestones array) get their built-in milestones synthesized, and
+                // every section (including display + arrays) is deep-merged with
+                // defaults — matching the on-load localStorage migration.
+                const mergedAssumptions = migrateAssumptions(data.assumptions, defaultAssumptions);
                 assumptionsDispatch({ type: 'SET_BULK_DATA', payload: mergedAssumptions });
             }
             else {
                 assumptionsDispatch({ type: 'RESET_DEFAULTS'});
             }
-            // Import budget data if present
+            // Import budget data if present. Reconstitute Date fields (transactions'
+            // date/statementDate, months' createdAt/updatedAt) since JSON.parse leaves
+            // them as ISO strings — bypassing hydrateBudgetState would otherwise store
+            // strings under Date-typed fields.
             if (data.budget) {
-                budgetDispatch({ type: 'SET_BULK_DATA', payload: data.budget });
+                budgetDispatch({ type: 'SET_BULK_DATA', payload: reconstituteBudgetState(data.budget) });
             }
             // Restore the SimpleFIN account mapping if present (v2+ backups)
             if (data.balanceAccountMap) {

--- a/src/components/Objects/Assumptions/AssumptionsContext.tsx
+++ b/src/components/Objects/Assumptions/AssumptionsContext.tsx
@@ -205,7 +205,7 @@ export const defaultAssumptions: AssumptionsState = {
  * Deep merge saved data with defaults, ensuring all fields exist.
  * This handles cases where old localStorage data is missing newer fields.
  */
-function migrateAssumptions(saved: unknown, defaults: AssumptionsState): AssumptionsState {
+export function migrateAssumptions(saved: unknown, defaults: AssumptionsState): AssumptionsState {
   // If saved is not an object, return defaults
   if (!saved || typeof saved !== 'object' || Array.isArray(saved)) {
     return defaults;
@@ -265,7 +265,13 @@ function migrateAssumptions(saved: unknown, defaults: AssumptionsState): Assumpt
     // Arrays: use saved if it's a valid array, otherwise use default
     priorities: Array.isArray(data.priorities) ? data.priorities as PriorityBucket[] : defaults.priorities,
     withdrawalStrategy: Array.isArray(data.withdrawalStrategy) ? data.withdrawalStrategy as WithdrawalBucket[] : defaults.withdrawalStrategy,
-    milestones: Array.isArray(data.milestones) ? data.milestones as CustomMilestone[] : defaults.milestones,
+    // When saved data has no milestones array, start EMPTY (not defaults.milestones)
+    // so the built-in-milestone synthesis below actually fires and can seed Birth/
+    // Retire/End-of-Plan from any legacy demographics.{birthYear,retirementAge,
+    // lifeExpectancy}. If we copied defaults.milestones here, those built-ins would
+    // already exist at default values (1990/65/90) and the legacy values would be
+    // silently dropped (Findings #8/#12).
+    milestones: Array.isArray(data.milestones) ? data.milestones as CustomMilestone[] : [],
   };
 
   // Migration: Get legacy values from old demographics if present

--- a/src/components/Objects/Assumptions/SimulationEngine.tsx
+++ b/src/components/Objects/Assumptions/SimulationEngine.tsx
@@ -271,12 +271,21 @@ function simulateOneYearWithNewEngine(
     // to priority ordering and surplus availability. Net worth is unchanged by
     // saving (cash out, fund up); it dips when the lump is spent in the due year.
     const goalFundCredits = new Map<string, number>(); // fund accountId → annual set-aside
-    for (const e of expenses) {
-        if (!isLongTermGoal(e) || !e.goalAccountId) continue;
+    // Collect the unique fund accountIds from milestone-active goals only, so a
+    // goal gated by an inactive start/end milestone is NOT funded (consistent
+    // with how its set-aside is excluded from living expenses).
+    const activeGoalFundIds = new Set<string>();
+    for (const e of milestoneFilteredExpenses) {
+        if (isLongTermGoal(e) && e.goalAccountId) activeGoalFundIds.add(e.goalAccountId);
+    }
+    for (const fundId of activeGoalFundIds) {
         // Months-prorated: a goal starting in June commits 7 months this year,
         // and the target year commits only the months before the target.
-        const annual = getGoalFundAnnualSetAside(expenses, e.goalAccountId, year) ?? 0;
-        if (annual > 0) goalFundCredits.set(e.goalAccountId, (goalFundCredits.get(e.goalAccountId) ?? 0) + annual);
+        // getGoalFundAnnualSetAside already SUMS the set-aside across every goal
+        // on this account, so assign once — never += (that would double-count
+        // when two goals share a fund account).
+        const annual = getGoalFundAnnualSetAside(milestoneFilteredExpenses, fundId, year) ?? 0;
+        if (annual > 0) goalFundCredits.set(fundId, annual);
     }
     const totalGoalFunding = [...goalFundCredits.values()].reduce((s, v) => s + v, 0);
 
@@ -541,11 +550,11 @@ function simulateOneYearWithNewEngine(
     // account. Net worth dips by what's available in the fund; recurring goals
     // keep accruing toward the next cycle afterward.
     // ------------------------------------------------------------------
-    for (const exp of expenses) {
+    for (const exp of milestoneFilteredExpenses) {
         if (!isLongTermGoal(exp) || !exp.goalAccountId || !isGoalDueInYear(exp, year)) continue;
         // A recurring goal can carry an end date (when to stop replacing it);
         // don't fire the lump after it.
-        if (exp.endDate && new Date(exp.endDate).getUTCFullYear() < year) continue;
+        if (exp.endDate && new Date(exp.endDate).getFullYear() < year) continue;
         const fund = nextAccounts.find(a => a.id === exp.goalAccountId);
         if (!fund) continue;
         const spent = Math.min(fund.amount, exp.amount);

--- a/src/components/Objects/Assumptions/SimulationEngine.tsx
+++ b/src/components/Objects/Assumptions/SimulationEngine.tsx
@@ -613,7 +613,7 @@ function simulateOneYearWithNewEngine(
     // change. Auth LTCG in that case is captured by `unfundedDeficit` instead.
     const brokerageLTCGFromGross = yearPlan.withdrawals
         .filter(w => w.capitalGains !== undefined)
-        .reduce((sum, w) => sum + w.tax, 0);
+        .reduce((sum, w) => sum + (w.tax - (w.ordinaryTax ?? 0)), 0);
     const totalCashAvailable =
         spendableIncome
         + withdrawalState.totalWithdrawals

--- a/src/components/Objects/Budget/BudgetContext.tsx
+++ b/src/components/Objects/Budget/BudgetContext.tsx
@@ -26,8 +26,14 @@ import type {
     BudgetState,
 } from './BudgetTypes';
 
-function generateId(prefix: string): string {
-    return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+// Monotonic counter so several ids minted in the same synchronous tick never
+// collide (Date.now() has ms resolution; multiple months can be created in one tick).
+let idCounter = 0;
+export function generateId(prefix: string): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return `${prefix}-${crypto.randomUUID()}`;
+    }
+    return `${prefix}-${Date.now()}-${idCounter++}-${Math.floor(Math.random() * 1000)}`;
 }
 
 const now = new Date();
@@ -196,7 +202,7 @@ function budgetReducer(state: BudgetState, action: BudgetAction): BudgetState {
 
             // If target month doesn't exist, we need to create it
             if (!targetMonth) {
-                const newMonthId = `MONTH-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+                const newMonthId = generateId('MONTH');
                 targetMonth = {
                     id: newMonthId,
                     month: toMonth,
@@ -430,11 +436,15 @@ export const BudgetContext = createContext<BudgetContextProps>({
     getCurrentMonth: () => undefined,
 });
 
-function hydrateBudgetState(parsed: unknown, initial: BudgetState): BudgetState {
-    const data = parsed as Record<string, unknown>;
-    if (!data) return initial;
-
-    const months = ((data.months as unknown[]) || []).map((m: unknown) => {
+/**
+ * Reconstitute the date fields of a parsed budget payload's months. JSON
+ * serializes Date as ISO strings; this converts transactions' date/statementDate
+ * and each month's createdAt/updatedAt back into Date instances. Used by both
+ * localStorage hydration and the global backup-import path (useFileManager) so
+ * imported budgets get the same Date typing as persisted ones.
+ */
+export function reconstituteBudgetMonths(rawMonths: unknown): MonthlySnapshot[] {
+    return ((rawMonths as unknown[]) || []).map((m: unknown) => {
         const month = m as Record<string, unknown>;
         const transactions = ((month.transactions as unknown[]) || []).map((t: unknown) => {
             const trans = t as Record<string, unknown>;
@@ -451,6 +461,47 @@ function hydrateBudgetState(parsed: unknown, initial: BudgetState): BudgetState 
             transactions,
         } as MonthlySnapshot;
     });
+}
+
+/**
+ * Reconstitute a parsed budget payload (Date strings -> Date) for import via
+ * SET_BULK_DATA. Returns a Partial<BudgetState> with months' dates rehydrated.
+ * Mirrors the month/importSettings date handling in hydrateBudgetState without
+ * the localStorage-specific selectedMonth/selectedYear defaulting.
+ */
+export function reconstituteBudgetState(parsed: unknown): Partial<BudgetState> {
+    const data = (parsed as Record<string, unknown>) || {};
+    const months = reconstituteBudgetMonths(data.months);
+
+    const importSettingsData = (data.importSettings as Record<string, unknown>) || undefined;
+    if (!importSettingsData) {
+        return { ...data, months };
+    }
+
+    const savedCSVFormats = ((importSettingsData.savedCSVFormats as unknown[]) || []).map((f: unknown) => {
+        const format = f as Record<string, unknown>;
+        return {
+            ...format,
+            lastUsed: format.lastUsed ? new Date(format.lastUsed as string) : new Date(),
+            createdAt: format.createdAt ? new Date(format.createdAt as string) : new Date(),
+        } as SavedCSVMapping;
+    });
+
+    return {
+        ...data,
+        months,
+        importSettings: {
+            ...(importSettingsData as unknown as BudgetState['importSettings']),
+            savedCSVFormats,
+        },
+    };
+}
+
+function hydrateBudgetState(parsed: unknown, initial: BudgetState): BudgetState {
+    const data = parsed as Record<string, unknown>;
+    if (!data) return initial;
+
+    const months = reconstituteBudgetMonths(data.months);
 
     const importSettingsData = (data.importSettings as Record<string, unknown>) || {};
     const savedCSVFormats = ((importSettingsData.savedCSVFormats as unknown[]) || []).map((f: unknown) => {

--- a/src/components/Objects/Expense/models.tsx
+++ b/src/components/Objects/Expense/models.tsx
@@ -355,8 +355,9 @@ export class MortgageExpense extends BaseExpense {
 
 
   calculateAnnualAmortization(year: number): { totalInterest: number, totalPrincipal: number, totalPayment: number } {
-    const purchaseYear = this.startDate != null ? this.startDate.getUTCFullYear() : new Date().getFullYear();
-    const purchaseMonth = this.startDate != null ? this.startDate.getUTCMonth() : new Date().getMonth();
+    // startDate is a local-midnight date-only value; use local accessors.
+    const purchaseYear = this.startDate != null ? this.startDate.getFullYear() : new Date().getFullYear();
+    const purchaseMonth = this.startDate != null ? this.startDate.getMonth() : new Date().getMonth();
 
     if (year < purchaseYear) {
       return { totalInterest: 0, totalPrincipal: 0, totalPayment: 0 };
@@ -438,7 +439,10 @@ export class MortgageExpense extends BaseExpense {
     const principal_payment = fixed_amortization - interest_payment;
 
     const property_tax_payment = (this.valuation - this.valuation_deduction) * this.property_taxes / 100 / 12;
-    const pmi_payment = this.valuation * this.pmi / 100 / 12;
+    // PMI applies only while loan-to-value is ABOVE 80% (low equity), matching the
+    // LTV gate in the constructor and increment(). Without the gate, calculatePayment
+    // overstates the payment for mortgages with >20% equity.
+    const pmi_payment = (this.loan_balance / this.valuation) > 0.8 ? this.valuation * this.pmi / 100 / 12 : 0;
     const repair_payment = this.maintenance / 100 / 12 * this.valuation;
     const home_owners_insurance_payment = this.home_owners_insurance / 100 / 12 * this.valuation;
 
@@ -484,10 +488,10 @@ export class MortgageExpense extends BaseExpense {
     // If target is before purchase, the loan didn't exist yet (return 0)
     if (targetDate < start) return 0;
 
-    // Calculate months elapsed
+    // Calculate months elapsed — both dates are local-midnight, use local accessors.
     const monthsElapsed =
-      (targetDate.getUTCFullYear() - start.getUTCFullYear()) * 12 +
-      (targetDate.getUTCMonth() - start.getUTCMonth());
+      (targetDate.getFullYear() - start.getFullYear()) * 12 +
+      (targetDate.getMonth() - start.getMonth());
 
     if (monthsElapsed <= 0) return this.starting_loan_balance;
 
@@ -592,12 +596,13 @@ export class LoanExpense extends BaseExpense {
   }
 
   calculateAnnualAmortization(year: number): { totalInterest: number, totalPrincipal: number, totalPayment: number } {
-    const loanStartYear = this.startDate ? this.startDate.getUTCFullYear() : new Date().getFullYear();
+    // startDate/endDate are local-midnight date-only values; use local accessors.
+    const loanStartYear = this.startDate ? this.startDate.getFullYear() : new Date().getFullYear();
     if (year < loanStartYear) {
         return { totalInterest: 0, totalPrincipal: 0, totalPayment: 0 };
     }
 
-    const loanEndYear = this.endDate ? this.endDate.getUTCFullYear() : null;
+    const loanEndYear = this.endDate ? this.endDate.getFullYear() : null;
     if (loanEndYear !== null && year > loanEndYear) {
         return { totalInterest: 0, totalPrincipal: 0, totalPayment: 0 };
     }
@@ -608,8 +613,8 @@ export class LoanExpense extends BaseExpense {
 
     const monthlyRate = this.apr / 100 / 12;
 
-    const startMonth = (year === loanStartYear) ? (this.startDate ? this.startDate.getUTCMonth() : 0) : 0;
-    const endMonth = (loanEndYear === year) ? (this.endDate ? this.endDate.getUTCMonth() : 11) : 11;
+    const startMonth = (year === loanStartYear) ? (this.startDate ? this.startDate.getMonth() : 0) : 0;
+    const endMonth = (loanEndYear === year) ? (this.endDate ? this.endDate.getMonth() : 11) : 11;
 
     for (let month = startMonth; month <= endMonth; month++) {
         if (balance <= 0) {
@@ -674,17 +679,25 @@ export class LoanExpense extends BaseExpense {
     if (!this.endDate || !this.startDate) return 0;
     const start = new Date(this.startDate);
     const end = new Date(this.endDate);
-    // startDate/endDate are UTC-midnight date-only values; read with getUTC* to
-    // avoid a one-month shift in negative-UTC timezones.
-    return (end.getUTCFullYear() - start.getUTCFullYear()) * 12 + (end.getUTCMonth() - start.getUTCMonth());
+    // startDate/endDate are local-midnight date-only values (parseDate uses new
+    // Date(y, m-1, d)); read with local getFullYear/getMonth.
+    return (end.getFullYear() - start.getFullYear()) * 12 + (end.getMonth() - start.getMonth());
   }
 
   getAnnualAmount(year?: number): number {
-    return this.getProratedAnnual(this.payment, year);
+    // Use calculateAnnualAmortization to cap the payment in the payoff year:
+    // in the final year the loan balance is paid off mid-year, so the actual
+    // payment is less than payment×12. calculateAnnualAmortization already
+    // handles loanStartYear/loanEndYear proration as well.
+    if (year !== undefined) {
+      return this.calculateAnnualAmortization(year).totalPayment;
+    }
+    // No year — full-year un-prorated amount (used for display).
+    return this.payment * 12;
   }
 
   getMonthlyAmount(year?: number): number {
-    return this.getProratedAnnual(this.payment, year) / 12;
+    return this.getAnnualAmount(year) / 12;
   }
 
   /**
@@ -820,21 +833,21 @@ export type AnyExpense = RentExpense | MortgageExpense | LoanExpense | Dependent
 
 export function getExpenseActiveMultiplier(expense: BaseExpense, year: number): number {
   const expenseStartDate = expense.startDate ? new Date(expense.startDate) : new Date();
-  // Date-only values come from parseDate, which returns UTC dates (see modelUtils
-  // contract). Read with getUTC* so the active window doesn't shift by a month/year
-  // in negative timezones.
-  const startYear = expenseStartDate.getUTCFullYear();
+  // Expense date-only values are built with parseDate (new Date(y, m-1, d)) — local
+  // midnight. Read with local getFullYear/getMonth so the active window does not
+  // shift in positive-UTC timezones (e.g. Sydney UTC+10/11).
+  const startYear = expenseStartDate.getFullYear();
 
   const safeEndDate = expense.endDate ? new Date(expense.endDate) : null;
-  const endYear = safeEndDate ? safeEndDate.getUTCFullYear() : null;
+  const endYear = safeEndDate ? safeEndDate.getFullYear() : null;
 
   if (startYear > year) return 0;
   if (endYear !== null && endYear < year) return 0;
 
-  const startMonthIndex = (startYear < year) ? 0 : expenseStartDate.getUTCMonth();
+  const startMonthIndex = (startYear < year) ? 0 : expenseStartDate.getMonth();
 
   const endMonthIndex = (safeEndDate && endYear === year)
-    ? safeEndDate.getUTCMonth()
+    ? safeEndDate.getMonth()
     : 11;
 
   const monthsActive = endMonthIndex - startMonthIndex + 1;
@@ -848,11 +861,11 @@ export function isExpenseActiveInCurrentMonth(expense: AnyExpense): boolean {
   const currentMonth = today.getMonth();
 
   const expenseStartDate = expense.startDate != null ? expense.startDate : new Date();
-  // Stored date-only values are UTC-midnight; read them with getUTC* (today stays
-  // local since it's a true instant). Both sides feed local new Date(y, m, 1)
-  // month-boundary comparisons, so the bases stay consistent.
-  const expenseStartYear = expenseStartDate.getUTCFullYear();
-  const expenseStartMonth = expenseStartDate.getUTCMonth();
+  // Expense date-only values are local-midnight (parseDate uses new Date(y, m-1, d)).
+  // Read with local getFullYear/getMonth (today stays local since it's a true instant).
+  // Both sides feed local new Date(y, m, 1) month-boundary comparisons.
+  const expenseStartYear = expenseStartDate.getFullYear();
+  const expenseStartMonth = expenseStartDate.getMonth();
 
   const currentMonthStart = new Date(currentYear, currentMonth, 1);
   const expenseEffectiveStart = new Date(expenseStartYear, expenseStartMonth, 1);
@@ -863,8 +876,8 @@ export function isExpenseActiveInCurrentMonth(expense: AnyExpense): boolean {
 
   if (expense.endDate) {
     const expenseEndDate = new Date(expense.endDate);
-    const expenseEndYear = expenseEndDate.getUTCFullYear();
-    const expenseEndMonth = expenseEndDate.getUTCMonth();
+    const expenseEndYear = expenseEndDate.getFullYear();
+    const expenseEndMonth = expenseEndDate.getMonth();
 
     const expenseEffectiveEnd = new Date(expenseEndYear, expenseEndMonth + 1, 0);
 
@@ -897,9 +910,9 @@ export function isLongTermGoal(expense: AnyExpense): boolean {
   return expense.goalType != null;
 }
 
-/** Whole months between two dates (>= 0). */
+/** Whole months between two local-midnight date-only values (>= 0). */
 function monthsBetween(from: Date, to: Date): number {
-  const months = (to.getUTCFullYear() - from.getUTCFullYear()) * 12 + (to.getUTCMonth() - from.getUTCMonth());
+  const months = (to.getFullYear() - from.getFullYear()) * 12 + (to.getMonth() - from.getMonth());
   return Math.max(0, months);
 }
 
@@ -929,10 +942,11 @@ export function getGoalMonthlySetAside(expense: AnyExpense): number {
  */
 export function isGoalDueInYear(expense: AnyExpense, year: number): boolean {
   if (expense.goalType === 'targetDate' && expense.endDate) {
-    return new Date(expense.endDate).getUTCFullYear() === year;
+    // Goal dates are local-midnight; use local accessors to avoid timezone shift.
+    return new Date(expense.endDate).getFullYear() === year;
   }
   if (expense.goalType === 'recurring' && expense.intervalYears && expense.intervalYears > 0) {
-    const anchorYear = (expense.startDate ? new Date(expense.startDate) : new Date()).getUTCFullYear();
+    const anchorYear = (expense.startDate ? new Date(expense.startDate) : new Date()).getFullYear();
     const diff = year - anchorYear;
     return diff > 0 && diff % expense.intervalYears === 0;
   }
@@ -950,9 +964,11 @@ export function isGoalDueInYear(expense: AnyExpense, year: number): boolean {
  * automatically. Returns 0 outside the active saving window — before the
  * goal's start year, and (for one-time goals) after the purchase year.
  *
- * Years are extracted with getUTCFullYear to match isGoalDueInYear: goal dates
- * are stored as UTC-midnight, so local accessors in a negative-UTC timezone
- * would shift a YYYY-01-01 target back a year.
+ * When multiple goals share the same goalAccountId, the cap is the sum of all
+ * their set-asides (each goal's own active window is respected).
+ *
+ * Goal dates are local-midnight (parseDate uses new Date(y, m-1, d)); read
+ * with local getFullYear/getMonth to avoid timezone shift.
  */
 export function getGoalFundMonthlyCap(
   expenses: AnyExpense[],
@@ -960,13 +976,15 @@ export function getGoalFundMonthlyCap(
   year: number,
 ): number | undefined {
   if (!accountId) return undefined;
-  const goal = expenses.find(e => isLongTermGoal(e) && e.goalAccountId === accountId);
-  if (!goal) return undefined;
-  const startYear = (goal.startDate ? new Date(goal.startDate) : new Date()).getUTCFullYear();
-  if (year < startYear) return 0; // not saving yet
-  if (goal.goalType === 'targetDate' && goal.endDate
-      && new Date(goal.endDate).getUTCFullYear() < year) return 0; // already purchased
-  return getGoalMonthlySetAside(goal);
+  const goals = expenses.filter(e => isLongTermGoal(e) && e.goalAccountId === accountId);
+  if (goals.length === 0) return undefined;
+  return goals.reduce((sum, goal) => {
+    const startYear = (goal.startDate ? new Date(goal.startDate) : new Date()).getFullYear();
+    if (year < startYear) return sum; // not saving yet for this goal
+    if (goal.goalType === 'targetDate' && goal.endDate
+        && new Date(goal.endDate).getFullYear() < year) return sum; // already purchased
+    return sum + getGoalMonthlySetAside(goal);
+  }, 0);
 }
 
 /**
@@ -975,29 +993,30 @@ export function getGoalFundMonthlyCap(
  * no saving months in that final year — the lump is due then). Summed across
  * years this equals monthsBetween(start, end) exactly, so a goal funded at its
  * monthly set-aside lands on its total by the target — mid-year starts and the
- * partial final year are handled instead of charging a full 12 months. UTC
- * accessors match the rest of the goal math.
+ * partial final year are handled instead of charging a full 12 months.
+ * Goal dates are local-midnight; read with local accessors to avoid timezone shift.
  */
 function goalMonthsActiveInYear(goal: AnyExpense, year: number): number {
   const start = goal.startDate ? new Date(goal.startDate) : new Date();
-  const startYear = start.getUTCFullYear();
+  const startYear = start.getFullYear();
   if (year < startYear) return 0;
-  const from = year === startYear ? start.getUTCMonth() : 0;
+  const from = year === startYear ? start.getMonth() : 0;
   let to = 12;
   if (goal.endDate) {
     const end = new Date(goal.endDate);
-    const endYear = end.getUTCFullYear();
+    const endYear = end.getFullYear();
     if (year > endYear) return 0;
-    if (year === endYear) to = end.getUTCMonth();
+    if (year === endYear) to = end.getMonth();
   }
   return Math.max(0, to - from);
 }
 
 /**
- * Annual committed set-aside for a goal's fund in a calendar year — the
- * monthly set-aside × months active that year — or undefined when the account
- * isn't a goal fund. This is what the simulation counts with living expenses
- * and credits into the fund; budget projections use it for per-year totals.
+ * Annual committed set-aside for a goal's fund in a calendar year — the sum
+ * of (monthly set-aside × months active) over every goal targeting the account
+ * — or undefined when the account isn't a goal fund. When multiple goals share
+ * the same goalAccountId, each goal's own active window is respected and their
+ * set-asides are summed.
  */
 export function getGoalFundAnnualSetAside(
   expenses: AnyExpense[],
@@ -1005,9 +1024,12 @@ export function getGoalFundAnnualSetAside(
   year: number,
 ): number | undefined {
   if (!accountId) return undefined;
-  const goal = expenses.find(e => isLongTermGoal(e) && e.goalAccountId === accountId);
-  if (!goal) return undefined;
-  return getGoalMonthlySetAside(goal) * goalMonthsActiveInYear(goal, year);
+  const goals = expenses.filter(e => isLongTermGoal(e) && e.goalAccountId === accountId);
+  if (goals.length === 0) return undefined;
+  return goals.reduce(
+    (sum, goal) => sum + getGoalMonthlySetAside(goal) * goalMonthsActiveInYear(goal, year),
+    0,
+  );
 }
 
 /**

--- a/src/components/Objects/Income/incomeFormTypes.ts
+++ b/src/components/Objects/Income/incomeFormTypes.ts
@@ -56,7 +56,7 @@ export function getInitialFormState(): IncomeFormState {
         name: '',
         amount: 0,
         frequency: 'Monthly',
-        startDate: new Date(Date.UTC(new Date().getFullYear(), 0, 1)),
+        startDate: new Date(new Date().getFullYear(), 0, 1),
         endDate: undefined,
         startMilestoneId: undefined,
         endMilestoneId: undefined,

--- a/src/components/Objects/Income/models.tsx
+++ b/src/components/Objects/Income/models.tsx
@@ -664,8 +664,10 @@ export class FERSPensionIncome extends BaseIncome {
     // FERS COLA is reduced compared to full CPI
     const cola = getFERSCOLA(inflation, currentAge);
 
-    // FERS Supplement ends at age 62
-    const newSupplement = currentAge >= 62 ? 0 : this.fersSupplement * (1 + cola);
+    // FERS Supplement ends at age 62. The real FERS Annuity Supplement receives NO
+    // COLA — it is a fixed bridge payment from retirement until 62 — so it must NOT
+    // grow with `cola`. (The basic benefit below still gets the COLA.)
+    const newSupplement = currentAge >= 62 ? 0 : this.fersSupplement;
 
     return new FERSPensionIncome(
       this.id,
@@ -804,26 +806,28 @@ export function calculateSocialSecurityStartDate(
     claimingMonth: number = 0
 ): Date {
     const year = calculateSocialSecurityStartYear(birthYear, claimingAge);
-    return new Date(Date.UTC(year, claimingMonth, 1));
+    // Date-only value: build at LOCAL midnight (parseDate convention) so it reads
+    // back as the same Y-M-D in any timezone.
+    return new Date(year, claimingMonth, 1);
 }
 
 export function getIncomeActiveMultiplier(income: AnyIncome, year: number): number {
     const incomeStartDate = income.startDate ? new Date(income.startDate) : new Date();
-    // Date-only values come from parseDate, which returns UTC dates (see modelUtils
-    // contract). Read with getUTC* so the active window doesn't shift by a month/year
-    // in negative timezones.
-    const startYear = incomeStartDate.getUTCFullYear();
+    // Date-only values come from parseDate, which returns LOCAL-midnight dates (the
+    // repo-wide convention). Read with local getFullYear()/getMonth() so a date
+    // entered as Y-M-D round-trips to the same Y-M-D in any timezone.
+    const startYear = incomeStartDate.getFullYear();
 
     const safeEndDate = income.end_date ? new Date(income.end_date) : null;
-    const endYear = safeEndDate ? safeEndDate.getUTCFullYear() : null;
+    const endYear = safeEndDate ? safeEndDate.getFullYear() : null;
 
     if (startYear > year) return 0;
     if (endYear !== null && endYear < year) return 0;
 
-    const startMonthIndex = (startYear < year) ? 0 : incomeStartDate.getUTCMonth();
+    const startMonthIndex = (startYear < year) ? 0 : incomeStartDate.getMonth();
 
     const endMonthIndex = (safeEndDate && endYear === year)
-        ? safeEndDate.getUTCMonth()
+        ? safeEndDate.getMonth()
         : 11;
 
     const monthsActive = endMonthIndex - startMonthIndex + 1;
@@ -837,11 +841,12 @@ export function isIncomeActiveInCurrentMonth(income: AnyIncome): boolean {
     const currentMonth = today.getMonth(); // 0-indexed
 
     const incomeStartDate = income.startDate != null ? income.startDate : new Date();
-    // Stored date-only values are UTC-midnight; read them with getUTC* (today stays
-    // local since it's a true instant). Both sides feed local new Date(y, m, 1)
-    // month-boundary comparisons, so the bases stay consistent.
-    const incomeStartYear = incomeStartDate.getUTCFullYear();
-    const incomeStartMonth = incomeStartDate.getUTCMonth();
+    // Stored date-only values are LOCAL-midnight (parseDate convention); read them
+    // with local accessors. `today` above is a true instant and also read locally,
+    // so both sides feed the local new Date(y, m, 1) month-boundary comparisons on
+    // a consistent basis.
+    const incomeStartYear = incomeStartDate.getFullYear();
+    const incomeStartMonth = incomeStartDate.getMonth();
 
     const currentMonthStart = new Date(currentYear, currentMonth, 1);
     const incomeEffectiveStart = new Date(incomeStartYear, incomeStartMonth, 1);
@@ -852,8 +857,8 @@ export function isIncomeActiveInCurrentMonth(income: AnyIncome): boolean {
 
     if (income.end_date) {
         const incomeEndDate = new Date(income.end_date);
-        const incomeEndYear = incomeEndDate.getUTCFullYear();
-        const incomeEndMonth = incomeEndDate.getUTCMonth();
+        const incomeEndYear = incomeEndDate.getFullYear();
+        const incomeEndMonth = incomeEndDate.getMonth();
 
         const incomeEffectiveEnd = new Date(incomeEndYear, incomeEndMonth + 1, 0);
 

--- a/src/components/Objects/Taxes/taxService/deductions.ts
+++ b/src/components/Objects/Taxes/taxService/deductions.ts
@@ -1,5 +1,14 @@
 import { AnyExpense, MortgageExpense, getExpenseActiveMultiplier } from "../../Expense/models";
 
+/**
+ * Narrow an expense to those that declare a numeric `tax_deductible` field.
+ * Only some classes in the AnyExpense union (Mortgage, Loan, Dependent,
+ * Healthcare, Charity) carry it; the SimpleExpense / Rent variants do not.
+ */
+function hasTaxDeductible(exp: AnyExpense): exp is AnyExpense & { tax_deductible: number } {
+    return "tax_deductible" in exp;
+}
+
 export function getItemizedDeductions(expenses: AnyExpense[], year: number): number {
     return expenses
         .filter(
@@ -12,7 +21,9 @@ export function getItemizedDeductions(expenses: AnyExpense[], year: number): num
             if (exp instanceof MortgageExpense) {
                 return val + exp.calculateAnnualAmortization(year).totalInterest;
             }
-            return val + exp.getProratedAnnual((exp as any).tax_deductible || 0, year);
+            return hasTaxDeductible(exp)
+                ? val + exp.getProratedAnnual(exp.tax_deductible ?? 0, year)
+                : val;
         }, 0);
 }
 
@@ -28,6 +39,8 @@ export function getYesDeductions(expenses: AnyExpense[], year: number): number {
             if (exp instanceof MortgageExpense) {
                 return val + exp.calculateAnnualAmortization(year).totalInterest;
             }
-            return val + exp.getProratedAnnual((exp as any).tax_deductible || 0, year);
+            return hasTaxDeductible(exp)
+                ? val + exp.getProratedAnnual(exp.tax_deductible ?? 0, year)
+                : val;
         }, 0);
 }

--- a/src/components/Objects/Taxes/taxService/federalTax.ts
+++ b/src/components/Objects/Taxes/taxService/federalTax.ts
@@ -58,15 +58,20 @@ export function calculateFederalTaxFromIncomes(
     const fedParams = getTaxParameters(year, state.filingStatus, "federal", undefined, assumptions);
     if (!fedParams) return 0;
 
-    // SALT cap interaction with state tax
-    const stateTax = additionalOrdinaryIncome > 0
-        ? calculateUnifiedStateTax(state, incomes, expenses, additionalOrdinaryIncome, year, assumptions)
-        : calculateStateTax(state, incomes, expenses, year, assumptions);
+    // SALT cap interaction with state tax. Only needed for the Itemized / Auto
+    // paths — on the Standard path `itemizedTotal` is never used, so skip the
+    // (expensive) state-tax + SALT + itemized computation entirely.
+    let itemizedTotal = 0;
+    if (state.deductionMethod !== "Standard") {
+        const stateTax = additionalOrdinaryIncome > 0
+            ? calculateUnifiedStateTax(state, incomes, expenses, additionalOrdinaryIncome, year, assumptions)
+            : calculateStateTax(state, incomes, expenses, year, assumptions);
 
-    const saltCap = getSALTCap(year, state.filingStatus);
-    const cappedStateTax = Math.min(stateTax, saltCap);
+        const saltCap = getSALTCap(year, state.filingStatus);
+        const cappedStateTax = Math.min(stateTax, saltCap);
 
-    const itemizedTotal = getItemizedDeductions(expenses, year) + cappedStateTax;
+        itemizedTotal = getItemizedDeductions(expenses, year) + cappedStateTax;
+    }
 
     const calcTaxWithDeduction = (deductionAmount: number): number => {
         const paramsWithDeduction = {

--- a/src/components/Objects/Taxes/taxService/ficaTax.ts
+++ b/src/components/Objects/Taxes/taxService/ficaTax.ts
@@ -4,6 +4,16 @@ import { AssumptionsState } from "../../Assumptions/AssumptionsContext";
 import { getTaxParameters } from "./parameters";
 import { getEarnedIncome, getFicaExemptions } from "./incomeAggregation";
 
+/**
+ * Income threshold above which the 0.9% Additional Medicare surtax applies,
+ * by filing status. Shared with the marginal-rate calculation so the two
+ * cannot drift apart.
+ */
+export function getAdditionalMedicareThreshold(filingStatus: TaxState['filingStatus']): number {
+    return filingStatus === 'Married Filing Jointly' ? 250000 :
+        filingStatus === 'Married Filing Separately' ? 125000 : 200000;
+}
+
 export function calculateFicaTax(
     state: TaxState,
     incomes: AnyIncome[],
@@ -26,9 +36,7 @@ export function calculateFicaTax(
         fedParams.socialSecurityTaxRate;
     const medicareTax = taxableBase * fedParams.medicareTaxRate;
 
-    const additionalMedicareThreshold =
-        state.filingStatus === 'Married Filing Jointly' ? 250000 :
-        state.filingStatus === 'Married Filing Separately' ? 125000 : 200000;
+    const additionalMedicareThreshold = getAdditionalMedicareThreshold(state.filingStatus);
     const additionalMedicareTax = Math.max(0, taxableBase - additionalMedicareThreshold) * 0.009;
 
     return ssTax + medicareTax + additionalMedicareTax;

--- a/src/components/Objects/Taxes/taxService/incomeAggregation.ts
+++ b/src/components/Objects/Taxes/taxService/incomeAggregation.ts
@@ -17,6 +17,27 @@ export function getGrossIncome(incomes: AnyIncome[], year: number): number {
 }
 
 /**
+ * Resolve the effective per-period 401k contribution field for a work income.
+ *
+ * When `useStoredValue` is true (simulation, after increment() has run) the stored
+ * preTax401k/roth401k is read directly. Otherwise, when an age is provided, the value
+ * is resolved through getEffective401k() (UI preview / auto-max). Falls back to the
+ * stored value when no age is available.
+ */
+function resolveEffective401k(
+    inc: WorkIncome,
+    year: number,
+    age: number | undefined,
+    useStoredValue: boolean,
+    kind: "preTax" | "roth",
+): number {
+    if (useStoredValue || age === undefined) {
+        return kind === "preTax" ? inc.preTax401k : inc.roth401k;
+    }
+    return inc.getEffective401k(year, age)[kind];
+}
+
+/**
  * Get pre-tax exemptions (401k, insurance, HSA) from work incomes.
  * @param useStoredValue - If true, reads stored preTax401k directly instead of calling getEffective401k().
  *                         Use true in simulation (after increment() has run), false for UI preview.
@@ -30,9 +51,7 @@ export function getPreTaxExemptions(
     return incomes
         .filter((inc) => inc instanceof WorkIncome)
         .reduce((acc, inc) => {
-            const preTax401k = useStoredValue
-                ? inc.preTax401k
-                : (age !== undefined ? inc.getEffective401k(year, age).preTax : inc.preTax401k);
+            const preTax401k = resolveEffective401k(inc, year, age, useStoredValue, "preTax");
             return (
                 acc +
                 inc.getProratedAnnual(preTax401k, year) +
@@ -65,9 +84,7 @@ export function getPostTaxExemptions(
     return incomes
         .filter((inc) => inc instanceof WorkIncome)
         .reduce((acc, inc) => {
-            const roth401k = useStoredValue
-                ? inc.roth401k
-                : (age !== undefined ? inc.getEffective401k(year, age).roth : inc.roth401k);
+            const roth401k = resolveEffective401k(inc, year, age, useStoredValue, "roth");
             return acc + inc.getProratedAnnual(roth401k, year);
         }, 0);
 }

--- a/src/components/Objects/Taxes/taxService/marginalRates.ts
+++ b/src/components/Objects/Taxes/taxService/marginalRates.ts
@@ -2,6 +2,7 @@ import { TaxParameters } from "../../../../data/TaxData";
 import { TaxState } from "../TaxContext";
 import { AssumptionsState } from "../../Assumptions/AssumptionsContext";
 import { getTaxParameters } from "./parameters";
+import { getAdditionalMedicareThreshold } from "./ficaTax";
 
 /** Result of marginal tax rate calculation */
 export interface MarginalRateResult {
@@ -93,8 +94,8 @@ export function getCombinedMarginalRate(
     const stateParams = getTaxParameters(year, taxState.filingStatus, 'state', taxState.stateResidency, assumptions);
 
     const adjustedGross = Math.max(0, grossIncome - preTaxDeductions);
-    const fedStdDed = fedParams?.standardDeduction || 14600;
-    const stateStdDed = stateParams?.standardDeduction || 0;
+    const fedStdDed = fedParams?.standardDeduction ?? 14600;
+    const stateStdDed = stateParams?.standardDeduction ?? 0;
 
     const fedTaxableIncome = Math.max(0, adjustedGross - fedStdDed);
     const stateTaxableIncome = Math.max(0, adjustedGross - stateStdDed);
@@ -102,7 +103,10 @@ export function getCombinedMarginalRate(
     const fedMarginal = fedParams ? getMarginalTaxRate(fedTaxableIncome, fedParams) : { rate: 0, headroom: Infinity };
     const stateMarginal = stateParams ? getMarginalTaxRate(stateTaxableIncome, stateParams) : { rate: 0, headroom: Infinity };
 
-    // FICA: 6.2% SS (up to wage base) + 1.45% Medicare
+    // FICA: 6.2% SS (up to wage base) + 1.45% Medicare + 0.9% Additional
+    // Medicare surtax above the filing-status threshold. Above the SS wage
+    // base the 6.2% has already dropped off, so a high earner ends at
+    // 0.0145 + 0.009 = 0.0235.
     let ficaRate = 0;
     if (includesFICA && fedParams) {
         const ssWageBase = fedParams.socialSecurityWageBase || 168600;
@@ -110,6 +114,12 @@ export function getCombinedMarginalRate(
             ficaRate = fedParams.socialSecurityTaxRate + fedParams.medicareTaxRate;
         } else {
             ficaRate = fedParams.medicareTaxRate;
+        }
+        // Mirror calculateFicaTax: the 0.9% surtax applies above a
+        // filing-status threshold (shared helper keeps the two in sync).
+        const additionalMedicareThreshold = getAdditionalMedicareThreshold(taxState.filingStatus);
+        if (grossIncome >= additionalMedicareThreshold) {
+            ficaRate += 0.009;
         }
     }
 

--- a/src/components/Objects/Taxes/taxService/parameters.ts
+++ b/src/components/Objects/Taxes/taxService/parameters.ts
@@ -63,6 +63,25 @@ export function getSALTCap(year: number, filingStatus: FilingStatus): number {
     return isMFS ? SALT_CAP_TCJA_MFS : SALT_CAP_TCJA_JOINT;
 }
 
+/**
+ * Find the year key in `sourceData` closest to `target`. On an exact tie
+ * (target equidistant between two years) the newer year wins (`<=`), since
+ * more recent tax law is the better approximation. Returns undefined when the
+ * table has no numeric year keys.
+ */
+function findNearestYear(
+    sourceData: AuthorityData,
+    target: number
+): number | undefined {
+    const availableYears = Object.keys(sourceData)
+        .map(Number)
+        .filter((y) => !Number.isNaN(y));
+    if (availableYears.length === 0) return undefined;
+    return availableYears.reduce((best, y) =>
+        Math.abs(y - target) <= Math.abs(best - target) ? y : best
+    );
+}
+
 export function getTaxParameters(
     year: number,
     filingStatus: FilingStatus,
@@ -73,7 +92,11 @@ export function getTaxParameters(
         macro: { ...defaultAssumptions.macro, inflationAdjusted: false },
     }
 ): TaxParameters | undefined {
-    const inflation = assumptions.macro.inflationRate / 100;
+    let inflation = assumptions.macro.inflationRate / 100;
+    // The default-param above only fills in when the WHOLE assumptions arg is
+    // undefined; a partial object missing inflationRate yields NaN, which would
+    // poison every inflated value. Treat a non-finite rate as 0%.
+    if (!Number.isFinite(inflation)) inflation = 0;
     const inflationAdjusted = assumptions.macro.inflationAdjusted;
 
     let sourceData: AuthorityData;
@@ -93,13 +116,9 @@ export function getTaxParameters(
         // logic used by the non-inflation path below) instead of throwing.
         let baseYear = max_year;
         if (!sourceData[max_year]) {
-            const availableYears = Object.keys(sourceData)
-                .map(Number)
-                .filter((y) => !Number.isNaN(y));
-            if (availableYears.length === 0) return undefined;
-            baseYear = availableYears.reduce((best, y) =>
-                Math.abs(y - max_year) < Math.abs(best - max_year) ? y : best
-            );
+            const nearest = findNearestYear(sourceData, max_year);
+            if (nearest === undefined) return undefined;
+            baseYear = nearest;
         }
 
         const baseYearParams = sourceData[baseYear][filingStatus];
@@ -126,6 +145,28 @@ export function getTaxParameters(
                 ...bracket,
                 threshold: Math.round(bracket.threshold * inflationMultiplier),
             })),
+            // Dollar-amount fields spread in via ...baseYearParams stay nominal
+            // unless re-inflated here. seniorAge / *Rate fields are NOT dollars,
+            // so they are intentionally left untouched.
+            ...(baseYearParams.seniorDeduction !== undefined && {
+                seniorDeduction: Math.round(
+                    baseYearParams.seniorDeduction * inflationMultiplier
+                ),
+            }),
+            ...(baseYearParams.ssExemptionThreshold !== undefined && {
+                ssExemptionThreshold: Math.round(
+                    baseYearParams.ssExemptionThreshold * inflationMultiplier
+                ),
+            }),
+            ...(baseYearParams.retirementIncomeExemption !== undefined && {
+                retirementIncomeExemption: {
+                    ...baseYearParams.retirementIncomeExemption,
+                    amount: Math.round(
+                        baseYearParams.retirementIncomeExemption.amount *
+                            inflationMultiplier
+                    ),
+                },
+            }),
         };
     }
 
@@ -137,12 +178,7 @@ export function getTaxParameters(
     // entry), so getClosestTaxYear — which only knows federal years — can resolve
     // to a year missing from this authority's table. Fall back to the nearest year
     // actually present so the gap doesn't return undefined → $0 tax.
-    const availableYears = Object.keys(sourceData)
-        .map(Number)
-        .filter((y) => !Number.isNaN(y));
-    if (availableYears.length === 0) return undefined;
-    const nearestYear = availableYears.reduce((best, y) =>
-        Math.abs(y - year) < Math.abs(best - year) ? y : best
-    );
+    const nearestYear = findNearestYear(sourceData, year);
+    if (nearestYear === undefined) return undefined;
     return sourceData[nearestYear]?.[filingStatus];
 }

--- a/src/components/Objects/Taxes/taxService/stateTax.ts
+++ b/src/components/Objects/Taxes/taxService/stateTax.ts
@@ -12,60 +12,56 @@ import { getTaxableSocialSecurityBenefits } from "./socialSecurity";
 import { getItemizedDeductions, getYesDeductions } from "./deductions";
 import { calculateTax } from "./bracketTax";
 
-export function calculateStateTax(
+/**
+ * Shared core of state-tax computation.
+ *
+ * Given the ordinary gross income BEFORE Social Security treatment
+ * (`annualGross`, which already includes any additional ordinary income like
+ * withdrawals / Roth conversions / RMDs), this applies the data-driven SS
+ * treatment, the senior deduction (doubled per-person for MFJ), and the
+ * Auto / Standard / Itemized deduction selection.
+ *
+ * Both `calculateStateTax` and `calculateUnifiedStateTax` delegate here so the
+ * SS-treatment switch, senior-deduction doubling, and deduction selection live
+ * in exactly one place. Callers are responsible for the `stateOverride`
+ * short-circuit and the `getTaxParameters` undefined guard before calling.
+ */
+function computeStateTaxFromGross(
+    annualGross: number,
     state: TaxState,
     incomes: AnyIncome[],
     expenses: AnyExpense[],
     year: number,
-    assumptions?: AssumptionsState,
-) {
-    if (state.stateOverride !== null) {
-        return state.stateOverride;
-    }
-
-    const annualGross = getGrossIncome(incomes, year);
-    const age = assumptions?.milestones ? year - getBirthYear(assumptions.milestones) : undefined;
+    stateParams: NonNullable<ReturnType<typeof getTaxParameters>>,
+    age: number | undefined,
+): number {
     const incomePreTaxDeductions = getPreTaxExemptions(incomes, year, age);
     const expenseAboveLineDeductions = getYesDeductions(expenses, year);
     const totalPreTaxDeductions = incomePreTaxDeductions + expenseAboveLineDeductions;
 
-    const itemizedTotal = getItemizedDeductions(expenses, year);
-    const stateParams = getTaxParameters(
-        year,
-        state.filingStatus,
-        "state",
-        state.stateResidency,
-        assumptions,
-    );
-
-    if (!stateParams) return 0;
-
     // Social Security handling — data-driven `socialSecurityTreatment` defaults to 'exempt'.
     const ssTreatment = stateParams.socialSecurityTreatment ?? 'exempt';
     const totalSSBenefits = getSocialSecurityBenefits(incomes, year);
-    let adjustedGrossForState = annualGross;
+    let adjustedGross = annualGross;
 
-    if (totalSSBenefits > 0) {
-        if (ssTreatment === 'taxable') {
-            // States that tax SS: use only the taxable portion (like federal)
-            const nonSSGross = annualGross - totalSSBenefits;
-            const agiExcludingSS = nonSSGross - totalPreTaxDeductions;
-            // TODO: Verify all income types are included (LTCG, STCG, dividends, etc.)
-            const taxableSSBenefits = getTaxableSocialSecurityBenefits(
-                totalSSBenefits,
-                agiExcludingSS,
-                0,
-                state.filingStatus,
-            );
-            adjustedGrossForState = annualGross - totalSSBenefits + taxableSSBenefits;
-        } else if (ssTreatment === 'income-based') {
-            // TODO: Implement income-based SS exemption for states like CO, CT, etc.
-            // For now, treat as exempt (conservative).
-            adjustedGrossForState = annualGross - totalSSBenefits;
-        } else {
-            // 'exempt' — exclude SS benefits entirely
-            adjustedGrossForState = annualGross - totalSSBenefits;
-        }
+    if (ssTreatment === 'taxable') {
+        // States that tax SS: use only the taxable portion (like federal)
+        const nonSSGross = annualGross - totalSSBenefits;
+        const agiExcludingSS = nonSSGross - totalPreTaxDeductions;
+        // TODO: Verify all income types are included (LTCG, STCG, dividends, etc.)
+        const taxableSSBenefits = getTaxableSocialSecurityBenefits(
+            totalSSBenefits,
+            agiExcludingSS,
+            0,
+            state.filingStatus,
+        );
+        adjustedGross = annualGross - totalSSBenefits + taxableSSBenefits;
+    } else {
+        // 'exempt' (and, for now, 'income-based' — treated conservatively as
+        // exempt) — exclude SS benefits entirely. Subtracting 0 when there are
+        // no SS benefits leaves the gross unchanged.
+        // TODO: Implement income-based SS exemption for states like CO, CT, etc.
+        adjustedGross = annualGross - totalSSBenefits;
     }
 
     // Senior deduction: per-person variants (e.g., Virginia) get doubled for MFJ
@@ -81,14 +77,15 @@ export function calculateStateTax(
         }
     }
 
+    const itemizedTotal = getItemizedDeductions(expenses, year);
     const stateStandardDeduction = (stateParams.standardDeduction || 0) + seniorDeductionAmount;
 
     if (state.deductionMethod === "Auto") {
-        const taxWithStandard = calculateTax(adjustedGrossForState, totalPreTaxDeductions, {
+        const taxWithStandard = calculateTax(adjustedGross, totalPreTaxDeductions, {
             ...stateParams,
             standardDeduction: stateStandardDeduction,
         });
-        const taxWithItemized = calculateTax(adjustedGrossForState, totalPreTaxDeductions, {
+        const taxWithItemized = calculateTax(adjustedGross, totalPreTaxDeductions, {
             ...stateParams,
             standardDeduction: itemizedTotal + seniorDeductionAmount,
         });
@@ -100,10 +97,22 @@ export function calculateStateTax(
             ? stateStandardDeduction
             : itemizedTotal + seniorDeductionAmount;
 
-    return calculateTax(adjustedGrossForState, totalPreTaxDeductions, {
+    return calculateTax(adjustedGross, totalPreTaxDeductions, {
         ...stateParams,
         standardDeduction: stateAppliedMainDeduction,
     });
+}
+
+export function calculateStateTax(
+    state: TaxState,
+    incomes: AnyIncome[],
+    expenses: AnyExpense[],
+    year: number,
+    assumptions?: AssumptionsState,
+) {
+    // calculateStateTax is exactly calculateUnifiedStateTax with no additional
+    // ordinary income — delegate so the two stay in lockstep.
+    return calculateUnifiedStateTax(state, incomes, expenses, 0, year, assumptions);
 }
 
 /**
@@ -141,67 +150,7 @@ export function calculateUnifiedStateTax(
 
     const incomeGross = getGrossIncome(incomes, year);
     const annualGross = incomeGross + additionalOrdinaryIncome;
-
     const age = assumptions?.milestones ? year - getBirthYear(assumptions.milestones) : undefined;
-    const incomePreTaxDeductions = getPreTaxExemptions(incomes, year, age);
-    const expenseAboveLineDeductions = getYesDeductions(expenses, year);
-    const totalPreTaxDeductions = incomePreTaxDeductions + expenseAboveLineDeductions;
 
-    const ssTreatment = stateParams.socialSecurityTreatment ?? 'exempt';
-    const totalSSBenefits = getSocialSecurityBenefits(incomes, year);
-    let adjustedGross = annualGross;
-
-    if (totalSSBenefits > 0) {
-        if (ssTreatment === 'taxable') {
-            const nonSSGross = annualGross - totalSSBenefits;
-            const agiExcludingSS = nonSSGross - totalPreTaxDeductions;
-            // TODO: Verify all income types are included (LTCG, STCG, dividends, etc.)
-            const taxableSSBenefits = getTaxableSocialSecurityBenefits(
-                totalSSBenefits,
-                agiExcludingSS,
-                0,
-                state.filingStatus,
-            );
-            adjustedGross = annualGross - totalSSBenefits + taxableSSBenefits;
-        } else if (ssTreatment === 'income-based') {
-            // TODO: Implement income-based SS exemption (CO, CT, etc.)
-            adjustedGross = annualGross - totalSSBenefits;
-        } else {
-            adjustedGross = annualGross - totalSSBenefits;
-        }
-    }
-
-    let seniorDeductionAmount = 0;
-    if (stateParams.seniorDeduction && age !== undefined) {
-        const seniorAge = stateParams.seniorAge ?? 65;
-        if (age >= seniorAge) {
-            seniorDeductionAmount = stateParams.seniorDeduction;
-            if (stateParams.seniorDeductionPerPerson && state.filingStatus === 'Married Filing Jointly') {
-                seniorDeductionAmount *= 2;
-            }
-        }
-    }
-
-    const itemizedTotal = getItemizedDeductions(expenses, year);
-    const stateStandardDeduction = (stateParams.standardDeduction || 0) + seniorDeductionAmount;
-
-    if (state.deductionMethod === "Auto") {
-        const taxWithStandard = calculateTax(adjustedGross, totalPreTaxDeductions, {
-            ...stateParams,
-            standardDeduction: stateStandardDeduction,
-        });
-        const taxWithItemized = calculateTax(adjustedGross, totalPreTaxDeductions, {
-            ...stateParams,
-            standardDeduction: itemizedTotal + seniorDeductionAmount,
-        });
-        return Math.min(taxWithStandard, taxWithItemized);
-    }
-
-    const stateAppliedMainDeduction =
-        state.deductionMethod === "Standard" ? stateStandardDeduction : itemizedTotal + seniorDeductionAmount;
-
-    return calculateTax(adjustedGross, totalPreTaxDeductions, {
-        ...stateParams,
-        standardDeduction: stateAppliedMainDeduction,
-    });
+    return computeStateTaxFromGross(annualGross, state, incomes, expenses, year, stateParams, age);
 }

--- a/src/data/PensionData.tsx
+++ b/src/data/PensionData.tsx
@@ -275,10 +275,11 @@ export function checkCSRSEligibility(
   if ((age >= 50 && yearsOfService >= 20) || yearsOfService >= 25) {
     const yearsUnder55 = Math.max(0, 55 - age);
     const reduction = yearsUnder55 * 2;
+    const cappedReduction = Math.min(reduction, 10); // Cap reduction at 10%
     return {
       eligible: true,
-      reductionPercent: Math.min(reduction, 10), // Cap reduction
-      message: `Early retirement with ${reduction}% reduction`
+      reductionPercent: cappedReduction,
+      message: `Early retirement with ${cappedReduction}% reduction`
     };
   }
 

--- a/src/data/TaxData.tsx
+++ b/src/data/TaxData.tsx
@@ -68,10 +68,10 @@ export const TAX_DATABASE: GlobalTaxDatabase = {
                 brackets: [
                     { threshold: 0, rate: 0.10 },
                     { threshold: 11600, rate: 0.12 },
-                    { threshold: 47151, rate: 0.22 },
-                    { threshold: 100526, rate: 0.24 },
-                    { threshold: 191951, rate: 0.32 },
-                    { threshold: 243726, rate: 0.35 },
+                    { threshold: 47150, rate: 0.22 },
+                    { threshold: 100525, rate: 0.24 },
+                    { threshold: 191950, rate: 0.32 },
+                    { threshold: 243725, rate: 0.35 },
                     { threshold: 609350, rate: 0.37 }
                 ],
                 capitalGainsBrackets: [

--- a/src/hooks/useDebouncedLocalStorage.ts
+++ b/src/hooks/useDebouncedLocalStorage.ts
@@ -34,6 +34,7 @@ export function useDebouncedLocalStorage<T>(
         }
 
         timeoutRef.current = setTimeout(() => {
+            timeoutRef.current = null;
             try {
                 localStorage.setItem(key, serializer(valueRef.current));
             } catch (e) {
@@ -47,6 +48,40 @@ export function useDebouncedLocalStorage<T>(
             }
         };
     }, [key, value, serializer, delay]);
+
+    // Flush any pending debounced write synchronously when the page is being
+    // unloaded (hard reload, tab close, or backgrounding). The React unmount
+    // cleanup below does NOT run on a real browser unload, so without this a
+    // value changed within the debounce window would be lost.
+    useEffect(() => {
+        const flush = () => {
+            if (timeoutRef.current === null) {
+                // No pending write — nothing to flush.
+                return;
+            }
+            clearTimeout(timeoutRef.current);
+            timeoutRef.current = null;
+            try {
+                localStorage.setItem(keyRef.current, serializerRef.current(valueRef.current));
+            } catch (e) {
+                console.error('Failed to flush localStorage on page unload:', e);
+            }
+        };
+
+        const onVisibilityChange = () => {
+            if (document.visibilityState === 'hidden') {
+                flush();
+            }
+        };
+
+        window.addEventListener('pagehide', flush);
+        document.addEventListener('visibilitychange', onVisibilityChange);
+
+        return () => {
+            window.removeEventListener('pagehide', flush);
+            document.removeEventListener('visibilitychange', onVisibilityChange);
+        };
+    }, []);
 
     // Write immediately on unmount to ensure data is not lost
     useEffect(() => {

--- a/src/services/CSVImportService.ts
+++ b/src/services/CSVImportService.ts
@@ -554,6 +554,23 @@ function isTransactionTypeCredit(value: string): boolean {
     return lower === 'credit' || lower === 'cr' || lower === 'c';
 }
 
+// Monotonic fallback counter so that, when crypto.randomUUID is unavailable,
+// ids minted within a single synchronous loop (same Date.now()) never collide.
+let txnIdCounter = 0;
+
+/**
+ * Mint a transaction id that is unique even within a single synchronous
+ * applyMapping call over hundreds of rows. Uses crypto.randomUUID() when
+ * available (jsdom/node both support it); otherwise falls back to a
+ * module-level monotonic counter combined with Date.now().
+ */
+function newTransactionId(): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return `TXN-${crypto.randomUUID()}`;
+    }
+    return `TXN-${Date.now()}-${txnIdCounter++}`;
+}
+
 /**
  * Apply mapping to convert CSV rows to transactions
  */
@@ -645,7 +662,7 @@ export function applyMapping(
         }
 
         transactions.push({
-            id: `TXN-${Date.now()}-${Math.floor(Math.random() * 10000)}`,
+            id: newTransactionId(),
             date,
             description: description.trim(),
             amount,
@@ -818,9 +835,19 @@ export function applyCategories(
         if (!isCategorizable) return txn;
 
         for (const rule of rules) {
-            const matches = rule.isRegex
-                ? new RegExp(rule.pattern, 'i').test(txn.description)
-                : txn.description.toLowerCase().includes(rule.pattern.toLowerCase());
+            let matches: boolean;
+            if (rule.isRegex) {
+                // A saved rule may carry an invalid pattern (e.g. "(" or "[a-").
+                // Treat an uncompilable regex as a non-match instead of letting
+                // the SyntaxError abort categorization of the entire import.
+                try {
+                    matches = new RegExp(rule.pattern, 'i').test(txn.description);
+                } catch {
+                    matches = false;
+                }
+            } else {
+                matches = txn.description.toLowerCase().includes(rule.pattern.toLowerCase());
+            }
 
             if (matches) {
                 autoCategorizedCount++;

--- a/src/services/SSAImportService.ts
+++ b/src/services/SSAImportService.ts
@@ -140,7 +140,10 @@ export function validateEarningsImport(
     warnings.push(`Found ${futureEarnings.length} future year(s) which will be ignored`);
   }
 
-  return { valid: warnings.length === 0, warnings };
+  // `valid` reflects only truly blocking conditions. Having no valid records
+  // is the sole hard block (handled above); all other warnings are advisory and
+  // must NOT block the import.
+  return { valid: earnings.length > 0, warnings };
 }
 
 /**

--- a/src/services/backupMerge.ts
+++ b/src/services/backupMerge.ts
@@ -133,9 +133,15 @@ export function makeTransaction(input: NewTransactionInput): Transaction {
 
 // --- Small helpers (mirror the app) ---
 
+// Monotonic counter so several months created in one synchronous tick get
+// distinct ids (Date.now() only has ms resolution).
+let monthIdCounter = 0;
 function generateMonthId(): string {
     // Mirrors BudgetContext.generateId('MONTH').
-    return `MONTH-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return `MONTH-${crypto.randomUUID()}`;
+    }
+    return `MONTH-${Date.now()}-${monthIdCounter++}-${Math.floor(Math.random() * 1000)}`;
 }
 
 function localToday(): string {

--- a/src/services/simulation/AccountGrowth.ts
+++ b/src/services/simulation/AccountGrowth.ts
@@ -149,7 +149,13 @@ export function processInflows(
                     discountAmount
                 };
 
-                withdrawalState.userInflows[esppAccount.id] = (withdrawalState.userInflows[esppAccount.id] || 0) + (reducedShares * fmvAtPurchase);
+                // NOTE: do NOT write the purchase FMV into userInflows[esppId].
+                // The ESPP balance is updated via addLot (esppLots) in growAccounts,
+                // not via userInflows. userInflows[esppId] is reserved for the NET
+                // SALE signal that SimulationEngine records as a negative entry — a
+                // positive purchase write here would net against a same-year sale and
+                // mask it (PR #56 #3). Cash deployed into ESPP is tracked separately
+                // via the WorkIncome contribution, not this field.
                 totalESPPFMVThisYear += remainingFMV;
 
                 if (!esppLots[esppAccount.id]) esppLots[esppAccount.id] = [];
@@ -167,7 +173,8 @@ export function processInflows(
                     discountAmount
                 };
 
-                withdrawalState.userInflows[esppAccount.id] = (withdrawalState.userInflows[esppAccount.id] || 0) + fmvOfShares;
+                // See note above: the purchase reaches the balance via addLot, so
+                // we must NOT add it to userInflows (it would mask a same-year sale).
                 totalESPPFMVThisYear += fmvOfShares;
 
                 if (!esppLots[esppAccount.id]) esppLots[esppAccount.id] = [];

--- a/src/services/simulation/AccountGrowth.ts
+++ b/src/services/simulation/AccountGrowth.ts
@@ -62,19 +62,33 @@ export function processInflows(
             // this income's new contributions, so multiple incomes feeding one
             // account share a single limit.
             const limit415c = get415cLimit(year, currentAge, assumptions.macro.inflationAdjusted);
+            let trimmedSelf = selfContribution;
             const totalAdditions = currentSelf + currentMatch + selfContribution + employerMatch;
             if (totalAdditions > limit415c) {
                 const excess = totalAdditions - limit415c;
+                // Trim the employer match first — the employee's own deferrals are
+                // already §402(g)-capped and are the participant's money.
                 const trimmedMatch = Math.max(0, employerMatch - excess);
                 if (trimmedMatch < employerMatch) {
                     logs.push(`[WARN] §415(c) limit: ${inc.name} employer match reduced by $${(employerMatch - trimmedMatch).toLocaleString(undefined, { maximumFractionDigits: 0 })} to stay within combined $${limit415c.toLocaleString()} 401k limit`);
                 }
+                const matchReduction = employerMatch - trimmedMatch;
                 employerMatch = trimmedMatch;
+
+                // If the match couldn't absorb all of the excess (e.g. multiple
+                // incomes feed this account and their combined EMPLOYEE deferrals
+                // alone exceed §415(c)), trim this income's employee deferral too —
+                // as a last resort — so the account is never over-funded (PR #56 #5).
+                const remainingExcess = Math.max(0, excess - matchReduction);
+                if (remainingExcess > 0) {
+                    trimmedSelf = Math.max(0, selfContribution - remainingExcess);
+                    logs.push(`[WARN] §415(c) limit: ${inc.name} employee deferral reduced by $${(selfContribution - trimmedSelf).toLocaleString(undefined, { maximumFractionDigits: 0 })} to stay within combined $${limit415c.toLocaleString()} 401k limit`);
+                }
             }
 
             totalEmployerMatch += employerMatch;
 
-            withdrawalState.userInflows[inc.matchAccountId] = currentSelf + selfContribution;
+            withdrawalState.userInflows[inc.matchAccountId] = currentSelf + trimmedSelf;
             withdrawalState.employerInflows[inc.matchAccountId] = currentMatch + employerMatch;
         }
     });

--- a/src/services/simulation/IncomeProjection.ts
+++ b/src/services/simulation/IncomeProjection.ts
@@ -1,7 +1,7 @@
 import { AnyIncome, WorkIncome, FutureSocialSecurityIncome, FERSPensionIncome, CSRSPensionIncome, PassiveIncome } from "../../components/Objects/Income/models";
 import { AnyAccount, SavedAccount } from "../../components/Objects/Accounts/models";
 import { AssumptionsState, getRetirementAge, getLifeExpectancy, getBirthYear } from "../../components/Objects/Assumptions/AssumptionsContext";
-import { calculateHigh3, checkFERSEligibility, checkCSRSEligibility, calculateFERSBasicBenefit, calculateCSRSBasicBenefit } from "../../data/PensionData";
+import { calculateHigh3, checkFERSEligibility, checkCSRSEligibility, calculateFERSBasicBenefit, calculateCSRSBasicBenefit, calculateFERSSupplement } from "../../data/PensionData";
 import { calculateAIME, extractEarningsFromSimulation, calculateEarningsTestReduction } from "../SocialSecurityCalculator";
 import { getFRA } from "../../data/SocialSecurityData";
 import * as TaxService from "../../components/Objects/Taxes/TaxService";
@@ -104,16 +104,29 @@ export function projectIncomes(
                     const reductionFactor = 1 - (eligibility.reductionPercent / 100);
                     const actualBenefit = baseBenefit * reductionFactor;
 
+                    // Auto-compute the FERS MRA-to-62 supplement on activation. Auto
+                    // pensions leave `fersSupplement` at its default 0, so deriving it
+                    // here mirrors the model's getSupplement(): estimatedSSAt62 is stored
+                    // as an ANNUAL figure and divided by 12 to feed the monthly-input
+                    // calculateFERSSupplement. The model's increment() COLA-grows this
+                    // value and zeroes it at 62, so it only needs to be correct now.
+                    const supplement = inc.retirementAge < 62
+                        ? calculateFERSSupplement(inc.yearsOfService, inc.estimatedSSAt62 / 12)
+                        : 0;
+
                     logs.push(`[PENSION] FERS Pension started: High-3 calculated as $${high3.toLocaleString()}/yr from ${salaryHistory.length} years of salary history`);
                     if (eligibility.reductionPercent > 0) {
                         logs.push(`   Base benefit: $${baseBenefit.toLocaleString()}/yr, reduced by ${eligibility.reductionPercent}% (${eligibility.message})`);
                     }
                     logs.push(`   Annual benefit: $${actualBenefit.toLocaleString()}/yr`);
+                    if (supplement > 0) {
+                        logs.push(`[PENSION] FERS Supplement (MRA-to-62): $${supplement.toLocaleString()}/yr until age 62`);
+                    }
 
                     return new FERSPensionIncome(
                         inc.id, inc.name, inc.yearsOfService, high3,
                         inc.retirementAge, inc.birthYear, actualBenefit,
-                        inc.fersSupplement, inc.estimatedSSAt62,
+                        supplement, inc.estimatedSSAt62,
                         inc.startDate, inc.end_date,
                         inc.autoCalculateHigh3, inc.linkedIncomeId,
                         inc.startMilestoneId, inc.endMilestoneId

--- a/src/services/simulation/IncomeProjection.ts
+++ b/src/services/simulation/IncomeProjection.ts
@@ -275,7 +275,22 @@ export function projectIncomes(
 
             if (currentAge < fra) {
                 const earnedIncome = TaxService.getEarnedIncome(nextIncomes, year);
-                const annualSSBenefit = inc.getProratedAnnual(inc.amount, year);
+                // Base the earnings-test withholding on the FULL benefit, NOT the running
+                // `inc.amount`. inc.amount = calculatedPIA × 12, and the earnings-test
+                // rebuild below stores the reduced monthly benefit back into calculatedPIA;
+                // next year's increment() carries that reduced value forward. If we
+                // recomputed off inc.amount each year, the withholding would re-apply to an
+                // already-reduced base and the payable would ratchet DOWN every year.
+                //
+                // projectedPIA is the full, un-reduced monthly PIA — set equal to
+                // calculatedPIA at activation (see the activation branch above) and
+                // COLA-grown in lockstep by increment() — so it stays the full benefit
+                // across years and yields a STABLE reduction (full − withheld). It is
+                // monthly, so ×12 to match inc.amount's annual basis. Fall back to
+                // inc.amount when projectedPIA is unset (0), e.g. an income constructed
+                // without it, so the single-year reduction still applies in that case.
+                const fullMonthlyPIA = inc.projectedPIA > 0 ? inc.projectedPIA : inc.amount / 12;
+                const annualSSBenefit = inc.getProratedAnnual(fullMonthlyPIA * 12, year);
                 const wageGrowthRate = assumptions.macro.inflationRate / 100;
                 const inflationAdjusted = assumptions.macro.inflationAdjusted;
 

--- a/src/services/simulation/IncomeProjection.ts
+++ b/src/services/simulation/IncomeProjection.ts
@@ -55,7 +55,7 @@ export function projectIncomes(
                 inc.taxType,
                 inc.contributionGrowthStrategy,
                 inc.startDate,
-                new Date(Date.UTC(retirementYear - 1, 11, 31)),
+                new Date(retirementYear - 1, 11, 31),
                 0, // hsaContribution
                 inc.autoMax401k,
                 inc.esppContributionType,
@@ -215,17 +215,17 @@ export function projectIncomes(
                     if (currentAge === inc.claimingAge) {
                         // At claiming age - activate the income
                         // Set both calculatedPIA (feeds amount) and projectedPIA
-                        const endDate = new Date(Date.UTC(
+                        const endDate = new Date(
                             birthYear + getLifeExpectancy(assumptions.milestones),
                             11, 31
-                        ));
+                        );
                         return new FutureSocialSecurityIncome(
                             inc.id,
                             inc.name,
                             inc.claimingAge,
                             adjustedMonthlyBenefit,  // calculatedPIA - activates income (amount = PIA * 12)
                             year,
-                            new Date(Date.UTC(year, 0, 1)),
+                            new Date(year, 0, 1),
                             endDate,
                             inc.startMilestoneId,
                             inc.endMilestoneId,
@@ -236,7 +236,7 @@ export function projectIncomes(
                         // calculatedPIA = 0 so amount stays 0 (income not yet active)
                         // projectedPIA = calculated value for Roth conversion planning
                         const claimingYear = birthYear + inc.claimingAge;
-                        const futureStartDate = new Date(Date.UTC(claimingYear, 0, 1));
+                        const futureStartDate = new Date(claimingYear, 0, 1);
                         return new FutureSocialSecurityIncome(
                             inc.id,
                             inc.name,
@@ -343,12 +343,11 @@ export function projectIncomes(
                     'Annually',
                     'No',
                     'Interest',
-                    // Use UTC so getIncomeActiveMultiplier (which reads getUTC*) sees a
-                    // clean full-calendar-year active window (multiplier = 1.0). Local
-                    // new Date(year, ...) shifts into the prior/next year in +UTC zones,
-                    // mis-prorating this full-year reinvested income.
-                    new Date(Date.UTC(year, 0, 1)),
-                    new Date(Date.UTC(year, 11, 31)),
+                    // Build LOCAL date-only values (the repo convention). getIncomeActiveMultiplier
+                    // now reads dates with local accessors, so a local Jan-1..Dec-31 window
+                    // yields a clean full-calendar-year multiplier (1.0) in any timezone.
+                    new Date(year, 0, 1),
+                    new Date(year, 11, 31),
                     true  // isReinvested
                 ));
             }

--- a/src/services/simulation/MilestoneEvaluator.ts
+++ b/src/services/simulation/MilestoneEvaluator.ts
@@ -127,8 +127,8 @@ export function calculateAnnualExpenses(expenses: AnyExpense[], year: number): n
 
     expenses.forEach(expense => {
         // Check if expense is active in this year
-        const startYear = expense.startDate ? expense.startDate.getUTCFullYear() : 0;
-        const endYear = expense.endDate ? expense.endDate.getUTCFullYear() : 9999;
+        const startYear = expense.startDate ? expense.startDate.getFullYear() : 0;
+        const endYear = expense.endDate ? expense.endDate.getFullYear() : 9999;
 
         if (year >= startYear && year <= endYear) {
             if (expense instanceof MortgageExpense) {

--- a/src/services/simulation/RothConversionDP.ts
+++ b/src/services/simulation/RothConversionDP.ts
@@ -430,19 +430,22 @@ export function buildDPYearContexts(
         // withdrawalDetail no longer includes RMD (RMD is surfaced as income), so the
         // trad withdrawal sum is already RMD-free — no subtraction needed.
         const tradNonRMDWithdrawals = sumTraditionalWithdrawals(simYear);
-        const baselineRMDAmount = simYear.rmdDetails?.totalRMD ?? 0;
 
-        // getGrossIncome includes RMD (PassiveIncome with sourceType='RMD') but
-        // excludes conversions and non-RMD trad withdrawals. We want
+        // The stored `simYear.incomes` already EXCLUDES RMD-sourced PassiveIncome
+        // (SimulationEngine filters it out of the returned year), so
+        // getGrossIncome(incomes) is already RMD-free. It also excludes
+        // conversions and non-RMD trad withdrawals. Subtracting SS leaves the
         // plan-INDEPENDENT ordinary-on-return — wages/pension/passive — EXCLUDING
         // RMD, SS, conversion, AND baseline trad withdrawals. RMD, conversion,
         // and trad-spending are added back inside evaluateCell using state-derived
         // amounts (Phase 3 makes trad-spending endogenous; Phase 2 leaves a
         // brief inconsistency where the 2D solver under-counts ordinary income
-        // in trad-spending years).
+        // in trad-spending years). NOTE: do NOT subtract rmdDetails.totalRMD here
+        // — that would remove RMD a second time and wrongly zero out ordinary
+        // income in post-RMD years where RMD > wages/pension.
         const nonSSOrdinaryIncomeExclRMD = Math.max(
             0,
-            grossIncome - ssBenefits - baselineRMDAmount,
+            grossIncome - ssBenefits,
         );
         const ltcgIncome = simYear.taxDetails.longTermCapitalGains ?? 0;
 

--- a/src/services/simulation/TaxOptimizedWithdrawal.ts
+++ b/src/services/simulation/TaxOptimizedWithdrawal.ts
@@ -1036,13 +1036,15 @@ export function calculateDynamicConversionCeiling(
     const projectedRMD = rmdDivisor > 0 ? effectiveProjectedBalance / rmdDivisor : 0;
     const projectedTaxableSS = TaxService.getTaxableSocialSecurityBenefits(
         effectiveSsAtRMD,
-        effectivePensionAtRMD + projectedRMD,
+        effectivePensionAtRMD + projectedRMD + effectivePassiveIncomeAtRMD,
         0,
         taxState.filingStatus
     );
     // Same units fix as peakRMDBracket: projectedRMD/SS/pension are in RMD-year
     // nominal dollars, so look up brackets in RMD-year params when available.
-    const projectedTaxableIncome = projectedRMD + effectivePensionAtRMD + projectedTaxableSS - peakBracketTaxParams.standardDeduction;
+    // Include passive income (rental/dividends) to match peakTaxableIncome — it
+    // was previously dropped here, understating the projected RMD bracket.
+    const projectedTaxableIncome = projectedRMD + effectivePensionAtRMD + effectivePassiveIncomeAtRMD + projectedTaxableSS - peakBracketTaxParams.standardDeduction;
     const projectedRMDBracket = TaxService.getMarginalTaxRate(Math.max(0, projectedTaxableIncome), peakBracketTaxParams).rate;
 
     return {

--- a/src/services/simulation/TaxOptimizedWithdrawal.ts
+++ b/src/services/simulation/TaxOptimizedWithdrawal.ts
@@ -856,8 +856,6 @@ export function projectBalanceAtRMD(
  * @param pensionIncomeAtRMD - Non-SS fixed income at RMD age (pensions, annuities)
  * @param ssAtRMD - Social Security benefits at RMD age
  * @param currentAGI - This year's AGI (excluding SS)
- * @param socialSecurityThisYear - This year's SS benefits
- * @param ltcgIncome - Long-term capital gains (for bump zone detection)
  * @param growthRate - Expected annual growth rate
  * @param rmdStartAge - Age at which RMDs begin (72, 73, or 75 based on birth year)
  * @param taxParams - Federal tax parameters
@@ -871,14 +869,10 @@ export function calculateDynamicConversionCeiling(
     ssAtRMD: number,
     passiveIncomeAtRMD: number,
     currentAGI: number,
-    _socialSecurityThisYear: number,
-    _ltcgIncome: number,
     growthRate: number,
     rmdStartAge: number,
     taxParams: TaxParameters,
     taxState: TaxState,
-    _stateParams: TaxParameters | null = null,
-    _acaOptions?: ACAOptions,
     baselineProjections?: BaselineProjections,
     /**
      * Simulation assumptions. When provided, the peak-RMD bracket lookup uses
@@ -1015,7 +1009,7 @@ export function calculateDynamicConversionCeiling(
     );
 
     const ceiling = rateMatchResult.topConversionRate;
-    let bracketSpacePerYear = rateMatchResult.optimalConversion;
+    const bracketSpacePerYear = rateMatchResult.optimalConversion;
 
     // Subsequent SS-torpedo / ACA / LTCG-bump logic (downstream in YearSolver) may
     // further reduce this; rate-match output is the rate-arbitrage optimum.

--- a/src/services/simulation/TaxOptimizedWithdrawal.ts
+++ b/src/services/simulation/TaxOptimizedWithdrawal.ts
@@ -13,7 +13,7 @@ import { TaxParameters, FilingStatus } from '../../data/TaxData';
 import * as TaxService from '../../components/Objects/Taxes/TaxService';
 import { TaxState } from '../../components/Objects/Taxes/TaxContext';
 import { AssumptionsState, getBirthYear } from '../../components/Objects/Assumptions/AssumptionsContext';
-import { calculateEffectiveConversionTax, ACAOptions } from './helpers';
+import { calculateEffectiveConversionTax, computeConversionTaxBaseline, ACAOptions } from './helpers';
 import { getDistributionPeriod } from '../../data/RMDData';
 import { BaselineProjections, RateMatchWalkRow } from './types';
 
@@ -220,6 +220,17 @@ export function getEffectiveConversionRate(
     stateParams: TaxParameters | null,
     acaOptions?: ACAOptions
 ): number {
+    // The "before" tax positions are conversion-independent, so compute them once
+    // and reuse for both probes instead of recomputing inside each call.
+    const baseline = computeConversionTaxBaseline(
+        ordinaryIncome,
+        socialSecurity,
+        ltcgIncome,
+        taxState.filingStatus,
+        taxParams,
+        stateParams,
+    );
+
     // Calculate total cost of converting conversionAmount
     // taxIncrease includes federal tax increase + state tax + ACA subsidy loss
     const resultAtAmount = calculateEffectiveConversionTax(
@@ -230,7 +241,8 @@ export function getEffectiveConversionRate(
         taxState.filingStatus,
         taxParams,
         stateParams,
-        acaOptions
+        acaOptions,
+        baseline,
     );
 
     // Calculate total cost of converting conversionAmount + $1
@@ -242,7 +254,8 @@ export function getEffectiveConversionRate(
         taxState.filingStatus,
         taxParams,
         stateParams,
-        acaOptions
+        acaOptions,
+        baseline,
     );
 
     // Marginal rate = difference in total cost for $1 more conversion

--- a/src/services/simulation/TaxOptimizedWithdrawal.ts
+++ b/src/services/simulation/TaxOptimizedWithdrawal.ts
@@ -166,22 +166,6 @@ export function getRMDDivisor(age: number): number {
 // =============================================================================
 
 /**
- * Get the damping factor for conversion calculations based on years until RMD.
- * More aggressive (higher %) when time is short, conservative when time is long.
- *
- * @param yearsUntilRMD - Years remaining until Required Minimum Distributions start
- * @returns Damping factor between 0.15 and 0.50
- */
-export function getDampingFactor(yearsUntilRMD: number): number {
-    if (yearsUntilRMD >= 15) return 0.15;  // Very conservative when lots of time
-    if (yearsUntilRMD >= 10) return 0.20;
-    if (yearsUntilRMD >= 7) return 0.25;
-    if (yearsUntilRMD >= 5) return 0.30;
-    if (yearsUntilRMD >= 3) return 0.40;
-    return 0.50;  // Aggressive when time is very short
-}
-
-/**
  * Get the ACA subsidy cliff threshold (400% FPL) for a given year and filing status.
  * Values should be updated annually when FPL is published (typically January).
  *

--- a/src/services/simulation/WithdrawalPlanner.ts
+++ b/src/services/simulation/WithdrawalPlanner.ts
@@ -600,7 +600,11 @@ export function planWithdrawals(
         const effectiveVestedBalance = snapshot.vestedBalance - acaAlreadyConsumed;
         if (effectiveVestedBalance <= 0) continue;
 
-        const ltcgRate = getLTCGRate(runningOrdinaryIncome);
+        // LTCG stacks on top of ordinary income AND on top of gains already
+        // realized earlier in this pass, so position the rate lookup above
+        // cumulativeLTCG — otherwise each successive gain-bearing account re-uses
+        // the 0% floor as if no gains had been realized yet.
+        const ltcgRate = getLTCGRate(runningOrdinaryIncome + cumulativeLTCG);
         const marginalRate = getMarginalRate(runningOrdinaryIncome) + getStateRate(runningOrdinaryIncome);
 
         let withdrawal: PlannedWithdrawal;
@@ -1069,6 +1073,8 @@ export function planWithdrawals(
                         gross: grossToWithdraw,
                         net: netReceived,
                         capitalGains: { shortTerm: 0, longTerm: esppLTCG },
+                        ordinaryIncome: esppOrdinaryIncome,
+                        ordinaryTax,
                         penalty: 0,
                         tax: actualTax,
                         reason,

--- a/src/services/simulation/WithdrawalPlanner.ts
+++ b/src/services/simulation/WithdrawalPlanner.ts
@@ -253,7 +253,7 @@ function grossUpSavings(netNeeded: number): { gross: number; tax: number; penalt
  * Calculate gross withdrawal needed for a given net from brokerage.
  * Uses algebraic formula: gross = net / (1 - gainRatio × ltcgRate)
  */
-function grossUpBrokerage(
+export function grossUpBrokerage(
     netNeeded: number,
     gainRatio: number,
     ltcgRate: number
@@ -263,8 +263,10 @@ function grossUpBrokerage(
         return { gross: netNeeded, tax: 0, ltcg: 0 };
     }
 
+    // Floor the divisor (mirrors the Roth/HSA/ESPP gross-ups) so a pathological
+    // ~100% effective rate can't divide by zero / explode. No-op for real rates.
     const effectiveRate = gainRatio * ltcgRate;
-    const gross = netNeeded / (1 - effectiveRate);
+    const gross = netNeeded / grossUpDivisor(effectiveRate);
     const ltcg = gross * gainRatio;
     const tax = ltcg * ltcgRate;
 

--- a/src/services/simulation/WithdrawalService.ts
+++ b/src/services/simulation/WithdrawalService.ts
@@ -2,7 +2,6 @@ import { AnyAccount, DeficitDebtAccount } from "../../components/Objects/Account
 
 export interface DeficitDebtResult {
     existingDeficitDebt: DeficitDebtAccount | undefined;
-    deficitDebtPayment: number;
     discretionaryCash: number;
     logs: string[];
 }
@@ -17,7 +16,6 @@ export function processDeficitDebt(
 ): DeficitDebtResult {
     const DEFICIT_DEBT_ID = 'system-deficit-debt';
     const DEFICIT_DEBT_NAME = 'Uncovered Deficit';
-    let deficitDebtPayment = 0;
 
     let existingDeficitDebt = accounts.find(
         acc => acc instanceof DeficitDebtAccount && acc.id === DEFICIT_DEBT_ID
@@ -47,5 +45,5 @@ export function processDeficitDebt(
         discretionaryCash = 0;
     }
 
-    return { existingDeficitDebt, deficitDebtPayment, discretionaryCash, logs };
+    return { existingDeficitDebt, discretionaryCash, logs };
 }

--- a/src/services/simulation/YearSolver.ts
+++ b/src/services/simulation/YearSolver.ts
@@ -35,7 +35,7 @@ import {
 } from "./types";
 import { WithdrawalResult } from "../WithdrawalStrategies";
 import { classifyIncome, getTotalSSBenefits } from "./IncomeClassifier";
-import { planWithdrawals, createOrderedSnapshots } from "./WithdrawalPlanner";
+import { planWithdrawals, createOrderedSnapshots, grossUpBrokerage } from "./WithdrawalPlanner";
 import * as TaxService from "../../components/Objects/Taxes/TaxService";
 import { getLTCGRate } from "../../components/Objects/Taxes/taxService/capitalGainsTax";
 import { calculateEffectiveConversionTax, ACAOptions } from "./helpers";
@@ -240,9 +240,9 @@ const getLTCGRateForIncome = getLTCGRate;
 function estimateLTCGFromDeficit(deficit: number, gainRatio: number, ltcgRate: number = 0): number {
     if (deficit <= 0 || gainRatio <= 0) return 0;
 
-    const effectiveRate = gainRatio * ltcgRate;
-    const grossWithdrawal = effectiveRate < 1 ? deficit / (1 - effectiveRate) : deficit;
-    return grossWithdrawal * gainRatio;
+    // Delegate to the authoritative brokerage sizer so this ACA-cliff prediction
+    // can't drift from how the withdrawal planner actually realizes LTCG.
+    return grossUpBrokerage(deficit, gainRatio, ltcgRate).ltcg;
 }
 
 // =============================================================================

--- a/src/services/simulation/YearSolver.ts
+++ b/src/services/simulation/YearSolver.ts
@@ -17,8 +17,6 @@
 
 import { AnyAccount, InvestedAccount } from "../../components/Objects/Accounts/models";
 import { AnyIncome, FERSPensionIncome } from "../../components/Objects/Income/models";
-// AnyExpense is currently unused but kept for future extension
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { AnyExpense } from "../../components/Objects/Expense/models";
 import { TaxParameters } from "../../data/TaxData";
 import { TaxState } from "../../components/Objects/Taxes/TaxContext";
@@ -701,11 +699,16 @@ function planConversion(
             // 4. Total ordinary tax (same as solver line 732)
             const ordinaryTax = ordinaryTaxResult.totalTax + stateTax;
 
-            // 5. Calculate base deficit using SAME formula as solver
+            // 5. Calculate base deficit using the SAME formula as the solver.
             // Note: ordinaryTax already includes conversion tax (via allOrdinaryIncome),
             // so no separate adjustment needed for taxSource='BROKERAGE'.
+            // classifyIncome already folds rmdAmount into spendableIncome, so it must
+            // NOT be subtracted again here — the authoritative loop deficit and the
+            // preliminaryDeficit both omit it. Subtracting it understated the deficit
+            // (and thus estimated LTCG and MAGI), letting the ACA-cliff search permit
+            // a conversion that breached the cliff.
             const estimatedDeficit = Math.max(0,
-                input.totalLivingExpenses + ordinaryTax + ficaTax - spendableIncome - input.rmdAmount
+                input.totalLivingExpenses + ordinaryTax + ficaTax - spendableIncome
             );
 
             // 6. Calculate LTCG using gross-up formula
@@ -855,7 +858,7 @@ function planConversion(
 
     // Determine tax payment source
     let taxSource: ConversionTaxSource = 'SURPLUS';
-    let netToRoth = conversionAmount;
+    const netToRoth = conversionAmount;
 
     const brokerageBalance = getTotalBrokerageBalance(input.accounts);
 
@@ -1050,13 +1053,6 @@ function planConversionDP(
                         `marginal rate ${(marginalResult.rate * 100).toFixed(1)}% ` +
                         `vs ${(conversionCeiling * 100).toFixed(0)}% ceiling).`,
                 });
-            } else {
-                decisions.push({
-                    category: 'conversion',
-                    description: `[DEBUG DP exec] year=${input.year}: spending reservation skipped — ` +
-                        `marginal ${(marginalResult.rate * 100).toFixed(1)}% > ceiling ${(conversionCeiling * 100).toFixed(0)}%; ` +
-                        `Roth-bound deficit $${Math.round(rothBoundDeficit).toLocaleString()} stays Roth-funded.`,
-                });
             }
         }
     }
@@ -1066,32 +1062,6 @@ function planConversionDP(
     const availableTradForConversion = Math.max(0, traditionalBalance - bracketSpaceForSpending);
     const targetConversion = input.dpConversionPlan?.get(input.year) ?? 0;
     const conversionAmount = Math.max(0, Math.min(targetConversion, availableTradForConversion));
-
-    // Log real-sim balances side-by-side with DP's projection so we can spot
-    // when DP's forward-sweep state diverges from reality.
-    const realRothBalance = input.accounts
-        .filter(a => a instanceof InvestedAccount && a.taxType === 'Roth IRA')
-        .reduce((sum, a) => sum + (a as InvestedAccount).vestedAmount, 0);
-    const realBrokerageBalance = getTotalBrokerageBalance(input.accounts);
-    decisions.push({
-        category: 'conversion',
-        description:
-            `[DEBUG DP exec] year=${input.year}: plan-lookup=${'$' + Math.round(targetConversion).toLocaleString()}, ` +
-            `traditional=${'$' + Math.round(traditionalBalance).toLocaleString()}, ` +
-            `bracketSpaceForSpending=${'$' + Math.round(bracketSpaceForSpending).toLocaleString()}, ` +
-            `availableTrad=${'$' + Math.round(availableTradForConversion).toLocaleString()}, ` +
-            `clampedAmount=${'$' + Math.round(conversionAmount).toLocaleString()}, ` +
-            `dpPlanProvided=${input.dpConversionPlan ? 'yes' : 'no'}`,
-    });
-    decisions.push({
-        category: 'conversion',
-        description:
-            `[DEBUG DP reality] year=${input.year}: ` +
-            `realTrad=${'$' + Math.round(traditionalBalance).toLocaleString()}, ` +
-            `realRoth=${'$' + Math.round(realRothBalance).toLocaleString()}, ` +
-            `realBrokerage=${'$' + Math.round(realBrokerageBalance).toLocaleString()} ` +
-            `— compare against [DEBUG DP solver] tradEntering and [DEBUG DP baseline] for divergence.`,
-    });
 
     if (conversionAmount <= 0) {
         // Spending reservation may still be nonzero — preserve it via skipReturn.
@@ -1338,7 +1308,11 @@ export function solveRetirementYear(input: YearSolverInput): YearPlan {
         fedParams
     ).totalTax;
     const roughStateTax = stateParams
-        ? TaxService.calculateTax(baseOrdinaryIncome, roughPreTaxDeductions, stateParams)
+        // State tax excludes Social Security (DC and all modeled states exempt
+        // it), mirroring the authoritative state calc below. baseOrdinaryIncome
+        // folds in taxable SS, so use the non-SS ordinary income — the same base
+        // the rough federal calc above uses.
+        ? TaxService.calculateTax(taxableBase - socialSecurityBenefits, roughPreTaxDeductions, stateParams)
         : 0;
     const roughFica = TaxService.calculateFicaTax(input.taxState, input.incomes, input.year, input.assumptions);
     const roughTax = roughFedTax + roughStateTax + roughFica;
@@ -1549,6 +1523,7 @@ export function solveRetirementYear(input: YearSolverInput): YearPlan {
     // Convergence: SS taxable is piecewise-linear and monotonic, so 2-4 iterations.
     let estimatedLTCG = 0;
     let estimatedTradWithdrawal = 0;
+    let estimatedESPPOrdinaryIncome = 0;
 
     // Initial federal tax: SS taxable computed without Traditional withdrawal
     // Pass allOrdinaryIncome (which includes taxable SS) with SS=0 to skip internal SS calc
@@ -1575,7 +1550,7 @@ export function solveRetirementYear(input: YearSolverInput): YearPlan {
             // AGI excluding SS includes: base income + conversion + Trad withdrawal + LTCG.
             const updatedSSTaxable = TaxService.getTaxableSocialSecurityBenefits(
                 socialSecurityBenefits,
-                nonSSBaseIncome + conversionAdded + estimatedTradWithdrawal + estimatedLTCG,
+                nonSSBaseIncome + conversionAdded + estimatedTradWithdrawal + estimatedESPPOrdinaryIncome + estimatedLTCG,
                 0,
                 input.taxState.filingStatus
             );
@@ -1646,9 +1621,11 @@ export function solveRetirementYear(input: YearSolverInput): YearPlan {
             ...withdrawals.filter(w => w.reason === 'Required Minimum Distribution'), // Keep RMD
             ...withdrawalResult.withdrawals,
         ];
+        // Ordinary withdrawal tax = the full tax of ordinary-only withdrawals
+        // (Traditional/HSA/Roth, capitalGains undefined) PLUS the ordinary
+        // portion of mixed withdrawals (ESPP bargain element, ordinaryTax set).
         withdrawalOrdinaryTax = withdrawalResult.withdrawals
-            .filter(w => w.capitalGains === undefined)
-            .reduce((sum, w) => sum + w.tax, 0);
+            .reduce((sum, w) => sum + (w.capitalGains === undefined ? w.tax : (w.ordinaryTax ?? 0)), 0);
         totalPenalties = withdrawalResult.totalPenalties;
         withdrawalDecisions = withdrawalResult.decisions;
         iterations = iter + 1;
@@ -1658,6 +1635,13 @@ export function solveRetirementYear(input: YearSolverInput): YearPlan {
         const newTradWithdrawal = withdrawalResult.withdrawals
             .filter(w => w.source === 'traditional_401k' || w.source === 'traditional_ira')
             .reduce((sum, w) => sum + w.gross, 0);
+
+        // ESPP bargain-element ordinary income drives SS taxability like a
+        // Traditional withdrawal. Its tax is reported via withdrawalOrdinaryTax,
+        // so it is NOT folded into allOrdinaryIncome's federal base (which would
+        // double-count the tax) — only into the SS-taxability combined income.
+        estimatedESPPOrdinaryIncome = withdrawalResult.withdrawals
+            .reduce((sum, w) => sum + (w.ordinaryIncome ?? 0), 0);
 
         // Check convergence: both LTCG and Traditional withdrawal (which drives SS taxable) must stabilize
         const newLTCG = withdrawalResult.totalLTCG;
@@ -1712,9 +1696,12 @@ export function solveRetirementYear(input: YearSolverInput): YearPlan {
     // The deficit already included LTCG (via finalFedResult.totalTax), so the gross withdrawal
     // is deficit + ltcgTax. Counting that full gross as spendable cash-in would create a phantom
     // surplus equal to ltcgTax. Subtract it so only the net (post-tax) portion is cash-in.
+    // LTCG pass-through tax = the LTCG portion of capital-gains withdrawals.
+    // For ESPP, exclude the bargain-element ordinary tax (ordinaryTax) — that is
+    // reported via withdrawalOrdinaryTax, not subtracted from cash-in here.
     const actualLTCGTax = withdrawals
         .filter(w => w.capitalGains !== undefined)
-        .reduce((sum, w) => sum + w.tax, 0);
+        .reduce((sum, w) => sum + (w.tax - (w.ordinaryTax ?? 0)), 0);
 
     const cashIn =
         incomeClassification.classified.spendable +
@@ -1892,6 +1879,7 @@ export function solveWorkingYear(input: YearSolverInput): YearPlan {
     let ltcgTax = 0;
     let withdrawalOrdinaryTax = 0;
     let totalPenalties = 0;
+    let niitTax = 0;
 
     if (initialDeficit > 0) {
         const accountSnapshots = createOrderedSnapshots(
@@ -1910,19 +1898,39 @@ export function solveWorkingYear(input: YearSolverInput): YearPlan {
         );
 
         withdrawals = withdrawalResult.withdrawals;
+        // Split mixed (ESPP) withdrawal tax: the LTCG portion → ltcgTax, the
+        // ordinary bargain-element portion → withdrawalOrdinaryTax. Before this
+        // split, ESPP's full tax was mislabeled as capital-gains tax.
         ltcgTax = withdrawalResult.withdrawals
             .filter(w => w.capitalGains !== undefined)
-            .reduce((sum, w) => sum + w.tax, 0);
+            .reduce((sum, w) => sum + (w.tax - (w.ordinaryTax ?? 0)), 0);
         withdrawalOrdinaryTax = withdrawalResult.withdrawals
-            .filter(w => w.capitalGains === undefined)
-            .reduce((sum, w) => sum + w.tax, 0);
+            .reduce((sum, w) => sum + (w.capitalGains === undefined ? w.tax : (w.ordinaryTax ?? 0)), 0);
         totalPenalties = withdrawalResult.totalPenalties;
+
+        // NIIT (3.8%) on capital gains realized to fund the deficit. The federal
+        // tax helper computes it internally from investment income; extract only
+        // the NIIT so the existing planner-based ltcgTax cash handling is kept.
+        const realizedLTCG = withdrawalResult.totalLTCG;
+        const realizedSTCG = withdrawalResult.totalSTCG;
+        if (realizedLTCG > 0 || realizedSTCG > 0) {
+            niitTax = TaxService.calculateTotalFederalTax(
+                taxableOrdinaryBase - socialSecurityBenefits,
+                socialSecurityBenefits,
+                realizedSTCG,
+                realizedLTCG,
+                preTaxDeductions,
+                input.taxState.filingStatus,
+                fedParams
+            ).niitTax;
+        }
+
         decisions.push(...withdrawalResult.decisions);
     }
 
     // Final cash flow including withdrawals
     const totalGrossWithdrawals = withdrawals.reduce((sum, w) => sum + w.gross, 0);
-    const finalTotalTax = totalTax + ltcgTax + withdrawalOrdinaryTax + totalPenalties;
+    const finalTotalTax = totalTax + ltcgTax + withdrawalOrdinaryTax + niitTax + totalPenalties;
 
     const finalCashIn = incomeCashIn + totalGrossWithdrawals;
     const finalCashOut = input.totalLivingExpenses + finalTotalTax;
@@ -1944,7 +1952,7 @@ export function solveWorkingYear(input: YearSolverInput): YearPlan {
         capitalGainsLT: ltcgTax,
         capitalGainsST: 0,
         withdrawalOrdinaryTax,
-        niit: 0,
+        niit: niitTax,
         penalties: totalPenalties,
         total: finalTotalTax,
     };

--- a/src/services/simulation/YearSolver.ts
+++ b/src/services/simulation/YearSolver.ts
@@ -245,6 +245,72 @@ function estimateLTCGFromDeficit(deficit: number, gainRatio: number, ltcgRate: n
     return grossUpBrokerage(deficit, gainRatio, ltcgRate).ltcg;
 }
 
+/**
+ * Compute a conversion's tax cost, its federal/state decomposition, and the
+ * tax-payment source. Shared by planConversion (rate-match) and planConversionDP
+ * so both strategies price an identical conversion identically (they previously
+ * duplicated this block, which risked the two paths silently diverging).
+ */
+function computeConversionTaxAndSource(
+    input: YearSolverInput,
+    baseOrdinaryIncome: number,
+    nonSSOrdinaryIncome: number,
+    socialSecurityBenefits: number,
+    conversionAmount: number,
+    spendingDeficit: number,
+    surplus: number,
+    fedParams: TaxParameters,
+    stateParams: TaxParameters | null,
+    acaOptions: ACAOptions | undefined,
+): { conversionTax: number; conversionFedTax: number; conversionStateTax: number; taxSource: ConversionTaxSource } {
+    // Estimate this year's LTCG so the conversion's displayed Tax Cost reflects
+    // the LTCG bump (brokerage is sold for the spending deficit + conversion tax,
+    // and the LTCG rate rises 0%→15%→20% as ordinary income climbs).
+    const ltcgGainRatio = getBrokerageGainRatio(input.accounts);
+    const ltcgRateAtIncome = getLTCGRateForIncome(baseOrdinaryIncome + conversionAmount, fedParams);
+    const estimatedLTCGForYear = estimateLTCGFromDeficit(
+        Math.max(0, spendingDeficit),
+        ltcgGainRatio,
+        ltcgRateAtIncome,
+    );
+
+    // First arg must be ordinary income EXCLUDING SS — the function re-derives
+    // taxable SS internally from the separate socialSecurityBenefits arg. Passing
+    // baseOrdinaryIncome (which already includes taxable SS) double-counts SS.
+    const conversionTaxResult = calculateEffectiveConversionTax(
+        nonSSOrdinaryIncome,
+        socialSecurityBenefits,
+        estimatedLTCGForYear,
+        conversionAmount,
+        input.taxState.filingStatus,
+        fedParams,
+        stateParams,
+        acaOptions,
+    );
+
+    const conversionTax = conversionTaxResult.taxIncrease;
+    const conversionFedTax = conversionTaxResult.breakdown.federalOrdinaryTaxCost
+        + conversionTaxResult.breakdown.ssTorpedoCost
+        + conversionTaxResult.breakdown.ltcgBumpCost
+        + conversionTaxResult.breakdown.niitCost;
+    const conversionStateTax = conversionTaxResult.breakdown.stateTaxCost;
+
+    // Tax payment source: prefer surplus, then brokerage, else withhold from the
+    // conversion (the spending deficit already includes the conversion tax via
+    // finalFedResult.totalTax, so the full amount still reaches Roth).
+    const brokerageBalance = getTotalBrokerageBalance(input.accounts);
+    let taxSource: ConversionTaxSource;
+    if (surplus >= conversionTax) {
+        taxSource = 'SURPLUS';
+    } else if (brokerageBalance >= conversionTax) {
+        taxSource = 'BROKERAGE';
+    } else {
+        taxSource = 'WITHHOLD';
+    }
+
+    return { conversionTax, conversionFedTax, conversionStateTax, taxSource };
+}
+
 // =============================================================================
 // CONVERSION PLANNING
 // =============================================================================
@@ -820,58 +886,12 @@ function planConversion(
         };
     }
 
-    // Estimate LTCG that the year will realize. Brokerage gets sold for two
-    // reasons: covering this year's spending deficit, and covering the
-    // conversion tax (when taxSource is BROKERAGE). The LTCG bumps the
-    // conversion's tax cost (LTCG rate goes from 0% → 15% / 15% → 20% as
-    // ordinary income rises), so we want it reflected in the displayed
-    // conversionTax. Same formula the ACA-cliff binary-search uses above.
-    const ltcgGainRatio = getBrokerageGainRatio(input.accounts);
-    const ltcgRateAtIncome = getLTCGRateForIncome(baseOrdinaryIncome + conversionAmount, fedParams);
-    const estimatedLTCGForYear = estimateLTCGFromDeficit(
-        Math.max(0, spendingDeficit),
-        ltcgGainRatio,
-        ltcgRateAtIncome,
-    );
-
-    // Calculate conversion tax.
-    // First arg must be ordinary income EXCLUDING SS — the function re-derives
-    // taxable SS internally from the separate socialSecurityBenefits arg. Passing
-    // baseOrdinaryIncome (which already includes taxable SS) double-counts SS.
-    const conversionTaxResult = calculateEffectiveConversionTax(
-        nonSSOrdinaryIncome,
-        socialSecurityBenefits,
-        estimatedLTCGForYear,
-        conversionAmount,
-        input.taxState.filingStatus,
-        fedParams,
-        stateParams,
-        acaOptions
-    );
-
-    const conversionTax = conversionTaxResult.taxIncrease;
-    const conversionFedTax = conversionTaxResult.breakdown.federalOrdinaryTaxCost
-                           + conversionTaxResult.breakdown.ssTorpedoCost
-                           + conversionTaxResult.breakdown.ltcgBumpCost
-                           + conversionTaxResult.breakdown.niitCost;
-    const conversionStateTax = conversionTaxResult.breakdown.stateTaxCost;
-
-    // Determine tax payment source
-    let taxSource: ConversionTaxSource = 'SURPLUS';
+    const { conversionTax, conversionFedTax, conversionStateTax, taxSource } =
+        computeConversionTaxAndSource(
+            input, baseOrdinaryIncome, nonSSOrdinaryIncome, socialSecurityBenefits,
+            conversionAmount, spendingDeficit, surplus, fedParams, stateParams, acaOptions,
+        );
     const netToRoth = conversionAmount;
-
-    const brokerageBalance = getTotalBrokerageBalance(input.accounts);
-
-    if (surplus >= conversionTax) {
-        taxSource = 'SURPLUS';
-    } else if (brokerageBalance >= conversionTax) {
-        taxSource = 'BROKERAGE';
-    } else {
-        // No surplus or brokerage to pay tax — tax is covered by the
-        // spending deficit (which already includes conversion tax via
-        // finalFedResult.totalTax). Full conversion amount reaches Roth.
-        taxSource = 'WITHHOLD';
-    }
 
     // Find source and target accounts
     const sourceAccount = getFirstTraditionalAccount(input.accounts);
@@ -1093,46 +1113,11 @@ function planConversionDP(
         };
     }
 
-    // Estimate this year's LTCG (mirrors the rate-match path) so the
-    // conversion's displayed Tax Cost reflects the LTCG bump.
-    const ltcgGainRatio = getBrokerageGainRatio(input.accounts);
-    const ltcgRateAtIncome = getLTCGRateForIncome(baseOrdinaryIncome + conversionAmount, fedParams);
-    const estimatedLTCGForYear = estimateLTCGFromDeficit(
-        Math.max(0, spendingDeficit),
-        ltcgGainRatio,
-        ltcgRateAtIncome,
-    );
-
-    // First arg must be ordinary income EXCLUDING SS — the function re-derives
-    // taxable SS internally from the separate socialSecurityBenefits arg. Passing
-    // baseOrdinaryIncome (which already includes taxable SS) double-counts SS.
-    const conversionTaxResult = calculateEffectiveConversionTax(
-        nonSSOrdinaryIncome,
-        socialSecurityBenefits,
-        estimatedLTCGForYear,
-        conversionAmount,
-        input.taxState.filingStatus,
-        fedParams,
-        stateParams,
-        acaOptions,
-    );
-    const conversionTax = conversionTaxResult.taxIncrease;
-    const conversionFedTax = conversionTaxResult.breakdown.federalOrdinaryTaxCost
-        + conversionTaxResult.breakdown.ssTorpedoCost
-        + conversionTaxResult.breakdown.ltcgBumpCost
-        + conversionTaxResult.breakdown.niitCost;
-    const conversionStateTax = conversionTaxResult.breakdown.stateTaxCost;
-
-    // Tax payment source selection (same priority as rate-match).
-    const brokerageBalance = getTotalBrokerageBalance(input.accounts);
-    let taxSource: ConversionTaxSource;
-    if (surplus >= conversionTax) {
-        taxSource = 'SURPLUS';
-    } else if (brokerageBalance >= conversionTax) {
-        taxSource = 'BROKERAGE';
-    } else {
-        taxSource = 'WITHHOLD';
-    }
+    const { conversionTax, conversionFedTax, conversionStateTax, taxSource } =
+        computeConversionTaxAndSource(
+            input, baseOrdinaryIncome, nonSSOrdinaryIncome, socialSecurityBenefits,
+            conversionAmount, spendingDeficit, surplus, fedParams, stateParams, acaOptions,
+        );
 
     const conversion: PlannedConversion = {
         amount: conversionAmount,

--- a/src/services/simulation/YearSolver.ts
+++ b/src/services/simulation/YearSolver.ts
@@ -326,7 +326,6 @@ function computeCeilingContext(
     baseOrdinaryIncome: number,
     socialSecurityBenefits: number,
     fedParams: TaxParameters,
-    stateParams: TaxParameters | null,
 ): {
     ceilingResult: ReturnType<typeof calculateDynamicConversionCeiling>;
     rmdStartAge: number;
@@ -412,14 +411,10 @@ function computeCeilingContext(
         fixedIncomeAtRMD.ssAtRMD,
         passiveIncome,
         baseOrdinaryIncome,
-        socialSecurityBenefits,
-        0,
         growthRate,
         rmdStartAge,
         fedParams,
         input.taxState,
-        stateParams,
-        acaOptions,
         input.baselineProjections,
         input.assumptions,
         input.conversionMode ?? 'rate-match'
@@ -516,7 +511,7 @@ function planConversion(
         yearsUntilRMD,
         fixedIncomeAtRMD,
         acaOptions,
-    } = computeCeilingContext(input, baseOrdinaryIncome, socialSecurityBenefits, fedParams, stateParams);
+    } = computeCeilingContext(input, baseOrdinaryIncome, socialSecurityBenefits, fedParams);
 
     // Log ceiling decision so it's visible in the year inspector
     decisions.push({
@@ -1034,7 +1029,7 @@ function planConversionDP(
     const penaltyApplies = input.currentAge < 59.5;
     if (spendingDeficit > 0 && !penaltyApplies) {
         const { ceilingResult } = computeCeilingContext(
-            input, baseOrdinaryIncome, socialSecurityBenefits, fedParams, stateParams,
+            input, baseOrdinaryIncome, socialSecurityBenefits, fedParams,
         );
         const conversionCeiling = ceilingResult.conversionCeiling;
         const bracketSpacePerYear = Math.max(0, ceilingResult.bracketSpacePerYear);

--- a/src/services/simulation/__tests__/TaxOptimizedWithdrawal.test.ts
+++ b/src/services/simulation/__tests__/TaxOptimizedWithdrawal.test.ts
@@ -17,7 +17,6 @@ import {
     SEARCH_CONFIG,
     MAX_CONVERSION_BRACKET,
 } from '../TaxOptimizedWithdrawal';
-import { TaxParameters } from '../../../data/TaxData';
 import { TaxState } from '../../../components/Objects/Taxes/TaxContext';
 import * as TaxService from '../../../components/Objects/Taxes/TaxService';
 import { AssumptionsState, defaultAssumptions, createBuiltinMilestones } from '../../../components/Objects/Assumptions/AssumptionsContext';
@@ -949,13 +948,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0, // passiveIncomeAtRMD
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
-                singleTaxState,
-                null
+                singleTaxState
             );
 
             expect(result.conversionCeiling).toBe(0);
@@ -974,13 +970,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0, // passiveIncomeAtRMD
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
-                singleTaxState,
-                null
+                singleTaxState
             );
 
             expect(result.conversionCeiling).toBe(0);
@@ -1011,13 +1004,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0, // passiveIncomeAtRMD
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
-                singleTaxState,
-                null
+                singleTaxState
             );
 
             // Rate-match algorithm: peak future RMD lands in 12% bracket. From 0%
@@ -1049,13 +1039,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0, // passiveIncomeAtRMD
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
-                singleTaxState,
-                null
+                singleTaxState
             );
 
             // Rate-match: peak future = 24% bracket. From 0% std-ded (gap 24, convert),
@@ -1088,13 +1075,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0, // passiveIncomeAtRMD
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
-                singleTaxState,
-                null
+                singleTaxState
             );
 
             // Rate-match: peak lands in 35%/37% bracket. With 5pp gap requirement,
@@ -1133,14 +1117,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0, // passiveIncomeAtRMD
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
                 singleTaxState,
-                null,
-                undefined,
                 baselineProjections
             );
 
@@ -1170,13 +1150,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0, // passiveIncomeAtRMD
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
-                singleTaxState,
-                null
+                singleTaxState
             );
 
             // projectedRMDBracket should be a valid bracket rate
@@ -1206,13 +1183,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0, // passiveIncomeAtRMD
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
-                singleTaxState,
-                null
+                singleTaxState
             );
 
             // If utilization ratio > 0.90, ceiling should raise even if projected bracket is low
@@ -1238,23 +1212,11 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0, // passiveIncomeAtRMD
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
-                singleTaxState,
-                null  // No state params
+                singleTaxState
             );
-
-            // With 5% flat state tax
-            const stateParams: TaxParameters = {
-                standardDeduction: 0,
-                brackets: [{ threshold: 0, rate: 0.05 }],
-                socialSecurityTaxRate: 0,
-                socialSecurityWageBase: 0,
-                medicareTaxRate: 0
-            };
 
             const stateTaxState: TaxState = {
                 ...singleTaxState,
@@ -1268,13 +1230,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0, // passiveIncomeAtRMD
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
-                stateTaxState,
-                stateParams  // 5% flat state tax
+                stateTaxState
             );
 
             // Both should use the same ceiling (based on federal RMD bracket projection)
@@ -1310,13 +1269,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0, // passiveIncomeAtRMD
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
-                singleTaxState,
-                null
+                singleTaxState
             );
 
             // Projected balance equals current balance (no growth)
@@ -1341,13 +1297,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0, // passiveIncomeAtRMD
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
-                singleTaxState,
-                null
+                singleTaxState
             );
 
             // conversionCeiling: valid bracket rate <= 32%
@@ -1388,13 +1341,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0, // passiveIncomeAtRMD
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 singleParams,
-                singleTaxState,
-                null
+                singleTaxState
             );
 
             const mfjResult = calculateDynamicConversionCeiling(
@@ -1404,13 +1354,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0, // passiveIncomeAtRMD
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 mfjParams,
-                mfjTaxState,
-                null
+                mfjTaxState
             );
 
             // MFJ has wider brackets, so may not need to raise ceiling as high
@@ -1472,14 +1419,14 @@ describe('calculateDynamicConversionCeiling', () => {
             const resultAt35 = calculateDynamicConversionCeiling(
                 balanceAtAge35, yearsAtAge35,
                 pensionAtRMD, ssAtRMD, passiveAtRMD,
-                0, 0, 0, growthRate, rmdStartAge,
-                fedAtAge35, taxStateAtAge35, null, undefined, undefined, assumptions
+                0, growthRate, rmdStartAge,
+                fedAtAge35, taxStateAtAge35, undefined, assumptions
             );
             const resultAt55 = calculateDynamicConversionCeiling(
                 balanceAtAge55, yearsAtAge55,
                 pensionAtRMD, ssAtRMD, passiveAtRMD,
-                0, 0, 0, growthRate, rmdStartAge,
-                fedAtAge55, taxStateAtAge55, null, undefined, undefined, assumptions
+                0, growthRate, rmdStartAge,
+                fedAtAge55, taxStateAtAge55, undefined, assumptions
             );
 
             // Same RMD-year balance and same RMD-year income → same peak-RMD bracket → same ceiling.
@@ -1501,8 +1448,8 @@ describe('calculateDynamicConversionCeiling', () => {
             const result = calculateDynamicConversionCeiling(
                 500_000, 30,
                 0, 30_000, 0,
-                50_000, 0, 0, 0.07, 75,
-                fedParams, taxState, null
+                50_000, 0.07, 75,
+                fedParams, taxState
                 // assumptions intentionally omitted
             );
 
@@ -1537,14 +1484,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0,
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
                 singleTaxState,
-                null,
-                undefined,
                 undefined,
                 undefined,
                 'std-ded-only'
@@ -1566,14 +1509,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0,
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
                 singleTaxState,
-                null,
-                undefined,
                 undefined,
                 undefined,
                 'std-ded-only'
@@ -1597,14 +1536,10 @@ describe('calculateDynamicConversionCeiling', () => {
                 inputs.ssAtRMD,
                 0,
                 inputs.currentAGI,
-                inputs.socialSecurityThisYear,
-                inputs.ltcgIncome,
                 inputs.growthRate,
                 inputs.rmdStartAge,
                 taxParams,
                 singleTaxState,
-                null,
-                undefined,
                 undefined,
                 undefined,
                 'std-ded-only'

--- a/src/services/simulation/__tests__/TaxOptimizedWithdrawal.test.ts
+++ b/src/services/simulation/__tests__/TaxOptimizedWithdrawal.test.ts
@@ -6,7 +6,6 @@
 
 import { describe, it, expect } from 'vitest';
 import {
-    getDampingFactor,
     getAcaCliffThreshold,
     getEffectiveConversionRate,
     coarseToFineSearch,
@@ -22,114 +21,6 @@ import { TaxParameters } from '../../../data/TaxData';
 import { TaxState } from '../../../components/Objects/Taxes/TaxContext';
 import * as TaxService from '../../../components/Objects/Taxes/TaxService';
 import { AssumptionsState, defaultAssumptions, createBuiltinMilestones } from '../../../components/Objects/Assumptions/AssumptionsContext';
-
-// =============================================================================
-// Task 2: getDampingFactor() tests
-// =============================================================================
-
-describe('getDampingFactor', () => {
-    describe('Tier: 15+ years (very conservative, 0.15)', () => {
-        it('returns 0.15 for yearsUntilRMD = 15', () => {
-            expect(getDampingFactor(15)).toBe(0.15);
-        });
-
-        it('returns 0.15 for yearsUntilRMD = 20', () => {
-            expect(getDampingFactor(20)).toBe(0.15);
-        });
-
-        it('returns 0.15 for yearsUntilRMD = 100', () => {
-            expect(getDampingFactor(100)).toBe(0.15);
-        });
-    });
-
-    describe('Tier: 10-14 years (0.20)', () => {
-        it('returns 0.20 for yearsUntilRMD = 14', () => {
-            expect(getDampingFactor(14)).toBe(0.20);
-        });
-
-        it('returns 0.20 for yearsUntilRMD = 10', () => {
-            expect(getDampingFactor(10)).toBe(0.20);
-        });
-
-        it('returns 0.20 for yearsUntilRMD = 12', () => {
-            expect(getDampingFactor(12)).toBe(0.20);
-        });
-    });
-
-    describe('Tier: 7-9 years (0.25)', () => {
-        it('returns 0.25 for yearsUntilRMD = 9', () => {
-            expect(getDampingFactor(9)).toBe(0.25);
-        });
-
-        it('returns 0.25 for yearsUntilRMD = 7', () => {
-            expect(getDampingFactor(7)).toBe(0.25);
-        });
-
-        it('returns 0.25 for yearsUntilRMD = 8', () => {
-            expect(getDampingFactor(8)).toBe(0.25);
-        });
-    });
-
-    describe('Tier: 5-6 years (0.30)', () => {
-        it('returns 0.30 for yearsUntilRMD = 6', () => {
-            expect(getDampingFactor(6)).toBe(0.30);
-        });
-
-        it('returns 0.30 for yearsUntilRMD = 5', () => {
-            expect(getDampingFactor(5)).toBe(0.30);
-        });
-    });
-
-    describe('Tier: 3-4 years (0.40)', () => {
-        it('returns 0.40 for yearsUntilRMD = 4', () => {
-            expect(getDampingFactor(4)).toBe(0.40);
-        });
-
-        it('returns 0.40 for yearsUntilRMD = 3', () => {
-            expect(getDampingFactor(3)).toBe(0.40);
-        });
-    });
-
-    describe('Tier: 0-2 years (aggressive, 0.50)', () => {
-        it('returns 0.50 for yearsUntilRMD = 2', () => {
-            expect(getDampingFactor(2)).toBe(0.50);
-        });
-
-        it('returns 0.50 for yearsUntilRMD = 1', () => {
-            expect(getDampingFactor(1)).toBe(0.50);
-        });
-
-        it('returns 0.50 for yearsUntilRMD = 0', () => {
-            expect(getDampingFactor(0)).toBe(0.50);
-        });
-    });
-
-    describe('Negative Values (Edge Case)', () => {
-        it('returns 0.50 for yearsUntilRMD = -1 (past RMD)', () => {
-            expect(getDampingFactor(-1)).toBe(0.50);
-        });
-
-        it('returns 0.50 for yearsUntilRMD = -5 (past RMD)', () => {
-            expect(getDampingFactor(-5)).toBe(0.50);
-        });
-    });
-
-    describe('Range Validation', () => {
-        it('result is always >= 0.15', () => {
-            const testValues = [-5, -1, 0, 1, 2, 3, 5, 7, 10, 15, 20, 100];
-            for (const years of testValues) {
-                expect(getDampingFactor(years)).toBeGreaterThanOrEqual(0.15);
-            }
-        });
-
-        it('result is always <= 0.50', () => {
-            const testValues = [-5, -1, 0, 1, 2, 3, 5, 7, 10, 15, 20, 100];
-            for (const years of testValues) {
-                expect(getDampingFactor(years)).toBeLessThanOrEqual(0.50);
-            }
-        });
-    });
-});
 
 // =============================================================================
 // Task 4: getAcaCliffThreshold() tests

--- a/src/services/simulation/helpers.ts
+++ b/src/services/simulation/helpers.ts
@@ -53,6 +53,41 @@ export interface EffectiveConversionTaxResult {
 }
 
 /**
+ * The conversion-INDEPENDENT "before" tax positions used by
+ * calculateEffectiveConversionTax. They depend only on the fixed income inputs,
+ * so a search that probes many conversion amounts at the same income (e.g.
+ * coarseToFineSearch via getEffectiveConversionRate) can compute this once and
+ * pass it in via the optional `baseline` param instead of recomputing it on
+ * every probe.
+ */
+export interface ConversionTaxBaseline {
+    taxResultBefore: ReturnType<typeof TaxService.calculateTotalFederalTax>;
+    taxBeforeManualSS: ReturnType<typeof TaxService.calculateTotalFederalTax>;
+    stateTaxBefore: number;
+}
+
+export function computeConversionTaxBaseline(
+    nonSSIncome: number,
+    totalSSBenefits: number,
+    ltcgIncome: number,
+    filingStatus: FilingStatus,
+    fedParams: TaxParameters,
+    stateParams: TaxParameters | null,
+): ConversionTaxBaseline {
+    const taxResultBefore = TaxService.calculateTotalFederalTax(
+        nonSSIncome, totalSSBenefits, 0, ltcgIncome, 0, filingStatus, fedParams,
+    );
+    // "before" with taxable SS folded into ordinary income (frozen-SS baseline).
+    const taxBeforeManualSS = TaxService.calculateTotalFederalTax(
+        nonSSIncome + taxResultBefore.taxableSS, 0, 0, ltcgIncome, 0, filingStatus, fedParams,
+    );
+    const stateTaxBefore = stateParams
+        ? TaxService.calculateTax(nonSSIncome + ltcgIncome, 0, stateParams)
+        : 0;
+    return { taxResultBefore, taxBeforeManualSS, stateTaxBefore };
+}
+
+/**
  * Calculate the effective tax cost of a Roth conversion, including:
  * - SS "tax torpedo" effect (conversion pushes more SS into taxable territory)
  * - LTCG bump (conversion can push LTCG from 0% to 15% bracket)
@@ -84,22 +119,21 @@ export function calculateEffectiveConversionTax(
     filingStatus: FilingStatus,
     fedParams: TaxParameters,
     stateParams: TaxParameters | null,
-    acaOptions?: ACAOptions
+    acaOptions?: ACAOptions,
+    /** Precomputed conversion-independent "before" positions. When omitted they
+     *  are computed here (unchanged behavior); a probing search can compute them
+     *  once and pass them in to avoid recomputing on every probe. */
+    baseline?: ConversionTaxBaseline,
 ): EffectiveConversionTaxResult {
+    const base = baseline ?? computeConversionTaxBaseline(
+        nonSSIncome, totalSSBenefits, ltcgIncome, filingStatus, fedParams, stateParams,
+    );
     // =========================================================================
     // CALCULATE FULL TAX BEFORE AND AFTER CONVERSION
     // =========================================================================
     // Use calculateTotalFederalTax for unified handling of SS taxability and LTCG stacking
     // Note: ltcgIncome is passed as longTermCapitalGains (4th param), STCG is 0 (3rd param)
-    const taxResultBefore = TaxService.calculateTotalFederalTax(
-        nonSSIncome,
-        totalSSBenefits,
-        0,          // shortTermCapitalGains
-        ltcgIncome, // longTermCapitalGains
-        0,          // preTaxDeductions - already accounted for in nonSSIncome
-        filingStatus,
-        fedParams
-    );
+    const taxResultBefore = base.taxResultBefore;
 
     const taxResultAfter = TaxService.calculateTotalFederalTax(
         nonSSIncome + conversionAmount,
@@ -150,16 +184,9 @@ export function calculateEffectiveConversionTax(
         fedParams
     );
 
-    // Also need the "before" state with SS added manually for apples-to-apples comparison
-    const taxBeforeManualSS = TaxService.calculateTotalFederalTax(
-        nonSSIncome + taxableSS_before,
-        0,          // no SS benefits
-        0,          // shortTermCapitalGains
-        ltcgIncome, // longTermCapitalGains
-        0,          // preTaxDeductions
-        filingStatus,
-        fedParams
-    );
+    // Also need the "before" state with SS added manually for apples-to-apples
+    // comparison (conversion-independent; supplied by the baseline).
+    const taxBeforeManualSS = base.taxBeforeManualSS;
 
     // federalOrdinaryTaxCost = marginal tax at current bracket (with existing taxable SS held constant)
     const federalOrdinaryTaxCost = taxFrozenSS.ordinaryTax - taxBeforeManualSS.ordinaryTax;
@@ -176,7 +203,7 @@ export function calculateEffectiveConversionTax(
         // Most states tax LTCG as ordinary income (no preferential rate).
         // Include LTCG in state income to get correct marginal rate on conversion.
         const stateIncome = nonSSIncome + ltcgIncome;
-        const stateTaxBefore = TaxService.calculateTax(stateIncome, 0, stateParams);
+        const stateTaxBefore = base.stateTaxBefore;
         const stateTaxAfter = TaxService.calculateTax(stateIncome + conversionAmount, 0, stateParams);
         stateTaxCost = stateTaxAfter - stateTaxBefore;
     }

--- a/src/services/simulation/types.ts
+++ b/src/services/simulation/types.ts
@@ -364,6 +364,15 @@ export interface PlannedWithdrawal {
     penalty: number;
     /** Tax on this withdrawal */
     tax: number;
+    /** Ordinary income realized by this withdrawal that is not already in the
+     *  income base (e.g. ESPP bargain element). Feeds SS-taxability like a
+     *  Traditional withdrawal. */
+    ordinaryIncome?: number;
+    /** Ordinary-income portion of `tax` (e.g. the ESPP bargain-element tax).
+     *  The remainder of `tax` is LTCG pass-through. When absent, `tax` is
+     *  all-ordinary (Traditional/HSA/Roth) or all-LTCG (brokerage) as indicated
+     *  by `capitalGains`. */
+    ordinaryTax?: number;
     /** Reason for withdrawal */
     reason: 'Required Minimum Distribution' | 'Spending deficit' | 'Conversion tax' | 'Healthcare expense' | 'ACA cliff Roth substitution';
 }


### PR DESCRIPTION
This is a FACT-CHECK pass, not a discovery review. The diff is the cumulative
output of five scoped local reviews (PRs #54–#58): every change here claims to
fix a specific finding with a specific failure scenario. Your job is to verify
or refute those claims — the failure mode we are guarding against is a "fix"
that breaks intentional behavior (it has happened: PR #53 finding 2 force-
filled capped buckets and broke sinking-fund reservations; the test suite
caught it, review did not).

THE CLAIMS are in this diff/tree at the repo root:
  - code-review-pr54.md — solver core (YearSolver, planners, allocator)
  - code-review-pr55.md — tax services + tax data
  - code-review-pr56.md — Roth/RMD/income-projection/account-growth
  - code-review-pr57.md — domain models + engine orchestration
  - code-review-pr58.md — persistence/contexts/QR/import
Each lists findings with dispositions (fixed @ commit / refuted / wont-fix).
Commit subjects reference findings as "PR #NN #K".

For each fix, answer three questions:
  1. Does the claimed failure scenario actually occur in the BASE version
     (left side of the diff)? If you cannot reproduce the reasoning, flag the
     fix as unsubstantiated.
  2. Does the change actually fix it — fully, not just for the reported
     trigger? Check boundary inputs around the fix.
  3. Does it break anything intentional? Search the surrounding code and tests
     for evidence the old behavior was deliberate (comments, adjudications in
     code-review-pr-50..53.md, symmetric code paths that still do the old
     thing). A fix applied to one of two duplicated code paths is a finding.

Specific areas that deserve the closest look:
  - The PR #57 date-convention unification (UTC→LOCAL everywhere). This
    REVERTS the direction PR #50 chose. It claims green suites under UTC,
    Australia/Sydney, and America/New_York. Verify the reader/creator pairing
    is now consistent at every touched site and that no remaining getUTC*
    reader consumes a local-midnight date (or vice versa) in the changed files.
  - PR #55 bracket/data changes (2024 Single brackets, seniorDeduction
    inflation): data corrections — verify against published IRS figures.
  - PR #56 §415(c) deferral trimming and SS earnings-test PIA base: both
    change amounts the sim deposits/pays; verify the new behavior against the
    actual IRS/SSA rules they cite.
  - PR #58 QR short-key remap (purchasePrice 'pp' collision → projectedPIA
    'Pi'): verify old QR payloads still decode correctly (legacy keys must
    keep decoding).
  - Behavioral-oracle note: tests added alongside fixes were written by the
    same agents that wrote the fixes. Where a test merely restates the
    implementation, say so.

Constraints/known-by-design (do not re-flag): surplus caps are pacing and do
not force-fill; goal funding is a committed transfer derived live from the
goal (no buckets, no stored set-aside); Roth conversions are back-loaded by
design (SORR); the 0% LTCG planner floor is accepted.

Output: per-fix verdicts (VERIFIED / UNSUBSTANTIATED / BREAKS-INTENDED with
the evidence), then any new defects introduced by the fixes, ranked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)